### PR TITLE
Fix for #12

### DIFF
--- a/clevertap-android-sdk/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-android-sdk/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -5071,6 +5071,7 @@ public class CleverTapAPI implements CTInAppNotification.CTInAppNotificationList
                     Intent actionLaunchIntent;
                     if (sendToCTIntentService) {
                         actionLaunchIntent = new Intent(CTNotificationIntentService.MAIN_ACTION);
+                        actionLaunchIntent.setPackage(context.getPackageName());
                         actionLaunchIntent.putExtra("ct_type", CTNotificationIntentService.TYPE_BUTTON_CLICK);
                         if (!dl.isEmpty()) {
                             actionLaunchIntent.putExtra("dl", dl);


### PR DESCRIPTION
Restricting the scope of the Intent for action launch to the current package to avoid failures in the cases where multiple apps using clevertap exists on the phone.

This fixes #12. Verified on Hotstar with SonyLIV installed.