### PR TITLE
Sanitise url before firing ACTION_VIEW intent

### DIFF
--- a/clevertap-android-sdk/src/main/java/com/clevertap/android/sdk/CTInAppBaseFragment.java
+++ b/clevertap-android-sdk/src/main/java/com/clevertap/android/sdk/CTInAppBaseFragment.java
@@ -94,7 +94,7 @@ public abstract class CTInAppBaseFragment extends Fragment {
 
     void fireUrlThroughIntent(String url, Bundle formData) {
         try {
-            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url.replace("\n", "").replace("\r", "")));
             startActivity(intent);
         } catch (Throwable t) {
             // Ignore

--- a/clevertap-android-sdk/src/main/java/com/clevertap/android/sdk/CTInboxListViewFragment.java
+++ b/clevertap-android-sdk/src/main/java/com/clevertap/android/sdk/CTInboxListViewFragment.java
@@ -254,7 +254,7 @@ public class CTInboxListViewFragment extends Fragment {
 
     void fireUrlThroughIntent(String url) {
         try {
-            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url.replace("\n", "").replace("\r", "")));
             startActivity(intent);
         } catch (Throwable t) {
             // Ignore

--- a/clevertap-android-sdk/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-android-sdk/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -329,7 +329,7 @@ public final class InAppNotificationActivity extends FragmentActivity implements
 
     void fireUrlThroughIntent(String url, Bundle formData) {
         try {
-            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+            Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url.replace("\n", "").replace("\r", "")));
             startActivity(intent);
         } catch (Throwable t) {
             // Ignore


### PR DESCRIPTION
When Mobile In-App campaigns are created with urls, they are always appended with `\n` leading to deeplinking issues, e.g. Branch.io deeplinks throw an error due to the included `\n`.

This can be seen in the logs (redacted for privacy)

```
D/CleverTap:TEST-XXX-XXX-XXXX: Preparing In-App for display: {"type":"interstitial", ..."actions":{"close":false,"android":"https:\/\/blablabla.com\/mylanding\n","ios":"https:\/\/.blablabla.com\/mylanding\n"}...}
```