### PR TITLE
SDK-886: Add option to exclude from lifecycle callbacks

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/ActivityLifecycleCallback.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/ActivityLifecycleCallback.java
@@ -72,6 +72,12 @@ public final class ActivityLifecycleCallback {
                                 CleverTapAPI.onActivityResumed(activity);
                             }
                         } else {
+                            CoreMetaData.setAppForeground(true);
+                            String currentActivityName = CoreMetaData.getCurrentActivityName();
+                            CoreMetaData.setCurrentActivity(activity);
+                            if (currentActivityName == null || !currentActivityName.equals(activity.getLocalClassName())) {
+                                CoreMetaData.incrementActivityCount();
+                            }
                             Logger.v("Not running onActivityResumed for - " + activity.getLocalClassName());
                         }
                     }


### PR DESCRIPTION
Allows setting of the app to foreground and setting of the current activity to ensure InApps and Inbox Activities are not affected.