### PR TITLE
[Feature] Allow Xiaomi plugin creds at runtime

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -144,6 +144,16 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     }
 
     /**
+     * This method is used to change the credentials of Xiaomi app id and key programmatically.
+     *
+     * @param xiaomiAppID  Xiaomi App Id
+     * @param xiaomiAppKey Xiaomi App Key
+     */
+    public static void changeXiaomiCredentials(String xiaomiAppID, String xiaomiAppKey) {
+        ManifestInfo.changeXiaomiCredentials(xiaomiAppID, xiaomiAppKey);
+    }
+
+    /**
      * Launches an asynchronous task to download the notification icon from CleverTap,
      * and create the Android notification.
      * <p>

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/ManifestInfo.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/ManifestInfo.java
@@ -91,8 +91,13 @@ public class ManifestInfo {
             intentServiceName = _getManifestStringValueForKey(metaData, Constants.LABEL_INTENT_SERVICE);
         }
 
-        xiaomiAppKey = _getManifestStringValueForKey(metaData, Constants.LABEL_XIAOMI_APP_KEY);
-        xiaomiAppID = _getManifestStringValueForKey(metaData, Constants.LABEL_XIAOMI_APP_ID);
+        if (xiaomiAppKey != null) {
+            xiaomiAppKey = _getManifestStringValueForKey(metaData, Constants.LABEL_XIAOMI_APP_KEY);
+        }
+
+        if (xiaomiAppID != null) {
+            xiaomiAppID = _getManifestStringValueForKey(metaData, Constants.LABEL_XIAOMI_APP_ID);
+        }
 
         profileKeys = parseProfileKeys(metaData);
     }
@@ -176,6 +181,11 @@ public class ManifestInfo {
         accountId = id;
         accountToken = token;
         accountRegion = region;
+    }
+
+    static void changeXiaomiCredentials(String xiaomiAppID, String xiaomiAppKey) {
+        ManifestInfo.xiaomiAppID = xiaomiAppID;
+        ManifestInfo.xiaomiAppKey = xiaomiAppKey;
     }
 
     /**


### PR DESCRIPTION
Implements the functions to allow setting Xiaomi plugin creds at runtime as opposed to keeping them in AndroidManifest.xml file.