### PR TITLE
Task/sdk/sdk 1910 onMessage Click Callback for App inbox

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTInboxMessageListener.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTInboxMessageListener.java
@@ -2,7 +2,7 @@ package com.clevertap.android.sdk;
 
 import com.clevertap.android.sdk.inbox.CTInboxMessage;
 
-public interface InboxMessageListener {
+public interface CTInboxMessageListener {
     /**
      * callback to transfer payload when inbox button is clicked
      */

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTInboxMessageListener.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTInboxMessageListener.java
@@ -4,7 +4,7 @@ import com.clevertap.android.sdk.inbox.CTInboxMessage;
 
 public interface CTInboxMessageListener {
     /**
-     * callback to transfer payload when inbox button is clicked
+     * callback to transfer payload when an inbox item is clicked
      */
     void onInboxItemClicked(CTInboxMessage message);
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -20,7 +20,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -1865,18 +1864,15 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
 
     @Override
     public void messageDidClick(CTInboxActivity ctInboxActivity, CTInboxMessage inboxMessage, Bundle data, HashMap<String, String> keyValue, boolean isBodyClick) {
-        Log.e("CleverTap", "CleverTapApi.java|messageDidClick()  called with: ctInboxActivity = [" + ctInboxActivity + "], inboxMessage = [" + inboxMessage + "], data = [" + data + "], keyValue = [" + keyValue + "], isBodyClick = [" + isBodyClick + "]");
 
         coreState.getAnalyticsManager().pushInboxMessageStateEvent(true, inboxMessage, data);
 
         if (keyValue != null && !keyValue.isEmpty()) {
-            Log.e("CleverTap", "CleverTapApi.java|messageDidClick: keyvalue is not null, therefore this function is called via button click. calling inboxMessageButtonListener if not empty" );
             if (inboxMessageButtonListener != null && inboxMessageButtonListener.get() != null) {
                 inboxMessageButtonListener.get().onInboxButtonClick(keyValue);
             }
         }
         else{
-            Log.e("CleverTap", "CleverTapApi.java|messageDidClick: keyvalue is  null, therefore this function is called via view click. calling inboxMessageListener if not empty" );
             if (isBodyClick && inboxMessageListener != null && inboxMessageListener.get() != null) {
                 inboxMessageListener.get().onInboxItemClicked(inboxMessage);
             }
@@ -2936,57 +2932,3 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
         return PushType.XPS.getRunningDevices();
     }
 }
-
-/* full message click
-
-inboxMessage = {CTInboxMessage@43330}
- actionUrl = null
- bgColor = "#ffffff"
- body = null
- campaignId = "1660721033_20220817"
- customData = null
- data = {JSONObject@43340} "{"id":"1660721033_1660721899","msg":{"type":"simple","bg":"#ffffff","orientation":"p","content":[{"key":3688751294,"message":{"text":"message message message","color":"#434761","replacements":"message message message","og":""},"title":{"text":"title title title","color":"#434761","replacements":"title title title","og":""},"action":{"hasUrl":true,"hasLinks":true,"url":{"android":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+androidUrl","replacements":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+androidUrl","og":""},"ios":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+iosUrl","replacements":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+iosUrl","og":""}},"links":[{"type":"url","text":"url button","color":"#007bff","bg":"#ffffff","copyText":{"text":"","replacements":"","og":""},"url":{"android":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onLink+androidUrl","replacements":"https:\/\/www.google.com\/search?q=you+cli"
- date = 1660721899
- expires = 0
- imageUrl = null
- inboxMessageContents = {ArrayList@43341}  size = 1
- isRead = false
- messageId = "1660721033_1660721899"
- orientation = "p"
- tags = {ArrayList@43344}  size = 1
- title = null
- type = {CTInboxMessageType@43345} "simple"
- wzrkParams = {JSONObject@43346} "{"wzrk_ttl":"0","wzrk_id":"1660721033_20220817","wzrk_pivot":"wzrk_default","wzrk_c2a":"url button"}"
- shadow$_klass_ = {Class@42885} "class com.clevertap.android.sdk.inbox.CTInboxMessage"
- shadow$_monitor_ = 0
-
-* */
-
-
-
-/*   btn click
-
-inboxMessage = {CTInboxMessage@43330}
- actionUrl = null
- bgColor = "#ffffff"
- body = null
- campaignId = "1660721033_20220817"
- customData = null
- data = {JSONObject@43340} "{"id":"1660721033_1660721899","msg":{"type":"simple","bg":"#ffffff","orientation":"p","content":[{"key":3688751294,"message":{"text":"message message message","color":"#434761","replacements":"message message message","og":""},"title":{"text":"title title title","color":"#434761","replacements":"title title title","og":""},"action":{"hasUrl":true,"hasLinks":true,"url":{"android":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+androidUrl","replacements":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+androidUrl","og":""},"ios":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+iosUrl","replacements":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+iosUrl","og":""}},"links":[{"type":"url","text":"url button","color":"#007bff","bg":"#ffffff","copyText":{"text":"","replacements":"","og":""},"url":{"android":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onLink+androidUrl","replacements":"https:\/\/www.google.com\/search?q=you+cli"
- date = 1660721899
- expires = 0
- imageUrl = null
- inboxMessageContents = {ArrayList@43341}  size = 1
- isRead = false
- messageId = "1660721033_1660721899"
- orientation = "p"
- tags = {ArrayList@43344}  size = 1
- title = null
- type = {CTInboxMessageType@43345} "simple"
- wzrkParams = {JSONObject@43346} "{"wzrk_ttl":"0","wzrk_id":"1660721033_20220817","wzrk_pivot":"wzrk_default","wzrk_c2a":"url button"}"
- shadow$_klass_ = {Class@42885} "class com.clevertap.android.sdk.inbox.CTInboxMessage"
- shadow$_monitor_ = 0
-data = {Bundle@43509} "Bundle[{wzrk_pivot=wzrk_default, wzrk_c2a=url button, wzrk_ttl=0, wzrk_id=1660721033_20220817}]"
-keyValue = null
-
-* */

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -20,7 +20,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -140,7 +139,7 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
 
     private WeakReference<InboxMessageButtonListener> inboxMessageButtonListener;
 
-    private WeakReference<InboxMessageListener> inboxMessageListener;
+    private WeakReference<CTInboxMessageListener> inboxMessageListener;
 
     /**
      * This method is used to change the credentials of CleverTap account Id and token programmatically
@@ -2396,7 +2395,7 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     }
 
     @SuppressWarnings("unused")
-    public void setInboxMessageListener(InboxMessageListener listener){
+    public void setCTInboxMessageListener(CTInboxMessageListener listener){
         this.inboxMessageListener = new WeakReference<>(listener);
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -1864,8 +1864,8 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     }
 
     @Override
-    public void messageDidClick(CTInboxActivity ctInboxActivity, CTInboxMessage inboxMessage, Bundle data, HashMap<String, String> keyValue) {
-        Log.d("CleverTap", "CleverTapApi.java|messageDidClick() called with: ctInboxActivity = [" + ctInboxActivity + "], inboxMessage = [" + inboxMessage + "], data = [" + data + "], keyValue = [" + keyValue + "]");
+    public void messageDidClick(CTInboxActivity ctInboxActivity, CTInboxMessage inboxMessage, Bundle data, HashMap<String, String> keyValue, boolean isBodyClick) {
+        Log.e("CleverTap", "CleverTapApi.java|messageDidClick()  called with: ctInboxActivity = [" + ctInboxActivity + "], inboxMessage = [" + inboxMessage + "], data = [" + data + "], keyValue = [" + keyValue + "], isBodyClick = [" + isBodyClick + "]");
 
         coreState.getAnalyticsManager().pushInboxMessageStateEvent(true, inboxMessage, data);
 
@@ -1877,7 +1877,7 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
         }
         else{
             Log.e("CleverTap", "CleverTapApi.java|messageDidClick: keyvalue is  null, therefore this function is called via view click. calling inboxMessageListener if not empty" );
-            if (inboxMessageListener != null && inboxMessageListener.get() != null) {
+            if (isBodyClick && inboxMessageListener != null && inboxMessageListener.get() != null) {
                 inboxMessageListener.get().onInboxItemClicked(inboxMessage);
             }
         }
@@ -2937,3 +2937,56 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     }
 }
 
+/* full message click
+
+inboxMessage = {CTInboxMessage@43330}
+ actionUrl = null
+ bgColor = "#ffffff"
+ body = null
+ campaignId = "1660721033_20220817"
+ customData = null
+ data = {JSONObject@43340} "{"id":"1660721033_1660721899","msg":{"type":"simple","bg":"#ffffff","orientation":"p","content":[{"key":3688751294,"message":{"text":"message message message","color":"#434761","replacements":"message message message","og":""},"title":{"text":"title title title","color":"#434761","replacements":"title title title","og":""},"action":{"hasUrl":true,"hasLinks":true,"url":{"android":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+androidUrl","replacements":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+androidUrl","og":""},"ios":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+iosUrl","replacements":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+iosUrl","og":""}},"links":[{"type":"url","text":"url button","color":"#007bff","bg":"#ffffff","copyText":{"text":"","replacements":"","og":""},"url":{"android":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onLink+androidUrl","replacements":"https:\/\/www.google.com\/search?q=you+cli"
+ date = 1660721899
+ expires = 0
+ imageUrl = null
+ inboxMessageContents = {ArrayList@43341}  size = 1
+ isRead = false
+ messageId = "1660721033_1660721899"
+ orientation = "p"
+ tags = {ArrayList@43344}  size = 1
+ title = null
+ type = {CTInboxMessageType@43345} "simple"
+ wzrkParams = {JSONObject@43346} "{"wzrk_ttl":"0","wzrk_id":"1660721033_20220817","wzrk_pivot":"wzrk_default","wzrk_c2a":"url button"}"
+ shadow$_klass_ = {Class@42885} "class com.clevertap.android.sdk.inbox.CTInboxMessage"
+ shadow$_monitor_ = 0
+
+* */
+
+
+
+/*   btn click
+
+inboxMessage = {CTInboxMessage@43330}
+ actionUrl = null
+ bgColor = "#ffffff"
+ body = null
+ campaignId = "1660721033_20220817"
+ customData = null
+ data = {JSONObject@43340} "{"id":"1660721033_1660721899","msg":{"type":"simple","bg":"#ffffff","orientation":"p","content":[{"key":3688751294,"message":{"text":"message message message","color":"#434761","replacements":"message message message","og":""},"title":{"text":"title title title","color":"#434761","replacements":"title title title","og":""},"action":{"hasUrl":true,"hasLinks":true,"url":{"android":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+androidUrl","replacements":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+androidUrl","og":""},"ios":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+iosUrl","replacements":"https:\/\/www.google.com\/search?q=you+clicked+onMessage+iosUrl","og":""}},"links":[{"type":"url","text":"url button","color":"#007bff","bg":"#ffffff","copyText":{"text":"","replacements":"","og":""},"url":{"android":{"text":"https:\/\/www.google.com\/search?q=you+clicked+onLink+androidUrl","replacements":"https:\/\/www.google.com\/search?q=you+cli"
+ date = 1660721899
+ expires = 0
+ imageUrl = null
+ inboxMessageContents = {ArrayList@43341}  size = 1
+ isRead = false
+ messageId = "1660721033_1660721899"
+ orientation = "p"
+ tags = {ArrayList@43344}  size = 1
+ title = null
+ type = {CTInboxMessageType@43345} "simple"
+ wzrkParams = {JSONObject@43346} "{"wzrk_ttl":"0","wzrk_id":"1660721033_20220817","wzrk_pivot":"wzrk_default","wzrk_c2a":"url button"}"
+ shadow$_klass_ = {Class@42885} "class com.clevertap.android.sdk.inbox.CTInboxMessage"
+ shadow$_monitor_ = 0
+data = {Bundle@43509} "Bundle[{wzrk_pivot=wzrk_default, wzrk_c2a=url button, wzrk_ttl=0, wzrk_id=1660721033_20220817}]"
+keyValue = null
+
+* */

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -20,6 +20,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -138,6 +140,8 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     private CoreState coreState;
 
     private WeakReference<InboxMessageButtonListener> inboxMessageButtonListener;
+
+    private WeakReference<InboxMessageListener> inboxMessageListener;
 
     /**
      * This method is used to change the credentials of CleverTap account Id and token programmatically
@@ -1860,12 +1864,21 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     }
 
     @Override
-    public void messageDidClick(CTInboxActivity ctInboxActivity, CTInboxMessage inboxMessage, Bundle data,
-            HashMap<String, String> keyValue) {
+    public void messageDidClick(CTInboxActivity ctInboxActivity, CTInboxMessage inboxMessage, Bundle data, HashMap<String, String> keyValue) {
+        Log.d("CleverTap", "CleverTapApi.java|messageDidClick() called with: ctInboxActivity = [" + ctInboxActivity + "], inboxMessage = [" + inboxMessage + "], data = [" + data + "], keyValue = [" + keyValue + "]");
+
         coreState.getAnalyticsManager().pushInboxMessageStateEvent(true, inboxMessage, data);
+
         if (keyValue != null && !keyValue.isEmpty()) {
+            Log.e("CleverTap", "CleverTapApi.java|messageDidClick: keyvalue is not null, therefore this function is called via button click. calling inboxMessageButtonListener if not empty" );
             if (inboxMessageButtonListener != null && inboxMessageButtonListener.get() != null) {
                 inboxMessageButtonListener.get().onInboxButtonClick(keyValue);
+            }
+        }
+        else{
+            Log.e("CleverTap", "CleverTapApi.java|messageDidClick: keyvalue is  null, therefore this function is called via view click. calling inboxMessageListener if not empty" );
+            if (inboxMessageListener != null && inboxMessageListener.get() != null) {
+                inboxMessageListener.get().onInboxItemClicked(inboxMessage);
             }
         }
     }
@@ -1873,8 +1886,7 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     //Session
 
     @Override
-    public void messageDidShow(CTInboxActivity ctInboxActivity, final CTInboxMessage inboxMessage,
-            final Bundle data) {
+    public void messageDidShow(CTInboxActivity ctInboxActivity, final CTInboxMessage inboxMessage, final Bundle data) {
         Task<Void> task = CTExecutorFactory.executors(coreState.getConfig()).postAsyncSafelyTask();
         task.execute("handleMessageDidShow", new Callable<Void>() {
             @Override
@@ -2385,6 +2397,11 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     @SuppressWarnings("unused")
     public void setInboxMessageButtonListener(InboxMessageButtonListener listener) {
         this.inboxMessageButtonListener = new WeakReference<>(listener);
+    }
+
+    @SuppressWarnings("unused")
+    public void setInboxMessageListener(InboxMessageListener listener){
+        this.inboxMessageListener = new WeakReference<>(listener);
     }
 
     @RestrictTo(Scope.LIBRARY_GROUP)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InboxMessageListener.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InboxMessageListener.java
@@ -1,0 +1,10 @@
+package com.clevertap.android.sdk;
+
+import com.clevertap.android.sdk.inbox.CTInboxMessage;
+
+public interface InboxMessageListener {
+    /**
+     * callback to transfer payload when inbox button is clicked
+     */
+    void onInboxItemClicked(CTInboxMessage message);
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
@@ -119,7 +119,7 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
         this.imageViewPager.addOnPageChangeListener(carouselPageChangeListener);
 
         this.clickLayout.setOnClickListener(
-                new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager));
+                new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true));
 
         Runnable carouselRunnable = new Runnable() {
             @Override

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
@@ -142,7 +142,7 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
         this.imageViewPager.addOnPageChangeListener(carouselPageChangeListener);
 
         this.clickLayout.setOnClickListener(
-                new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager));
+                new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true));
 
         Runnable carouselRunnable = new Runnable() {
             @Override

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPagerAdapter.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPagerAdapter.java
@@ -111,7 +111,7 @@ public class CTCarouselViewPagerAdapter extends PagerAdapter {
             public void onClick(View v) {
                 CTInboxListViewFragment parent = getParent();
                 if (parent != null) {
-                    parent.handleViewPagerClick(row, position);
+                    parent.handleViewPagerClick(row, position,true);
                 }
             }
         });

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
@@ -105,7 +105,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         hideTwoButtons(this.cta1, this.cta2, this.cta3);
                         if (parentWeak != null) {
                             this.cta1.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta1.getText().toString(), cta1Object, parentWeak));
+                                    this.cta1.getText().toString(), cta1Object, parentWeak,false));
                         }
                         break;
                     case 2:
@@ -122,9 +122,9 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         hideOneButton(this.cta1, this.cta2, this.cta3);
                         if (parentWeak != null) {
                             this.cta1.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta1.getText().toString(), cta1Object, parentWeak));
+                                    this.cta1.getText().toString(), cta1Object, parentWeak,false));
                             this.cta2.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta2.getText().toString(), cta2Object, parentWeak));
+                                    this.cta2.getText().toString(), cta2Object, parentWeak,false));
                         }
                         break;
                     case 3:
@@ -145,11 +145,11 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         this.cta3.setBackgroundColor(Color.parseColor(content.getLinkBGColor(cta3Object)));
                         if (parentWeak != null) {
                             this.cta1.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta1.getText().toString(), cta1Object, parentWeak));
+                                    this.cta1.getText().toString(), cta1Object, parentWeak,false));
                             this.cta2.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta2.getText().toString(), cta2Object, parentWeak));
+                                    this.cta2.getText().toString(), cta2Object, parentWeak,false));
                             this.cta3.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta3.getText().toString(), cta3Object, parentWeak));
+                                    this.cta3.getText().toString(), cta3Object, parentWeak,false));
                         }
                         break;
                 }
@@ -422,7 +422,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
 
         if (parentWeak != null) {
             clickLayout.setOnClickListener(
-                    new CTInboxButtonClickListener(position, inboxMessage, null, null, parentWeak));
+                    new CTInboxButtonClickListener(position, inboxMessage, null, null, parentWeak,true));
         }
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
@@ -36,7 +36,7 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
     public interface InboxActivityListener {
 
         void messageDidClick(CTInboxActivity ctInboxActivity, CTInboxMessage inboxMessage, Bundle data,
-                HashMap<String, String> keyValue);
+                HashMap<String, String> keyValue,boolean isBodyClick);
 
         void messageDidShow(CTInboxActivity ctInboxActivity, CTInboxMessage inboxMessage, Bundle data);
     }
@@ -208,8 +208,8 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
 
     @Override
     public void messageDidClick(Context baseContext, CTInboxMessage inboxMessage, Bundle data,
-            HashMap<String, String> keyValue) {
-        didClick(data, inboxMessage, keyValue);
+            HashMap<String, String> keyValue, boolean isBodyClick) {
+        didClick(data, inboxMessage, keyValue,isBodyClick);
     }
 
     @Override
@@ -217,10 +217,10 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
         didShow(data, inboxMessage);
     }
 
-    void didClick(Bundle data, CTInboxMessage inboxMessage, HashMap<String, String> keyValue) {
+    void didClick(Bundle data, CTInboxMessage inboxMessage, HashMap<String, String> keyValue, boolean isBodyClick) {
         InboxActivityListener listener = getListener();
         if (listener != null) {
-            listener.messageDidClick(this, inboxMessage, data, keyValue);
+            listener.messageDidClick(this, inboxMessage, data, keyValue,isBodyClick);
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxButtonClickListener.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxButtonClickListener.java
@@ -26,23 +26,27 @@ class CTInboxButtonClickListener implements View.OnClickListener {
     private final int position;
 
     private ViewPager viewPager;
+    private boolean isBodyClick;
 
     CTInboxButtonClickListener(int position, CTInboxMessage inboxMessage, String buttonText, JSONObject jsonObject,
-            CTInboxListViewFragment fragment) {
+            CTInboxListViewFragment fragment, boolean isInboxMessageBodyClick) {
         this.position = position;
         this.inboxMessage = inboxMessage;
         this.buttonText = buttonText;
         this.fragment = fragment; // be sure to pass this as a Weak Ref
         this.buttonObject = jsonObject;
+        this.isBodyClick = isInboxMessageBodyClick;
     }
 
     CTInboxButtonClickListener(int position, CTInboxMessage inboxMessage, String buttonText,
-            CTInboxListViewFragment fragment, ViewPager viewPager) {
+            CTInboxListViewFragment fragment, ViewPager viewPager, boolean isInboxMessageBodyClick) {
         this.position = position;
         this.inboxMessage = inboxMessage;
         this.buttonText = buttonText;
         this.fragment = fragment; // be sure to pass this as a Weak Ref
         this.viewPager = viewPager;
+        this.isBodyClick = isInboxMessageBodyClick;
+
     }
 
 
@@ -50,7 +54,7 @@ class CTInboxButtonClickListener implements View.OnClickListener {
     public void onClick(View v) {
         if (viewPager != null) {//Handles viewpager clicks
             if (fragment != null) {
-                fragment.handleViewPagerClick(position, viewPager.getCurrentItem());
+                fragment.handleViewPagerClick(position, viewPager.getCurrentItem(),isBodyClick);
             }
         } else {//Handles button clicks
             if (buttonText != null && buttonObject != null) {
@@ -62,11 +66,11 @@ class CTInboxButtonClickListener implements View.OnClickListener {
                         }
                     }
 
-                    fragment.handleClick(this.position, buttonText, buttonObject, getKeyValues(inboxMessage));
+                    fragment.handleClick(this.position, buttonText, buttonObject, getKeyValues(inboxMessage),isBodyClick);
                 }
             } else {
                 if (fragment != null) {
-                    fragment.handleClick(this.position, null, null, null);
+                    fragment.handleClick(this.position, null, null, null,isBodyClick);
                 }
             }
         }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
@@ -42,7 +42,7 @@ public class CTInboxListViewFragment extends Fragment {
     interface InboxListener {
 
         void messageDidClick(Context baseContext, CTInboxMessage inboxMessage, Bundle data,
-                HashMap<String, String> keyValue);
+                HashMap<String, String> keyValue,boolean isBodyClick);
 
         void messageDidShow(Context baseContext, CTInboxMessage inboxMessage, Bundle data);
     }
@@ -202,12 +202,11 @@ public class CTInboxListViewFragment extends Fragment {
         }
     }
 
-    void didClick(Bundle data, int position, HashMap<String, String> keyValuePayload) {
+    void didClick(Bundle data, int position, HashMap<String, String> keyValuePayload, boolean isInboxMessageBodyClick) {
         CTInboxListViewFragment.InboxListener listener = getListener();
         if (listener != null) {
             //noinspection ConstantConditions
-            listener.messageDidClick(getActivity().getBaseContext(), inboxMessages.get(position), data,
-                    keyValuePayload);
+            listener.messageDidClick(getActivity().getBaseContext(), inboxMessages.get(position), data, keyValuePayload, isInboxMessageBodyClick);
         }
     }
 
@@ -257,8 +256,7 @@ public class CTInboxListViewFragment extends Fragment {
         this.mediaRecyclerView = mediaRecyclerView;
     }
 
-    void handleClick(int position, String buttonText, JSONObject jsonObject,
-            HashMap<String, String> keyValuePayload) {
+    void handleClick(int position, String buttonText, JSONObject jsonObject, HashMap<String, String> keyValuePayload, boolean isInboxMessageBodyClick) {
         try {
             Bundle data = new Bundle();
             JSONObject wzrkParams = inboxMessages.get(position).getWzrkParams();
@@ -273,7 +271,7 @@ public class CTInboxListViewFragment extends Fragment {
             if (buttonText != null && !buttonText.isEmpty()) {
                 data.putString("wzrk_c2a", buttonText);
             }
-            didClick(data, position, keyValuePayload);
+            didClick(data, position, keyValuePayload,isInboxMessageBodyClick);
             boolean isKVButton = keyValuePayload != null && !keyValuePayload.isEmpty();
             if (jsonObject != null) {
                 if (isKVButton || inboxMessages.get(position).getInboxMessageContents().get(0).getLinktype(jsonObject)
@@ -298,7 +296,7 @@ public class CTInboxListViewFragment extends Fragment {
         }
     }
 
-    void handleViewPagerClick(int position, int viewPagerPosition) {
+    void handleViewPagerClick(int position, int viewPagerPosition,boolean isInboxMessageBodyClick) {
         try {
             Bundle data = new Bundle();
             JSONObject wzrkParams = inboxMessages.get(position).getWzrkParams();
@@ -309,7 +307,7 @@ public class CTInboxListViewFragment extends Fragment {
                     data.putString(keyName, wzrkParams.getString(keyName));
                 }
             }
-            didClick(data, position, null);
+            didClick(data, position, null,isInboxMessageBodyClick);
             String actionUrl = inboxMessages.get(position).getInboxMessageContents().get(viewPagerPosition)
                     .getActionUrl();
             fireUrlThroughIntent(actionUrl);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
@@ -101,7 +101,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         hideTwoButtons(this.cta1, this.cta2, this.cta3);
                         if (parentWeak != null) {
                             this.cta1.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta1.getText().toString(), cta1Object, parentWeak));
+                                    this.cta1.getText().toString(), cta1Object, parentWeak,false));
                         }
                         break;
                     case 2:
@@ -118,9 +118,9 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         hideOneButton(this.cta1, this.cta2, this.cta3);
                         if (parentWeak != null) {
                             this.cta1.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta1.getText().toString(), cta1Object, parentWeak));
+                                    this.cta1.getText().toString(), cta1Object, parentWeak,false));
                             this.cta2.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta2.getText().toString(), cta2Object, parentWeak));
+                                    this.cta2.getText().toString(), cta2Object, parentWeak,false));
                         }
                         break;
                     case 3:
@@ -141,11 +141,11 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         this.cta3.setBackgroundColor(Color.parseColor(content.getLinkBGColor(cta3Object)));
                         if (parentWeak != null) {
                             this.cta1.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta1.getText().toString(), cta1Object, parentWeak));
+                                    this.cta1.getText().toString(), cta1Object, parentWeak,false));
                             this.cta2.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta2.getText().toString(), cta2Object, parentWeak));
+                                    this.cta2.getText().toString(), cta2Object, parentWeak,false));
                             this.cta3.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
-                                    this.cta3.getText().toString(), cta3Object, parentWeak));
+                                    this.cta3.getText().toString(), cta3Object, parentWeak,false));
                         }
                         break;
                 }
@@ -389,7 +389,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
         simpleHandler.postDelayed(simpleRunnable, 2000);
         if (parentWeak != null) {
             this.clickLayout.setOnClickListener(
-                    new CTInboxButtonClickListener(position, inboxMessage, null, null, parentWeak));
+                    new CTInboxButtonClickListener(position, inboxMessage, null, null, parentWeak,true));
         }
 
     }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/SessionManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/SessionManagerTest.kt
@@ -127,7 +127,7 @@ class SessionManagerTest : BaseTestCase() {
     @Test
     fun testCreateSession() {
         // when current session has ended (i.e when currentSessionId<=0 ) session is  created .
-        // we verify by verifying coreMetaDataSpy calls
+        // we verify by verifying coreMetaDataSpy calls.
         var coreMetaDataSpy = Mockito.spy(coreMetaData).also { it.currentSessionId = 0 }
         var ctxSpy = Mockito.spy(application)
         sessionManagerDef = SessionManager(configDef,coreMetaDataSpy,validator,localDataStoreDef)


### PR DESCRIPTION
[SDK-1813/SDK-1910](https://wizrocket.atlassian.net/browse/SDK-1910) : onMessage Click Callback for App inbox

Goal was to receive an inbox item click and pass it to a listener provided by the client. 
The previous code was already  generating such clicks, but was passing them through the button click callback, i.e a click on message button or the message body was considered same. 

Changes:
- on the client side : user can now pass an `InboxMessageListener` in addition to `InboxMessageButtonListener` to receive inbox item click 
- internally : we pass "isBodyClick" = true/false from each of the view holder on wherever there is a click listener in CleverTapApi, we  call the user provided listeners on the basis of this boolean