### PR TITLE
fix(chore):Add separate intent-filters for appLaunch & for handing deep links

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -20,10 +20,16 @@
             android:name=".HomeScreenActivity"
             android:exported="true"
             android:theme="@style/AppTheme.NoActionBar">
+
+            <!-- This intent filter handles app launch -->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!-- This intent filter used for handling deep link -->
+            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
@@ -35,7 +41,6 @@
                     android:host="${applicationId}"
                     android:pathPrefix="/HomeScreenActivity"
                     android:scheme="ctdemo" />
-
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
Fixes a bug where the icon of sample app does not show up when app is installed in emulator or device.It is caused due to multiple categories and actions being added in the same intent-filter.


> You can create a filter that includes more than one instance of <action>,<data>,<category>. If you do, you need to be certain that the component can handle any and all combinations of those filter elements.
> 
> When you want to handle multiple kinds of intents, but only in specific combinations of action, data, and category type, then you need to create multiple intent filters.

Full documentation can be found regarding intent-filters [here](https://developer.android.com/guide/components/intents-filters#Receiving)