### PR TITLE
fix(push-templates): add subtitle to notification header above android 12 SDK-2160

### DIFF
--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/styles/Style.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/styles/Style.kt
@@ -3,6 +3,7 @@ package com.clevertap.android.pushtemplates.styles
 import android.app.PendingIntent
 import android.content.Context
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.text.Html
 import android.widget.RemoteViews
@@ -28,6 +29,11 @@ abstract class Style(private var renderer: TemplateRenderer) {
         if (contentViewBig != null) {
             notificationBuilder.setCustomBigContentView(contentViewBig)
         }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            notificationBuilder.setSubText(renderer.pt_subtitle)
+        }
+
         return notificationBuilder.setSmallIcon(renderer.smallIcon)
             .setContentTitle(Html.fromHtml(pt_title))
             .setContentIntent(pIntent)


### PR DESCRIPTION
- fixes a bug on android 12 where push template notification header was not displaying subtitle text.