### PR TITLE
update cicd actions to support independent artifacts

### DIFF
--- a/.github/mini_flows/build_code_debug/action.yml
+++ b/.github/mini_flows/build_code_debug/action.yml
@@ -9,7 +9,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: assembleDebug-clevertap-core
         path: clevertap-core/build/outputs/aar
@@ -23,7 +23,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: assembleDebug-clevertap-geofence
         path: clevertap-geofence/build/outputs/aar
@@ -37,7 +37,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: assembleDebug-clevertap-hms
         path: clevertap-hms/build/outputs/aar
@@ -51,7 +51,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: assembleDebug-clevertap-pushTemplates
         path:  clevertap-pushtemplates/build/outputs/aar
@@ -64,7 +64,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: assembleDebug-clevertap-xps
         path: clevertap-xps/build/outputs/aar

--- a/.github/mini_flows/build_code_debug/action.yml
+++ b/.github/mini_flows/build_code_debug/action.yml
@@ -2,18 +2,69 @@ runs:
   using: "composite"
   steps:
 
-    - name: Generate AAR files
+    - name: assembleDebug-clevertap-core
+      if: always()
       shell: bash
-      run: ./gradlew :clevertap-core:assembleDebug :clevertap-geofence:assembleDebug  :clevertap-hms:assembleDebug  :clevertap-pushTemplates:assembleDebug :clevertap-xps:assembleDebug
+      run: ./gradlew :clevertap-core:assembleDebug
 
     - name: Upload AAR and apk files
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: aars_and_apks.zip
-        path: |
-          clevertap-core/build/outputs/aar
-          clevertap-hms/build/outputs/aar
-          clevertap-xps/build/outputs/aar
-          clevertap-geofence/build/outputs/aar
-          clevertap-pushtemplates/build/outputs/aar
+        name: assembleDebug-clevertap-core
+        path: clevertap-core/build/outputs/aar
+
+###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: assembleDebug-clevertap-geofence
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-geofence:assembleDebug
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: assembleDebug-clevertap-geofence
+        path: clevertap-geofence/build/outputs/aar
+
+###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: assembleDebug-clevertap-hms
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-hms:assembleDebug
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: assembleDebug-clevertap-hms
+        path: clevertap-hms/build/outputs/aar
+
+###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: assembleDebug-clevertap-pushTemplates
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-pushtemplates:assembleDebug
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: assembleDebug-clevertap-pushTemplates
+        path:  clevertap-pushtemplates/build/outputs/aar
+
+###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: assembleDebug-clevertap-xps
+      shell: bash
+      run: ./gradlew :clevertap-xps:assembleDebug
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: assembleDebug-clevertap-xps
+        path: clevertap-xps/build/outputs/aar

--- a/.github/mini_flows/build_code_release/action.yml
+++ b/.github/mini_flows/build_code_release/action.yml
@@ -9,7 +9,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: assembleRelease-clevertap-core
         path: clevertap-core/build/outputs/aar
@@ -23,7 +23,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: assembleRelease-clevertap-geofence
         path: clevertap-geofence/build/outputs/aar
@@ -37,7 +37,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: assembleRelease-clevertap-hms
         path: clevertap-hms/build/outputs/aar
@@ -51,7 +51,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: assembleRelease-clevertap-pushTemplates
         path:  clevertap-pushtemplates/build/outputs/aar
@@ -64,7 +64,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: assembleRelease-clevertap-xps
         path: clevertap-xps/build/outputs/aar

--- a/.github/mini_flows/build_code_release/action.yml
+++ b/.github/mini_flows/build_code_release/action.yml
@@ -2,18 +2,69 @@ runs:
   using: "composite"
   steps:
 
-    - name: Generate AAR files
+    - name: assembleRelease-clevertap-core
+      if: always()
       shell: bash
-      run: ./gradlew :clevertap-core:assembleRelease :clevertap-geofence:assembleRelease  :clevertap-hms:assembleRelease  :clevertap-pushTemplates:assembleRelease :clevertap-xps:assembleRelease
+      run: ./gradlew :clevertap-core:assembleRelease
 
     - name: Upload AAR and apk files
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: aars_and_apks.zip
-        path: |
-          clevertap-core/build/outputs/aar
-          clevertap-hms/build/outputs/aar
-          clevertap-xps/build/outputs/aar
-          clevertap-geofence/build/outputs/aar
-          clevertap-pushtemplates/build/outputs/aar
+        name: assembleRelease-clevertap-core
+        path: clevertap-core/build/outputs/aar
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: assembleRelease-clevertap-geofence
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-geofence:assembleRelease
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: assembleRelease-clevertap-geofence
+        path: clevertap-geofence/build/outputs/aar
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: assembleRelease-clevertap-hms
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-hms:assembleRelease
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: assembleRelease-clevertap-hms
+        path: clevertap-hms/build/outputs/aar
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: assembleRelease-clevertap-pushTemplates
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-pushtemplates:assembleRelease
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: assembleRelease-clevertap-pushTemplates
+        path:  clevertap-pushtemplates/build/outputs/aar
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: assembleRelease-clevertap-xps
+      shell: bash
+      run: ./gradlew :clevertap-xps:assembleRelease
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: assembleRelease-clevertap-xps
+        path: clevertap-xps/build/outputs/aar

--- a/.github/mini_flows/codechecks_checkstyle/action.yml
+++ b/.github/mini_flows/codechecks_checkstyle/action.yml
@@ -9,7 +9,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: checkstyle-clevertap-core
         path: clevertap-core/build/reports/checkstyle
@@ -23,7 +23,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: checkstyle-clevertap-geofence
         path: clevertap-geofence/build/reports/checkstyle
@@ -37,7 +37,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: checkstyle-clevertap-hms
         path: clevertap-hms/build/reports/checkstyle
@@ -51,7 +51,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: checkstyle-clevertap-pushTemplates
         path:  clevertap-pushtemplates/build/reports/checkstyle
@@ -64,7 +64,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: checkstyle-clevertap-xps
         path: clevertap-xps/build/reports/checkstyle

--- a/.github/mini_flows/codechecks_checkstyle/action.yml
+++ b/.github/mini_flows/codechecks_checkstyle/action.yml
@@ -2,19 +2,69 @@ runs:
   using: "composite"
   steps:
 
-    - name: CodeAnalysis via  checkstyle
+    - name: checkstyle-clevertap-core
+      if: always()
       shell: bash
-      run: ./gradlew :clevertap-core:checkstyle :clevertap-geofence:checkstyle  :clevertap-hms:checkstyle  :clevertap-pushTemplates:checkstyle :clevertap-xps:checkstyle
+      run: ./gradlew :clevertap-core:checkstyle
 
-    - name: Upload checkstyle results
+    - name: Upload AAR and apk files
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: checkstyle_results
-        path: |
-          clevertap-core/build/reports/checkstyle
-          clevertap-hms/build/reports/checkstyle
-          clevertap-xps/build/reports/checkstyle
-          clevertap-geofence/build/reports/checkstyle
-          clevertap-pushtemplates/build/reports/checkstyle
+        name: checkstyle-clevertap-core
+        path: clevertap-core/build/reports/checkstyle
 
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: checkstyle-clevertap-geofence
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-geofence:checkstyle
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: checkstyle-clevertap-geofence
+        path: clevertap-geofence/build/reports/checkstyle
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: checkstyle-clevertap-hms
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-hms:checkstyle
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: checkstyle-clevertap-hms
+        path: clevertap-hms/build/reports/checkstyle
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: checkstyle-clevertap-pushTemplates
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-pushtemplates:checkstyle
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: checkstyle-clevertap-pushTemplates
+        path:  clevertap-pushtemplates/build/reports/checkstyle
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: checkstyle-clevertap-xps
+      shell: bash
+      run: ./gradlew :clevertap-xps:checkstyle
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: checkstyle-clevertap-xps
+        path: clevertap-xps/build/reports/checkstyle

--- a/.github/mini_flows/codechecks_detekt/action.yml
+++ b/.github/mini_flows/codechecks_detekt/action.yml
@@ -9,7 +9,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: detekt-clevertap-core
         path: clevertap-core/build/reports/detekt
@@ -23,7 +23,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: detekt-clevertap-geofence
         path: clevertap-geofence/build/reports/detekt
@@ -37,7 +37,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: detekt-clevertap-hms
         path: clevertap-hms/build/reports/detekt
@@ -51,7 +51,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: detekt-clevertap-pushTemplates
         path:  clevertap-pushtemplates/build/reports/detekt
@@ -64,7 +64,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: detekt-clevertap-xps
         path: clevertap-xps/build/reports/detekt

--- a/.github/mini_flows/codechecks_detekt/action.yml
+++ b/.github/mini_flows/codechecks_detekt/action.yml
@@ -1,19 +1,70 @@
 runs:
   using: "composite"
   steps:
-    - name: CodeAnalysis via  detekt
-      shell: bash
-      run: ./gradlew :clevertap-core:detekt :clevertap-geofence:detekt  :clevertap-hms:detekt  :clevertap-pushTemplates:detekt :clevertap-xps:detekt
 
-    - name: Upload detekt results
+    - name: detekt-clevertap-core
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-core:detekt
+
+    - name: Upload AAR and apk files
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: detekt_results
-        path:  |
-          clevertap-core/build/reports/detekt
-          clevertap-hms/build/reports/detekt
-          clevertap-xps/build/reports/detekt
-          clevertap-geofence/build/reports/detekt
-          clevertap-pushtemplates/build/reports/detekt
+        name: detekt-clevertap-core
+        path: clevertap-core/build/reports/detekt
 
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: detekt-clevertap-geofence
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-geofence:detekt
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: detekt-clevertap-geofence
+        path: clevertap-geofence/build/reports/detekt
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: detekt-clevertap-hms
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-hms:detekt
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: detekt-clevertap-hms
+        path: clevertap-hms/build/reports/detekt
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: detekt-clevertap-pushTemplates
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-pushtemplates:detekt
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: detekt-clevertap-pushTemplates
+        path:  clevertap-pushtemplates/build/reports/detekt
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: detekt-clevertap-xps
+      shell: bash
+      run: ./gradlew :clevertap-xps:detekt
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: detekt-clevertap-xps
+        path: clevertap-xps/build/reports/detekt

--- a/.github/mini_flows/lint/action.yml
+++ b/.github/mini_flows/lint/action.yml
@@ -9,7 +9,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: lint-clevertap-core
         path: clevertap-core/build/reports/lint-results-debug.html
@@ -23,7 +23,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: lint-clevertap-geofence
         path: clevertap-geofence/build/reports/lint-results-debug.html
@@ -37,7 +37,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: lint-clevertap-hms
         path: clevertap-hms/build/reports/lint-results-debug.html
@@ -51,7 +51,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: lint-clevertap-pushTemplates
         path:  clevertap-pushtemplates/build/reports/lint-results-debug.html
@@ -64,7 +64,7 @@ runs:
 
     - name: Upload AAR and apk files
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: lint-clevertap-xps
         path: clevertap-xps/build/reports/lint-results-debug.html

--- a/.github/mini_flows/lint/action.yml
+++ b/.github/mini_flows/lint/action.yml
@@ -1,18 +1,70 @@
 runs:
   using: "composite"
   steps:
-    - name: Check lint
-      shell: bash
-      run: ./gradlew :clevertap-core:lint :clevertap-geofence:lint  :clevertap-hms:lint  :clevertap-pushTemplates:lint :clevertap-xps:lint
 
-    - name: Upload Lint results
+    - name: lint-clevertap-core
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-core:lint
+
+    - name: Upload AAR and apk files
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: lint_results
-        path:  |
-          clevertap-core/build/reports/lint-results.html
-          clevertap-hms/build/reports/lint-results.html
-          clevertap-xps/build/reports/lint-results.html
-          clevertap-geofence/build/reports/lint-results.html
-          clevertap-pushtemplates/build/reports/lint-results.html
+        name: lint-clevertap-core
+        path: clevertap-core/build/reports/lint-results-debug.html
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: lint-clevertap-geofence
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-geofence:lint
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: lint-clevertap-geofence
+        path: clevertap-geofence/build/reports/lint-results-debug.html
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: lint-clevertap-hms
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-hms:lint
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: lint-clevertap-hms
+        path: clevertap-hms/build/reports/lint-results-debug.html
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: lint-clevertap-pushTemplates
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-pushtemplates:lint
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: lint-clevertap-pushTemplates
+        path:  clevertap-pushtemplates/build/reports/lint-results-debug.html
+
+    ###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------###------##----------
+
+    - name: lint-clevertap-xps
+      shell: bash
+      run: ./gradlew :clevertap-xps:lint
+
+    - name: Upload AAR and apk files
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: lint-clevertap-xps
+        path: clevertap-xps/build/reports/lint-results-debug.html

--- a/.github/mini_flows/setup_jdk/action.yml
+++ b/.github/mini_flows/setup_jdk/action.yml
@@ -2,7 +2,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/mini_flows/test_and_coverage_debug/action.yml
+++ b/.github/mini_flows/test_and_coverage_debug/action.yml
@@ -9,14 +9,14 @@ runs:
 
     - name: Upload1
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: TestReportDebug-clevertap-core
         path: clevertap-core/build/reports/tests
 
     - name: Upload2
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: JacocoReportDebug-clevertap-core
         path: clevertap-core/build/reports/jacoco
@@ -30,14 +30,14 @@ runs:
 
     - name: Upload1
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: TestReportDebug-clevertap-geofence
         path: clevertap-geofence/build/reports/tests
 
     - name: Upload2
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: JacocoReportDebug-clevertap-geofence
         path: clevertap-geofence/build/reports/jacoco
@@ -51,14 +51,14 @@ runs:
 
     - name: Upload1
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: TestReportDebug-clevertap-hms
         path: clevertap-hms/build/reports/tests
 
     - name: Upload2
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: JacocoReportDebug-clevertap-hms
         path: clevertap-hms/build/reports/jacoco
@@ -72,14 +72,14 @@ runs:
 
     - name: Upload1
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: TestReportDebug-clevertap-xps
         path: clevertap-xps/build/reports/tests
 
     - name: Upload2
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: JacocoReportDebug-clevertap-xps
         path: clevertap-xps/build/reports/jacoco
@@ -94,14 +94,14 @@ runs:
 
     - name: Upload1
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: TestReportDebug-clevertap-pushtemplates
         path: clevertap-pushtemplates/build/reports/tests
 
     - name: Upload2
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: JacocoReportDebug-clevertap-pushtemplates
         path: clevertap-pushtemplates/build/reports/jacoco

--- a/.github/mini_flows/test_and_coverage_debug/action.yml
+++ b/.github/mini_flows/test_and_coverage_debug/action.yml
@@ -2,31 +2,106 @@ runs:
   using: "composite"
   steps:
 
-    - name: Run Unit Tests And Code Coverage (DEBUG)
+    - name: jacocoTestReportDebug-clevertap-core
+      if: always()
       shell: bash
-      run: ./gradlew :clevertap-core:jacocoTestReportDebug  -Pcoverage='true' :clevertap-geofence:jacocoTestReportDebug  -Pcoverage='true'  :clevertap-hms:jacocoTestReportDebug  -Pcoverage='true'  :clevertap-pushTemplates:jacocoTestReportDebug  -Pcoverage='true' :clevertap-xps:jacocoTestReportDebug  -Pcoverage='true'
+      run: ./gradlew :clevertap-core:jacocoTestReportDebug  -Pcoverage='true'
 
-    - name: Upload Unit tests
+    - name: Upload1
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: code-coverage-results
-        path: |
-          clevertap-core/build/reports/tests
-          clevertap-core/build/reports/jacoco
+        name: TestReportDebug-clevertap-core
+        path: clevertap-core/build/reports/tests
 
-          clevertap-hms/build/reports/tests
-          clevertap-hms/build/reports/jacoco
-
-          clevertap-xps/build/reports/tests
-          clevertap-xps/build/reports/jacoco
-
-          clevertap-geofence/build/reports/tests
-          clevertap-geofence/build/reports/jacoco
-
-          clevertap-pushtemplates/build/reports/tests
-          clevertap-pushtemplates/build/reports/jacoco
+    - name: Upload2
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: JacocoReportDebug-clevertap-core
+        path: clevertap-core/build/reports/jacoco
 
 
+    #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
+    - name: jacocoTestReportDebug-clevertap-geofence
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-geofence:jacocoTestReportDebug  -Pcoverage='true'
 
-      #todo : set success/failure as output and use slack action to send message . setting success failure: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions
+    - name: Upload1
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: TestReportDebug-clevertap-geofence
+        path: clevertap-geofence/build/reports/tests
+
+    - name: Upload2
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: JacocoReportDebug-clevertap-geofence
+        path: clevertap-geofence/build/reports/jacoco
+
+
+    #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
+    - name: jacocoTestReportDebug-clevertap-hms
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-hms:jacocoTestReportDebug  -Pcoverage='true'
+
+    - name: Upload1
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: TestReportDebug-clevertap-hms
+        path: clevertap-hms/build/reports/tests
+
+    - name: Upload2
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: JacocoReportDebug-clevertap-hms
+        path: clevertap-hms/build/reports/jacoco
+
+
+    #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
+    - name: jacocoTestReportDebug-clevertap-xps
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-xps:jacocoTestReportDebug  -Pcoverage='true'
+
+    - name: Upload1
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: TestReportDebug-clevertap-xps
+        path: clevertap-xps/build/reports/tests
+
+    - name: Upload2
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: JacocoReportDebug-clevertap-xps
+        path: clevertap-xps/build/reports/jacoco
+
+
+
+    #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
+    - name: jacocoTestReportDebug-clevertap-pushtemplates
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-pushtemplates:jacocoTestReportDebug  -Pcoverage='true'
+
+    - name: Upload1
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: TestReportDebug-clevertap-pushtemplates
+        path: clevertap-pushtemplates/build/reports/tests
+
+    - name: Upload2
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: JacocoReportDebug-clevertap-pushtemplates
+        path: clevertap-pushtemplates/build/reports/jacoco

--- a/.github/mini_flows/test_and_coverage_release/action.yml
+++ b/.github/mini_flows/test_and_coverage_release/action.yml
@@ -8,14 +8,14 @@ runs:
 
     - name: Upload1
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: TestReportRelease-clevertap-core
         path: clevertap-core/build/reports/tests
 
     - name: Upload2
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: JacocoReportRelease-clevertap-core
         path: clevertap-core/build/reports/jacoco
@@ -29,14 +29,14 @@ runs:
 
     - name: Upload1
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: TestReportRelease-clevertap-geofence
         path: clevertap-geofence/build/reports/tests
 
     - name: Upload2
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: JacocoReportRelease-clevertap-geofence
         path: clevertap-geofence/build/reports/jacoco
@@ -50,14 +50,14 @@ runs:
 
     - name: Upload1
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: TestReportRelease-clevertap-hms
         path: clevertap-hms/build/reports/tests
 
     - name: Upload2
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: JacocoReportRelease-clevertap-hms
         path: clevertap-hms/build/reports/jacoco
@@ -71,14 +71,14 @@ runs:
 
     - name: Upload1
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: TestReportRelease-clevertap-xps
         path: clevertap-xps/build/reports/tests
 
     - name: Upload2
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: JacocoReportRelease-clevertap-xps
         path: clevertap-xps/build/reports/jacoco
@@ -93,14 +93,14 @@ runs:
 
     - name: Upload1
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: TestReportRelease-clevertap-pushtemplates
         path: clevertap-pushtemplates/build/reports/tests
 
     - name: Upload2
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: JacocoReportRelease-clevertap-pushtemplates
         path: clevertap-pushtemplates/build/reports/jacoco

--- a/.github/mini_flows/test_and_coverage_release/action.yml
+++ b/.github/mini_flows/test_and_coverage_release/action.yml
@@ -1,32 +1,106 @@
 runs:
   using: "composite"
   steps:
-
-    - name: Run Unit Tests And Code Coverage (RELEASE)
+    - name: jacocoTestReportRelease-clevertap-core
+      if: always()
       shell: bash
-      run: ./gradlew :clevertap-core:jacocoTestReportRelease -Pcoverage='true' :clevertap-geofence:jacocoTestReportRelease -Pcoverage='true'  :clevertap-hms:jacocoTestReportRelease -Pcoverage='true'  :clevertap-pushTemplates:jacocoTestReportRelease -Pcoverage='true' :clevertap-xps:jacocoTestReportRelease -Pcoverage='true'
+      run: ./gradlew :clevertap-core:jacocoTestReportRelease  -Pcoverage='true'
 
-    - name: Upload Unit tests
+    - name: Upload1
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: code-coverage-results
-        path: |
-          clevertap-core/build/reports/tests
-          clevertap-core/build/reports/jacoco
+        name: TestReportRelease-clevertap-core
+        path: clevertap-core/build/reports/tests
 
-          clevertap-hms/build/reports/tests
-          clevertap-hms/build/reports/jacoco
-
-          clevertap-xps/build/reports/tests
-          clevertap-xps/build/reports/jacoco
-
-          clevertap-geofence/build/reports/tests
-          clevertap-geofence/build/reports/jacoco
-
-          clevertap-pushtemplates/build/reports/tests
-          clevertap-pushtemplates/build/reports/jacoco
+    - name: Upload2
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: JacocoReportRelease-clevertap-core
+        path: clevertap-core/build/reports/jacoco
 
 
+    #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
+    - name: jacocoTestReportRelease-clevertap-geofence
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-geofence:jacocoTestReportRelease  -Pcoverage='true'
 
-      #todo : set success/failure as output and use slack action to send message . setting success failure: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions
+    - name: Upload1
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: TestReportRelease-clevertap-geofence
+        path: clevertap-geofence/build/reports/tests
+
+    - name: Upload2
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: JacocoReportRelease-clevertap-geofence
+        path: clevertap-geofence/build/reports/jacoco
+
+
+    #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
+    - name: jacocoTestReportRelease-clevertap-hms
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-hms:jacocoTestReportRelease  -Pcoverage='true'
+
+    - name: Upload1
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: TestReportRelease-clevertap-hms
+        path: clevertap-hms/build/reports/tests
+
+    - name: Upload2
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: JacocoReportRelease-clevertap-hms
+        path: clevertap-hms/build/reports/jacoco
+
+
+    #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
+    - name: jacocoTestReportRelease-clevertap-xps
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-xps:jacocoTestReportRelease  -Pcoverage='true'
+
+    - name: Upload1
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: TestReportRelease-clevertap-xps
+        path: clevertap-xps/build/reports/tests
+
+    - name: Upload2
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: JacocoReportRelease-clevertap-xps
+        path: clevertap-xps/build/reports/jacoco
+
+
+
+    #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
+    - name: jacocoTestReportRelease-clevertap-pushtemplates
+      if: always()
+      shell: bash
+      run: ./gradlew :clevertap-pushtemplates:jacocoTestReportRelease  -Pcoverage='true'
+
+    - name: Upload1
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: TestReportRelease-clevertap-pushtemplates
+        path: clevertap-pushtemplates/build/reports/tests
+
+    - name: Upload2
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: JacocoReportRelease-clevertap-pushtemplates
+        path: clevertap-pushtemplates/build/reports/jacoco

--- a/.github/mini_flows/test_debug/action.yml
+++ b/.github/mini_flows/test_debug/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Upload Unit tests
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: unit-tests-results
         path: |

--- a/.github/mini_flows/test_release/action.yml
+++ b/.github/mini_flows/test_release/action.yml
@@ -12,7 +12,7 @@ runs:
 
     - name: Upload Unit tests
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: unit-tests-results
         path: |

--- a/.github/workflows/manually_validate.yml
+++ b/.github/workflows/manually_validate.yml
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout the code from Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Mandatory File Changes
         if: ${{ github.event.inputs.check_mandatory }}

--- a/.github/workflows/on_pr_from_develop_to_master.yml
+++ b/.github/workflows/on_pr_from_develop_to_master.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout the code from Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup JDK 11.
         uses: ./.github/mini_flows/setup_jdk

--- a/.github/workflows/on_pr_from_task_to_develop.yml
+++ b/.github/workflows/on_pr_from_task_to_develop.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout the code from Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup JDK 11.
         uses: ./.github/mini_flows/setup_jdk

--- a/.github/workflows/on_pr_merged_in_master.yml
+++ b/.github/workflows/on_pr_merged_in_master.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout the code from Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup JDK 11.
         uses: ./.github/mini_flows/setup_jdk


### PR DESCRIPTION
**Current situation** 
when a cicd pipeline is successfully ran, it generates a single zip file for all AARs in large nested folder (`build>output>aars>com>clevertap>(module) > .aar file`) . This result in large bandwidth wastage for during downloads and also does not give a correct idea about which tasks generated a successful artifact and size of independent artifacts

**What this PR proposes**
This PR splits each step of various workflows into independent module level steps. For eg, if there was a single build step before : 

```yml 


    - name: Generate AAR files

      shell: bash
      run: ./gradlew :clevertap-core:assembleDebug :clevertap-geofence:assembleDebug  :clevertap-hms:assembleDebug  :clevertap-pushTemplates:assembleDebug :clevertap-xps:assembleDebug

```

it is split into multiple steps: 

```yml
    - name: assembleDebug-clevertap-core
      if: always()
      shell: bash
      run: ./gradlew :clevertap-core:assembleDebug


    - name: assembleDebug-clevertap-geofence
      if: always()
      shell: bash
      run: ./gradlew :clevertap-geofence:assembleDebug

#...

```

Let me know if these changes are correct or require any modifications

