### PR TITLE
[SDK-2293] multiple  NOC fixes

### DIFF
--- a/clevertap-core/consumer-rules.pro
+++ b/clevertap-core/consumer-rules.pro
@@ -9,6 +9,9 @@
 -keep class com.google.android.exoplayer2.ui.StyledPlayerView{*;}
 -keep class com.google.android.gms.ads.identifier.AdvertisingIdClient{*;}
 -keep class com.google.android.gms.common.GooglePlayServicesUtil{*;}
+-keepnames class * implements android.os.Parcelable {
+    public static final ** CREATOR;
+}
 
 -keepattributes Exceptions,InnerClasses,Signature,Deprecated,
                 SourceFile,LineNumberTable,*Annotation*,EnclosingMethod

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/ActivityLifeCycleManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/ActivityLifeCycleManager.java
@@ -157,7 +157,7 @@ class ActivityLifeCycleManager {
                 public void onInstallReferrerSetupFinished(int responseCode) {
                     switch (responseCode) {
                         case InstallReferrerClient.InstallReferrerResponse.OK:
-                            // Connection established.
+                            // Connection established
                             Task<ReferrerDetails> task = CTExecutorFactory.executors(config).postAsyncSafelyTask();
                             task.execute("ActivityLifeCycleManager#getInstallReferrer", () -> {
                                 ReferrerDetails response = null;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/ActivityLifeCycleManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/ActivityLifeCycleManager.java
@@ -159,19 +159,7 @@ class ActivityLifeCycleManager {
                         case InstallReferrerClient.InstallReferrerResponse.OK:
                             // Connection established
                             Task<ReferrerDetails> task = CTExecutorFactory.executors(config).postAsyncSafelyTask();
-                            task.execute("ActivityLifeCycleManager#getInstallReferrer", () -> {
-                                ReferrerDetails response = null;
-                                try {
-                                    response = referrerClient.getInstallReferrer();
-                                } catch (RemoteException e) {
-                                    config.getLogger().debug(config.getAccountId(),
-                                            "Remote exception caused by Google Play Install Referrer library - " + e
-                                                    .getMessage());
-                                    referrerClient.endConnection();
-                                    coreMetaData.setInstallReferrerDataSent(false);
-                                }
-                                return response;
-                            });
+
                             task.addOnSuccessListener(response -> {
                                 try {
                                     String referrerUrl = response.getInstallReferrer();
@@ -185,12 +173,28 @@ class ActivityLifeCycleManager {
                                             "Install Referrer data set [Referrer URL-" + referrerUrl + "]");
                                 } catch (NullPointerException npe) {
                                     config.getLogger().debug(config.getAccountId(),
-                                            "Install referrer client null pointer exception caused by Google Play Install Referrer library - " + npe
+                                            "Install referrer client null pointer exception caused by Google Play Install Referrer library - "
+                                                    + npe
                                                     .getMessage());
                                     referrerClient.endConnection();
                                     coreMetaData.setInstallReferrerDataSent(false);
                                 }
                             });
+
+                            task.execute("ActivityLifeCycleManager#getInstallReferrer", () -> {
+                                ReferrerDetails response = null;
+                                try {
+                                    response = referrerClient.getInstallReferrer();
+                                } catch (RemoteException e) {
+                                    config.getLogger().debug(config.getAccountId(),
+                                            "Remote exception caused by Google Play Install Referrer library - " + e
+                                                    .getMessage());
+                                    referrerClient.endConnection();
+                                    coreMetaData.setInstallReferrerDataSent(false);
+                                }
+                                return response;
+                            });
+
                             break;
                         case InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED:
                             // API not available on the current Play Store app.

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -65,6 +65,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -127,7 +128,7 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
 
     static CleverTapInstanceConfig defaultConfig;
 
-    private static HashMap<String, CleverTapAPI> instances;
+    private static ConcurrentHashMap<String, CleverTapAPI> instances;
 
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private static String sdkVersion;  // For Google Play Store/Android Studio analytics
@@ -770,11 +771,11 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
         return null;// failed to get instance
     }
 
-    public static HashMap<String, CleverTapAPI> getInstances() {
+    public static ConcurrentHashMap<String, CleverTapAPI> getInstances() {
         return instances;
     }
 
-    public static void setInstances(final HashMap<String, CleverTapAPI> instances) {
+    public static void setInstances(final ConcurrentHashMap<String, CleverTapAPI> instances) {
         CleverTapAPI.instances = instances;
     }
 
@@ -860,7 +861,7 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
             return null;
         }
         if (instances == null) {
-            instances = new HashMap<>();
+            instances = new ConcurrentHashMap<>();
         }
 
         CleverTapAPI instance = instances.get(config.getAccountId());

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/ActivityLifeCycleManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/ActivityLifeCycleManagerTest.kt
@@ -115,11 +115,7 @@ class ActivityLifeCycleManagerTest : BaseTestCase() {
         //`when`(coreState.callbackManager.geofenceCallback).thenReturn(geofenceCallback)
 
         mockStatic(CTExecutorFactory::class.java).use {
-            `when`(CTExecutorFactory.executors(any())).thenReturn(
-                MockCTExecutors(
-                    cleverTapInstanceConfig
-                )
-            )
+            `when`(CTExecutorFactory.executors(cleverTapInstanceConfig)).thenReturn(MockCTExecutors(cleverTapInstanceConfig))
             mockStatic(InstallReferrerClient::class.java).use {
                 val referrerDetails = mock(ReferrerDetails::class.java)
                 val captor = ArgumentCaptor.forClass(InstallReferrerStateListener::class.java)


### PR DESCRIPTION
- add Proguard rules to keep CREATOR instance for Parcelable classes  (fixes ANR 1 from SUC-119607) 
- make call to `installReferral` async   (fixes crash 3 from SUC-119607) 
- use concurrent HashMap instead of HashMap for storing `CleverTapApi` instances (fixes crash 1 and 2 from SUC-119607) 
- update unit tests