### PR TITLE
[SDK-2596] Changes SDK endpoint 

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -111,7 +111,7 @@ public interface Constants {
     String WZRK_ACCT_ID_KEY = "wzrk_acct_id";
     String WZRK_FROM = "CTPushNotificationReceiver";
     String NETWORK_INFO = "NetworkInfo";
-    String PRIMARY_DOMAIN = "wzrkt.com";
+    String PRIMARY_DOMAIN = "clevertap-prod.com";
     String KEY_DOMAIN_NAME = "comms_dmn";
     String SPIKY_KEY_DOMAIN_NAME = "comms_dmn_spiky";
     String HEADER_DOMAIN_NAME = "X-WZRK-RD";


### PR DESCRIPTION
[SDK-2596]  setting clevertap-prod.com as PRIMARY_DOMAIN instead of wzrkt.com

[SDK-2596]: https://wizrocket.atlassian.net/browse/SDK-2596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ