### PR TITLE
Release core v4.6.7 push-templates v1.0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### March 14, 2023
 * [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTCORECHANGELOG.md)
 * [CleverTap Push Templates SDK v1.0.5.1](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTPUSHTEMPLATESCHANGELOG.md). CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTCORECHANGELOG.md) to work properly.
+* **Note:** This release is being done for Android 12 targeted users, satisfying below points.
+  * Targeting Android 12 and
+  * Using RenderMax and/or using Push Templates
 
 ### March 6, 2023
 * [CleverTap RenderMax SDK v1.0.3](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAXCHANGELOG.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## CHANGE LOG.
 
 ### March 14, 2023
-* [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md)
-* [CleverTap Push Templates SDK v1.0.5.1](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTPUSHTEMPLATESCHANGELOG.md). CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md) to work properly.
+* [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTCORECHANGELOG.md)
+* [CleverTap Push Templates SDK v1.0.5.1](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTPUSHTEMPLATESCHANGELOG.md). CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md) to work properly.
 
 ### March 6, 2023
 * [CleverTap RenderMax SDK v1.0.3](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAXCHANGELOG.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### March 14, 2023
 * [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTCORECHANGELOG.md)
-* [CleverTap Push Templates SDK v1.0.5.1](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTPUSHTEMPLATESCHANGELOG.md). CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md) to work properly.
+* [CleverTap Push Templates SDK v1.0.5.1](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTPUSHTEMPLATESCHANGELOG.md). CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTCORECHANGELOG.md) to work properly.
 
 ### March 6, 2023
 * [CleverTap RenderMax SDK v1.0.3](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAXCHANGELOG.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## CHANGE LOG.
 
+### March 14, 2023
+* [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md)
+* [CleverTap Push Templates SDK v1.0.5.1](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTPUSHTEMPLATESCHANGELOG.md). CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md) to work properly.
+
+### March 6, 2023
+* [CleverTap RenderMax SDK v1.0.3](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAXCHANGELOG.md)
+
 ### October 31, 2022
 * [CleverTap Android SDK v4.6.6](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ CleverTap Huawei Push SDK provides an out of the box service to use the Huawei M
 CleverTap Push Templates SDK helps you engage with your users using fancy push notification templates built specifically to work with [CleverTap](https://www.clevertap.com).
 Find the integration steps for the CleverTap Push Templates SDK [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTPUSHTEMPLATES.md)
 
-## 📲 CleverTap RenderMax Push SDK
+## 📲 CleverTap RenderMax SDK
 [(Back to top)](#-table-of-contents)
 
-RenderMax Push SDK delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
-Find the integration steps for the CleverTap RenderMax Push SDK [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAX.md)
+RenderMax SDK delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
+Find the integration steps for the CleverTap RenderMax SDK [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAX.md)
 
 ## 📄 License
 [(Back to top)](#-table-of-contents)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We publish the SDK to `mavenCentral` as an `AAR` file. Just declare it as depend
 
 ```groovy
     dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:4.6.6"
+         implementation "com.clevertap.android:clevertap-android-sdk:4.6.7"
     }
 ```
 
@@ -34,7 +34,7 @@ Alternatively, you can download and add the AAR file included in this repo in yo
     
  ```groovy
     dependencies {      
-        implementation (name: "clevertap-android-sdk-4.6.6", ext: 'aar')
+        implementation (name: "clevertap-android-sdk-4.6.7", ext: 'aar')
     }
 ```
 
@@ -46,7 +46,7 @@ Add the Firebase Messaging library and Android Support Library v4 as dependencie
 
 ```groovy
      dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:4.6.6"
+         implementation "com.clevertap.android:clevertap-android-sdk:4.6.7"
          implementation "androidx.core:core:1.3.0"
          implementation "com.google.firebase:firebase-messaging:21.0.0"
          implementation "com.google.android.gms:play-services-ads:19.4.0" // Required only if you enable Google ADID collection in the SDK (turned off by default).

--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ CleverTap Huawei Push SDK provides an out of the box service to use the Huawei M
 CleverTap Push Templates SDK helps you engage with your users using fancy push notification templates built specifically to work with [CleverTap](https://www.clevertap.com).
 Find the integration steps for the CleverTap Push Templates SDK [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTPUSHTEMPLATES.md)
 
+## 📲 CleverTap RenderMax Push SDK
+[(Back to top)](#-table-of-contents)
+
+RenderMax Push SDK delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
+Find the integration steps for the CleverTap RenderMax Push SDK [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAX.md)
+
 ## 📄 License
 [(Back to top)](#-table-of-contents)
 CleverTap Android SDK is MIT licensed, as found in the [LICENSE](https://github.com/CleverTap/clevertap-android-sdk/blob/master/LICENSE) file.

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ task copyTemplates {
     file("versions.properties").withInputStream { props.load(it) }
     outputs.upToDateWhen { false }
     props.put("clevertap_android_sdk",Libs.clevertap_android_sdk.dropRight(1))
+    props.put("clevertap_rendermax_sdk", Libs.clevertap_rendermax_sdk.dropRight(1))
     props.put("clevertap_geofence_sdk",Libs.clevertap_geofence_sdk.dropRight(1))
     props.put("clevertap_hms_sdk",Libs.clevertap_hms_sdk.dropRight(1))
     props.put("clevertap_xiaomi_sdk",Libs.clevertap_xiaomi_sdk.dropRight(1))

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -75,6 +75,8 @@ object Libs {
 
     const val clevertap_android_sdk: String = "com.clevertap.android:clevertap-android-sdk:_"
 
+    const val clevertap_rendermax_sdk: String = "com.clevertap.android:clevertap-rendermax-sdk:_"
+
     const val clevertap_geofence_sdk: String = "com.clevertap.android:clevertap-geofence-sdk:_"
 
     const val clevertap_hms_sdk: String = "com.clevertap.android:clevertap-hms-sdk:_"

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -2882,14 +2882,15 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     }
 
     //TODO: start synchronizing entire flow from here
-    public void renderPushNotification(@NonNull INotificationRenderer iNotificationRenderer, Context context,
+    public Future<?> renderPushNotification(@NonNull INotificationRenderer iNotificationRenderer, Context context,
             Bundle extras) {
 
         CleverTapInstanceConfig config = coreState.getConfig();
+        Future<?> future = null;
 
         try {
             Task<Void> task = CTExecutorFactory.executors(config).postAsyncSafelyTask();
-            task.execute("CleverTapAPI#renderPushNotification",
+            future = task.submit("CleverTapAPI#renderPushNotification",
                     new Callable<Void>() {
                         @Override
                         public Void call() {
@@ -2898,9 +2899,11 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
 
                                 if (extras != null && extras.containsKey(Constants.PT_NOTIF_ID)) {
                                     coreState.getPushProviders()
-                                            ._createNotification(context, extras, extras.getInt(Constants.PT_NOTIF_ID));
+                                            ._createNotification(context, extras,
+                                                    extras.getInt(Constants.PT_NOTIF_ID));
                                 } else {
-                                    coreState.getPushProviders()._createNotification(context, extras, Constants.EMPTY_NOTIFICATION_ID);
+                                    coreState.getPushProviders()
+                                            ._createNotification(context, extras, Constants.EMPTY_NOTIFICATION_ID);
                                 }
                             }
                             return null;
@@ -2909,6 +2912,8 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
         } catch (Throwable t) {
             config.getLogger().debug(config.getAccountId(), "Failed to process renderPushNotification()", t);
         }
+
+        return future;
 
     }
 

--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Version 4.6.7 (March 14, 2023)
 * Bug fixes and performance improvements.
+* **Note:** This release is being done for Android 12 targeted users, satisfying below points.
+  * Targeting Android 12 and
+  * Using RenderMax and/or using Push Templates
 
 ### Version 4.6.6 (October 31, 2022)
 * Fixes App Inbox bug where an Inbox message's video would not play when new Inbox messages were available

--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -1,5 +1,8 @@
 ## CleverTap Android SDK CHANGE LOG
 
+### Version 4.6.7 (March 14, 2023)
+* Bug fixes and performance improvements.
+
 ### Version 4.6.6 (October 31, 2022)
 * Fixes App Inbox bug where an Inbox message's video would not play when new Inbox messages were available
 

--- a/docs/CTGEOFENCE.md
+++ b/docs/CTGEOFENCE.md
@@ -17,7 +17,7 @@ Add the following dependencies to the `build.gradle`
 
 ```Groovy
 implementation "com.clevertap.android:clevertap-geofence-sdk:1.1.0"
-implementation "com.clevertap.android:clevertap-android-sdk:4.6.6" // 3.9.0 and above
+implementation "com.clevertap.android:clevertap-android-sdk:4.6.7" // 3.9.0 and above
 implementation "com.google.android.gms:play-services-location:18.0.0"
 implementation "androidx.work:work-runtime:2.7.0" // required for FETCH_LAST_LOCATION_PERIODIC
 implementation "androidx.concurrent:concurrent-futures:1.1.0" // required for FETCH_LAST_LOCATION_PERIODIC

--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -20,8 +20,8 @@ CleverTap Push Templates SDK helps you engage with your users using fancy push n
 1. Add the dependencies to the `build.gradle`
 
 ```groovy
-implementation "com.clevertap.android:push-templates:1.0.5"
-implementation "com.clevertap.android:clevertap-android-sdk:4.6.6" // 4.4.0 and above
+implementation "com.clevertap.android:push-templates:1.0.5.1"
+implementation "com.clevertap.android:clevertap-android-sdk:4.6.7" // 4.4.0 and above
 ```
 
 2. Add the following line to your Application class before the `onCreate()`

--- a/docs/CTPUSHTEMPLATESCHANGELOG.md
+++ b/docs/CTPUSHTEMPLATESCHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Version 1.0.5.1 (March 14, 2023)
 * Supports CleverTap Android SDK v4.6.7. CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTCORECHANGELOG.md) to work properly.
+* **Note:** This release is being done for Android 12 targeted users, satisfying below points.
+  * Targeting Android 12 and
+  * Using RenderMax and/or using Push Templates
 
 ### Version 1.0.5 (September 13, 2022)
 * fixes a bug on android 12 where push template notification header was not displaying subtitle text.

--- a/docs/CTPUSHTEMPLATESCHANGELOG.md
+++ b/docs/CTPUSHTEMPLATESCHANGELOG.md
@@ -1,7 +1,7 @@
 ## CleverTap Push Templates SDK CHANGE LOG
 
 ### Version 1.0.5.1 (March 14, 2023)
-* Supports CleverTap Android SDK v4.6.7. CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md) to work properly.
+* Supports CleverTap Android SDK v4.6.7. CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTCORECHANGELOG.md) to work properly.
 
 ### Version 1.0.5 (September 13, 2022)
 * fixes a bug on android 12 where push template notification header was not displaying subtitle text.

--- a/docs/CTPUSHTEMPLATESCHANGELOG.md
+++ b/docs/CTPUSHTEMPLATESCHANGELOG.md
@@ -1,5 +1,8 @@
 ## CleverTap Push Templates SDK CHANGE LOG
 
+### Version 1.0.5.1 (March 14, 2023)
+* Supports CleverTap Android SDK v4.6.7. CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md) to work properly.
+
 ### Version 1.0.5 (September 13, 2022)
 * fixes a bug on android 12 where push template notification header was not displaying subtitle text.
 

--- a/docs/CTRENDERMAX.md
+++ b/docs/CTRENDERMAX.md
@@ -21,7 +21,7 @@ To use CleverTap's RenderMax SDK with your app, add the following code snippet i
 
 ```groovy
     dependencies {
-         implementation "com.clevertap.android:clevertap-rendermax-sdk:1.0.2"
+         implementation "com.clevertap.android:clevertap-rendermax-sdk:1.0.3"
     }
 ```
 

--- a/docs/CTRENDERMAX.md
+++ b/docs/CTRENDERMAX.md
@@ -29,7 +29,7 @@ To use CleverTap's RenderMax Push Delivery with your app, add the following code
 
 [(Back to top)](#table-of-contents)
 
-* The RenderMax Push SDK is supported for Android SDK `v4.6.6`, React Native SDK `v0.9.3`, and above.
+* The RenderMax SDK is supported for Android SDK `v4.6.6`, React Native SDK `v0.9.3`, Flutter SDK `v1.5.5` and above.
 * If the app is custom rendering the push notification and not passing the payload to CleverTap SDK, add the following code before you render the notification:
 
   ```
@@ -40,12 +40,12 @@ To use CleverTap's RenderMax Push Delivery with your app, add the following code
 
 [(Back to top)](#table-of-contents)
 
-RenderMax push SDK is distributed as obfuscated package and for it's smooth working with proguard you must add necessary rules.
-The Good News is that, Proguard rules for renderMAX is provided out of the box through `consumer-rules.pro` which gets merged with App's proguard rule so you don't have to do anything here.
-Thanks to `consumer-rules.pro`. You can check renderMAX proguard rules in your `/build/outputs/mapping/configuration.txt` by searching rendermax keyword.
+RenderMax SDK is distributed as obfuscated package and for it's smooth working with proguard you must add necessary rules.
+The good News is that, Proguard rules for RenderMax is provided out of the box through `consumer-rules.pro` which gets merged with App's proguard rule so you don't have to do anything here.
+Thanks to `consumer-rules.pro`. You can check RenderMax proguard rules in your `/build/outputs/mapping/configuration.txt` by searching RenderMax keyword.
 
 # Changelog
 
 [(Back to top)](#table-of-contents)
 
-ChangeLog can be found [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAXCHANGELOG.md)
+Changelog can be found [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAXCHANGELOG.md)

--- a/docs/CTRENDERMAX.md
+++ b/docs/CTRENDERMAX.md
@@ -1,0 +1,51 @@
+<p align="center">
+  <img src="https://github.com/CleverTap/clevertap-ios-sdk/blob/master/docs/images/clevertap-logo.png" height="220"/>
+</p>
+
+# RenderMax by CleverTap
+
+RenderMax Push Delivery delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
+
+# Table of contents
+
+- [Installation](#installation)
+- [Developer Notes](#developer-notes)
+- [Proguard](#proguard)
+- [Changelog](#changelog)
+
+# Installation
+
+[(Back to top)](#table-of-contents)
+
+To use CleverTap's RenderMax Push Delivery with your app, add the following code snippet in the `build.gradle` of the app.
+
+```groovy
+    dependencies {
+         implementation "com.clevertap.android:clevertap-rendermax-sdk:1.0.2"
+    }
+```
+
+# Developer Notes
+
+[(Back to top)](#table-of-contents)
+
+* The RenderMax Push SDK is supported for Android SDK `v4.6.6`, React Native SDK `v0.9.3`, and above.
+* If the app is custom rendering the push notification and not passing the payload to CleverTap SDK, add the following code before you render the notification:
+
+  ```
+  CleverTapAPI.processPushNotification(getApplicationContext(),extras);
+  ```
+
+# Proguard
+
+[(Back to top)](#table-of-contents)
+
+RenderMax push SDK is distributed as obfuscated package and for it's smooth working with proguard you must add necessary rules.
+The Good News is that, Proguard rules for renderMAX is provided out of the box through `consumer-rules.pro` which gets merged with App's proguard rule so you don't have to do anything here.
+Thanks to `consumer-rules.pro`. You can check renderMAX proguard rules in your `/build/outputs/mapping/configuration.txt` by searching rendermax keyword.
+
+# Changelog
+
+[(Back to top)](#table-of-contents)
+
+ChangeLog can be found [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAXCHANGELOG.md)

--- a/docs/CTRENDERMAX.md
+++ b/docs/CTRENDERMAX.md
@@ -4,7 +4,7 @@
 
 # RenderMax by CleverTap
 
-RenderMax Push Delivery delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
+RenderMax SDK delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
 
 # Table of contents
 
@@ -17,7 +17,7 @@ RenderMax Push Delivery delivers and renders notifications on the user's device 
 
 [(Back to top)](#table-of-contents)
 
-To use CleverTap's RenderMax Push Delivery with your app, add the following code snippet in the `build.gradle` of the app.
+To use CleverTap's RenderMax SDK with your app, add the following code snippet in the `build.gradle` of the app.
 
 ```groovy
     dependencies {
@@ -41,8 +41,8 @@ To use CleverTap's RenderMax Push Delivery with your app, add the following code
 [(Back to top)](#table-of-contents)
 
 RenderMax SDK is distributed as obfuscated package and for it's smooth working with proguard you must add necessary rules.
-The good News is that, Proguard rules for RenderMax is provided out of the box through `consumer-rules.pro` which gets merged with App's proguard rule so you don't have to do anything here.
-Thanks to `consumer-rules.pro`. You can check RenderMax proguard rules in your `/build/outputs/mapping/configuration.txt` by searching RenderMax keyword.
+The good news is that, Proguard rules for RenderMax SDK is provided out of the box through `consumer-rules.pro` which gets merged with App's Proguard rule so you don't have to do anything here.
+Thanks to `consumer-rules.pro`. You can check RenderMax Proguard rules in your `/build/outputs/mapping/configuration.txt` by searching RenderMax keyword.
 
 # Changelog
 

--- a/docs/CTRENDERMAXCHANGELOG.md
+++ b/docs/CTRENDERMAXCHANGELOG.md
@@ -1,0 +1,11 @@
+## CleverTap RenderMAX Push SDK CHANGE LOG
+
+### Version 1.0.2 (January 25, 2023)
+* Fix [runtime exception](https://github.com/CleverTap/clevertap-android-sdk/issues/379)
+
+### Version 1.0.1 (December 14, 2022)
+* Internal improvements.
+
+### Version 1.0.0 (November 30, 2022)
+* Initial release! 🎉
+* Supports CleverTap Android SDK `v4.6.6`

--- a/docs/CTRENDERMAXCHANGELOG.md
+++ b/docs/CTRENDERMAXCHANGELOG.md
@@ -1,4 +1,4 @@
-## CleverTap RenderMAX Push SDK CHANGE LOG
+## CleverTap RenderMax SDK CHANGE LOG
 
 ### Version 1.0.2 (January 25, 2023)
 * Fix [runtime exception](https://github.com/CleverTap/clevertap-android-sdk/issues/379)

--- a/docs/CTRENDERMAXCHANGELOG.md
+++ b/docs/CTRENDERMAXCHANGELOG.md
@@ -1,5 +1,9 @@
 ## CleverTap RenderMax SDK CHANGE LOG
 
+### Version 1.0.3 (March 6, 2023)
+* Fix ANR while receiving push through RenderMax
+* Fix crash - java.lang.IllegalStateException
+
 ### Version 1.0.2 (January 25, 2023)
 * Fix [runtime exception](https://github.com/CleverTap/clevertap-android-sdk/issues/379)
 

--- a/gradle-scripts/commons.gradle
+++ b/gradle-scripts/commons.gradle
@@ -26,7 +26,12 @@ ext["sonatypeStagingProfileId"] = ''
 version = libraryVersion
 group = publishedGroupId
 
-def (major,minor,patch) = libraryVersion.split("\\.")
+def build = null
+def versionArr = libraryVersion.split("\\.")
+def (major, minor, patch) = versionArr
+if (versionArr.size() > 3) {
+    build = versionArr[3]
+}
 
 android {
     compileSdkVersion Android.compileSdkVersionVal
@@ -36,11 +41,14 @@ android {
         minSdkVersion minSdkVersionVal
         targetSdkVersion Android.targetSdkVersionVal
         versionCode "${major}0${minor}0${patch}".toInteger()
+        if (build != null) {
+            versionCode "${versionCode}0${build}".toInteger()
+        }
         versionName libraryVersion
 
         //AGP 4.1.0 change https://developer.android.com/studio/releases/gradle-plugin#version_properties_removed_from_buildconfig_class_in_library_projects
-        buildConfigField ("int", "VERSION_CODE", "$versionCode")
-        buildConfigField ("String", "VERSION_NAME", "\"$versionName\"")
+        buildConfigField("int", "VERSION_CODE", "$versionCode")
+        buildConfigField("String", "VERSION_NAME", "\"$versionName\"")
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-rules.pro'
@@ -52,14 +60,14 @@ android {
             System.out.println("coverage="+coverage)
             testCoverageEnabled (coverage) //To get coverage reports for instrumentation tests
             buildConfigField "String", "SDK_VERSION_STRING",
-                    "\"!SDK-VERSION-STRING!:$publishedGroupId:$artifact:$major.$minor.$patch.0\""
+                    "\"!SDK-VERSION-STRING!:$publishedGroupId:$artifact:$major.$minor.$patch.${build == null ? 0 : build}\""
         }
         release {
             Boolean coverage = project.hasProperty('coverage') //only true when a command is run with argument, like this : `gradle <command>  -Pcoverage='true'`
             System.out.println("coverage="+coverage)
             testCoverageEnabled (coverage) //To get coverage reports for instrumentation tests
             buildConfigField "String", "SDK_VERSION_STRING",
-                    "\"!SDK-VERSION-STRING!:$publishedGroupId:$artifact:$major.$minor.$patch.0\""
+                    "\"!SDK-VERSION-STRING!:$publishedGroupId:$artifact:$major.$minor.$patch.${build == null ? 0 : build}\""
             minifyEnabled false// keep it false we will supply proguard through consumerProguardFiles
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Version 4.6.7 (March 14, 2023)
 * Bug fixes and performance improvements.
+* **Note:** This release is being done for Android 12 targeted users, satisfying below points.
+  * Targeting Android 12 and
+  * Using RenderMax and/or using Push Templates
 
 ### Version 4.6.6 (October 31, 2022)
 * Fixes App Inbox bug where an Inbox message's video would not play when new Inbox messages were available

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -1,5 +1,8 @@
 ## CleverTap Android SDK CHANGE LOG
 
+### Version 4.6.7 (March 14, 2023)
+* Bug fixes and performance improvements.
+
 ### Version 4.6.6 (October 31, 2022)
 * Fixes App Inbox bug where an Inbox message's video would not play when new Inbox messages were available
 

--- a/templates/CTPUSHTEMPLATESCHANGELOG.md
+++ b/templates/CTPUSHTEMPLATESCHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Version 1.0.5.1 (March 14, 2023)
 * Supports CleverTap Android SDK v4.6.7. CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTCORECHANGELOG.md) to work properly.
+* **Note:** This release is being done for Android 12 targeted users, satisfying below points.
+  * Targeting Android 12 and
+  * Using RenderMax and/or using Push Templates
 
 ### Version 1.0.5 (September 13, 2022)
 * fixes a bug on android 12 where push template notification header was not displaying subtitle text.

--- a/templates/CTPUSHTEMPLATESCHANGELOG.md
+++ b/templates/CTPUSHTEMPLATESCHANGELOG.md
@@ -1,7 +1,7 @@
 ## CleverTap Push Templates SDK CHANGE LOG
 
 ### Version 1.0.5.1 (March 14, 2023)
-* Supports CleverTap Android SDK v4.6.7. CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md) to work properly.
+* Supports CleverTap Android SDK v4.6.7. CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master_android12/docs/CTCORECHANGELOG.md) to work properly.
 
 ### Version 1.0.5 (September 13, 2022)
 * fixes a bug on android 12 where push template notification header was not displaying subtitle text.

--- a/templates/CTPUSHTEMPLATESCHANGELOG.md
+++ b/templates/CTPUSHTEMPLATESCHANGELOG.md
@@ -1,5 +1,8 @@
 ## CleverTap Push Templates SDK CHANGE LOG
 
+### Version 1.0.5.1 (March 14, 2023)
+* Supports CleverTap Android SDK v4.6.7. CleverTap Push Templates SDK `v1.0.5.1` requires [CleverTap Android SDK v4.6.7](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md) to work properly.
+
 ### Version 1.0.5 (September 13, 2022)
 * fixes a bug on android 12 where push template notification header was not displaying subtitle text.
 

--- a/templates/CTRENDERMAX.md
+++ b/templates/CTRENDERMAX.md
@@ -29,7 +29,7 @@ To use CleverTap's RenderMax Push Delivery with your app, add the following code
 
 [(Back to top)](#table-of-contents)
 
-* The RenderMax Push SDK is supported for Android SDK `v4.6.6`, React Native SDK `v0.9.3`, and above.
+* The RenderMax SDK is supported for Android SDK `v4.6.6`, React Native SDK `v0.9.3`, Flutter SDK `v1.5.5` and above.
 * If the app is custom rendering the push notification and not passing the payload to CleverTap SDK, add the following code before you render the notification:
 
   ```
@@ -40,12 +40,12 @@ To use CleverTap's RenderMax Push Delivery with your app, add the following code
 
 [(Back to top)](#table-of-contents)
 
-RenderMax push SDK is distributed as obfuscated package and for it's smooth working with proguard you must add necessary rules.
-The Good News is that, Proguard rules for renderMAX is provided out of the box through `consumer-rules.pro` which gets merged with App's proguard rule so you don't have to do anything here.
-Thanks to `consumer-rules.pro`. You can check renderMAX proguard rules in your `/build/outputs/mapping/configuration.txt` by searching rendermax keyword.
+RenderMax SDK is distributed as obfuscated package and for it's smooth working with proguard you must add necessary rules.
+The good News is that, Proguard rules for RenderMax is provided out of the box through `consumer-rules.pro` which gets merged with App's proguard rule so you don't have to do anything here.
+Thanks to `consumer-rules.pro`. You can check RenderMax proguard rules in your `/build/outputs/mapping/configuration.txt` by searching RenderMax keyword.
 
 # Changelog
 
 [(Back to top)](#table-of-contents)
 
-ChangeLog can be found [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAXCHANGELOG.md)
+Changelog can be found [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAXCHANGELOG.md)

--- a/templates/CTRENDERMAX.md
+++ b/templates/CTRENDERMAX.md
@@ -1,0 +1,51 @@
+<p align="center">
+  <img src="https://github.com/CleverTap/clevertap-ios-sdk/blob/master/docs/images/clevertap-logo.png" height="220"/>
+</p>
+
+# RenderMax by CleverTap
+
+RenderMax Push Delivery delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
+
+# Table of contents
+
+- [Installation](#installation)
+- [Developer Notes](#developer-notes)
+- [Proguard](#proguard)
+- [Changelog](#changelog)
+
+# Installation
+
+[(Back to top)](#table-of-contents)
+
+To use CleverTap's RenderMax Push Delivery with your app, add the following code snippet in the `build.gradle` of the app.
+
+```groovy
+    dependencies {
+         implementation "${ext.clevertap_rendermax_sdk}${ext['version.com.clevertap.android..clevertap-rendermax-sdk']}"
+    }
+```
+
+# Developer Notes
+
+[(Back to top)](#table-of-contents)
+
+* The RenderMax Push SDK is supported for Android SDK `v4.6.6`, React Native SDK `v0.9.3`, and above.
+* If the app is custom rendering the push notification and not passing the payload to CleverTap SDK, add the following code before you render the notification:
+
+  ```
+  CleverTapAPI.processPushNotification(getApplicationContext(),extras);
+  ```
+
+# Proguard
+
+[(Back to top)](#table-of-contents)
+
+RenderMax push SDK is distributed as obfuscated package and for it's smooth working with proguard you must add necessary rules.
+The Good News is that, Proguard rules for renderMAX is provided out of the box through `consumer-rules.pro` which gets merged with App's proguard rule so you don't have to do anything here.
+Thanks to `consumer-rules.pro`. You can check renderMAX proguard rules in your `/build/outputs/mapping/configuration.txt` by searching rendermax keyword.
+
+# Changelog
+
+[(Back to top)](#table-of-contents)
+
+ChangeLog can be found [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAXCHANGELOG.md)

--- a/templates/CTRENDERMAX.md
+++ b/templates/CTRENDERMAX.md
@@ -4,7 +4,7 @@
 
 # RenderMax by CleverTap
 
-RenderMax Push Delivery delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
+RenderMax SDK delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
 
 # Table of contents
 
@@ -17,7 +17,7 @@ RenderMax Push Delivery delivers and renders notifications on the user's device 
 
 [(Back to top)](#table-of-contents)
 
-To use CleverTap's RenderMax Push Delivery with your app, add the following code snippet in the `build.gradle` of the app.
+To use CleverTap's RenderMax SDK with your app, add the following code snippet in the `build.gradle` of the app.
 
 ```groovy
     dependencies {
@@ -41,8 +41,8 @@ To use CleverTap's RenderMax Push Delivery with your app, add the following code
 [(Back to top)](#table-of-contents)
 
 RenderMax SDK is distributed as obfuscated package and for it's smooth working with proguard you must add necessary rules.
-The good News is that, Proguard rules for RenderMax is provided out of the box through `consumer-rules.pro` which gets merged with App's proguard rule so you don't have to do anything here.
-Thanks to `consumer-rules.pro`. You can check RenderMax proguard rules in your `/build/outputs/mapping/configuration.txt` by searching RenderMax keyword.
+The good news is that, Proguard rules for RenderMax SDK is provided out of the box through `consumer-rules.pro` which gets merged with App's Proguard rule so you don't have to do anything here.
+Thanks to `consumer-rules.pro`. You can check RenderMax Proguard rules in your `/build/outputs/mapping/configuration.txt` by searching RenderMax keyword.
 
 # Changelog
 

--- a/templates/CTRENDERMAXCHANGELOG.md
+++ b/templates/CTRENDERMAXCHANGELOG.md
@@ -1,0 +1,11 @@
+## CleverTap RenderMAX Push SDK CHANGE LOG
+
+### Version 1.0.2 (January 25, 2023)
+* Fix [runtime exception](https://github.com/CleverTap/clevertap-android-sdk/issues/379)
+
+### Version 1.0.1 (December 14, 2022)
+* Internal improvements.
+
+### Version 1.0.0 (November 30, 2022)
+* Initial release! 🎉
+* Supports CleverTap Android SDK `v4.6.6`

--- a/templates/CTRENDERMAXCHANGELOG.md
+++ b/templates/CTRENDERMAXCHANGELOG.md
@@ -1,4 +1,4 @@
-## CleverTap RenderMAX Push SDK CHANGE LOG
+## CleverTap RenderMax SDK CHANGE LOG
 
 ### Version 1.0.2 (January 25, 2023)
 * Fix [runtime exception](https://github.com/CleverTap/clevertap-android-sdk/issues/379)

--- a/templates/CTRENDERMAXCHANGELOG.md
+++ b/templates/CTRENDERMAXCHANGELOG.md
@@ -1,5 +1,9 @@
 ## CleverTap RenderMax SDK CHANGE LOG
 
+### Version 1.0.3 (March 6, 2023)
+* Fix ANR while receiving push through RenderMax
+* Fix crash - java.lang.IllegalStateException
+
 ### Version 1.0.2 (January 25, 2023)
 * Fix [runtime exception](https://github.com/CleverTap/clevertap-android-sdk/issues/379)
 

--- a/templates/README.md
+++ b/templates/README.md
@@ -190,11 +190,11 @@ CleverTap Huawei Push SDK provides an out of the box service to use the Huawei M
 CleverTap Push Templates SDK helps you engage with your users using fancy push notification templates built specifically to work with [CleverTap](https://www.clevertap.com).
 Find the integration steps for the CleverTap Push Templates SDK [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTPUSHTEMPLATES.md)
 
-## 📲 CleverTap RenderMax Push SDK
+## 📲 CleverTap RenderMax SDK
 [(Back to top)](#-table-of-contents)
 
-RenderMax Push SDK delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
-Find the integration steps for the CleverTap RenderMax Push SDK [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAX.md)
+RenderMax SDK delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
+Find the integration steps for the CleverTap RenderMax SDK [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAX.md)
 
 ## 📄 License
 [(Back to top)](#-table-of-contents)

--- a/templates/README.md
+++ b/templates/README.md
@@ -190,6 +190,12 @@ CleverTap Huawei Push SDK provides an out of the box service to use the Huawei M
 CleverTap Push Templates SDK helps you engage with your users using fancy push notification templates built specifically to work with [CleverTap](https://www.clevertap.com).
 Find the integration steps for the CleverTap Push Templates SDK [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTPUSHTEMPLATES.md)
 
+## 📲 CleverTap RenderMax Push SDK
+[(Back to top)](#-table-of-contents)
+
+RenderMax Push SDK delivers and renders notifications on the user's device even if the FCM delivery fails or the device is optimized for battery consumption.
+Find the integration steps for the CleverTap RenderMax Push SDK [here](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTRENDERMAX.md)
+
 ## 📄 License
 [(Back to top)](#-table-of-contents)
 CleverTap Android SDK is MIT licensed, as found in the [LICENSE](https://github.com/CleverTap/clevertap-android-sdk/blob/master/LICENSE) file.

--- a/versions.properties
+++ b/versions.properties
@@ -320,14 +320,12 @@ version.com.android.installreferrer..installreferrer=2.2
 ##                                       # available=2.2
 version.com.android.tools.lint..lint-api=27.0.1
 version.com.android.tools.lint..lint-checks=27.0.1
-
-version.com.clevertap.android..clevertap-android-sdk=4.6.6
+version.com.clevertap.android..clevertap-android-sdk=4.6.7
 version.com.clevertap.android..clevertap-geofence-sdk=1.1.0
 version.com.clevertap.android..clevertap-hms-sdk=1.3.1
 version.com.clevertap.android..clevertap-xiaomi-sdk=1.5.1
-version.com.clevertap.android..push-templates=1.0.5
-version.com.clevertap.android..clevertap-rendermax-sdk=1.0.2
-
+version.com.clevertap.android..push-templates=1.0.5.1
+version.com.clevertap.android..clevertap-rendermax-sdk=1.0.3
 version.com.github.bumptech.glide..glide=4.12.0
 ##                           # available=4.12.0
 version.com.google.android.exoplayer..exoplayer=2.17.1

--- a/versions.properties
+++ b/versions.properties
@@ -326,6 +326,7 @@ version.com.clevertap.android..clevertap-geofence-sdk=1.1.0
 version.com.clevertap.android..clevertap-hms-sdk=1.3.1
 version.com.clevertap.android..clevertap-xiaomi-sdk=1.5.1
 version.com.clevertap.android..push-templates=1.0.5
+version.com.clevertap.android..clevertap-rendermax-sdk=1.0.2
 
 version.com.github.bumptech.glide..glide=4.12.0
 ##                           # available=4.12.0


### PR DESCRIPTION
This release is being done for Android 12 targeted users, satisfying below points.
- Targeting Android 12 and
- Using RenderMax and/or using Push Templates