### PR TITLE
[SDK-2799] - 'Rating Submitted' event consistency for all Android OS versions

### DIFF
--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/PendingIntentFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/PendingIntentFactory.kt
@@ -13,6 +13,7 @@ import com.clevertap.android.pushtemplates.PTPushNotificationReceiver
 import com.clevertap.android.pushtemplates.PushTemplateReceiver
 import com.clevertap.android.pushtemplates.TemplateRenderer
 import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.Logger
 import com.clevertap.android.sdk.Utils
 import com.clevertap.android.sdk.pushnotification.CTNotificationIntentService
 import com.clevertap.android.sdk.pushnotification.LaunchPendingIntentFactory
@@ -184,12 +185,12 @@ internal object PendingIntentFactory {
             RATING_CLICK1_PENDING_INTENT -> {
                 launchIntent!!.putExtras(extras)
                 launchIntent!!.putExtra("click1", true)
-                launchIntent!!.putExtra("clickedStar", 1)
+                launchIntent!!.putExtra("clickedStar", 1)//TODO Change the key to public constants.
                 launchIntent!!.putExtra(PTConstants.PT_NOTIF_ID, notificationId)
                 launchIntent!!.putExtra("config", renderer?.config)
                 return PendingIntent.getBroadcast(
                     context,
-                    Random().nextInt(),
+                    RATING_CLICK1_PENDING_INTENT,
                     launchIntent!!,
                     flagsLaunchPendingIntent
                 )
@@ -203,7 +204,7 @@ internal object PendingIntentFactory {
                 launchIntent!!.putExtra("config", renderer?.config)
                 return PendingIntent.getBroadcast(
                     context,
-                    Random().nextInt(),
+                    RATING_CLICK2_PENDING_INTENT,
                     launchIntent!!,
                     flagsLaunchPendingIntent
                 )
@@ -217,7 +218,7 @@ internal object PendingIntentFactory {
                 launchIntent!!.putExtra("config", renderer?.config)
                 return PendingIntent.getBroadcast(
                     context,
-                    Random().nextInt(),
+                    RATING_CLICK3_PENDING_INTENT,
                     launchIntent!!,
                     flagsLaunchPendingIntent
                 )
@@ -231,7 +232,7 @@ internal object PendingIntentFactory {
                 launchIntent!!.putExtra("config", renderer?.config)
                 return PendingIntent.getBroadcast(
                     context,
-                    Random().nextInt(),
+                    RATING_CLICK4_PENDING_INTENT,
                     launchIntent!!,
                     flagsLaunchPendingIntent
                 )
@@ -245,7 +246,7 @@ internal object PendingIntentFactory {
                 launchIntent!!.putExtra("config", renderer?.config)
                 return PendingIntent.getBroadcast(
                     context,
-                    Random().nextInt(),
+                    RATING_CLICK5_PENDING_INTENT,
                     launchIntent!!,
                     flagsLaunchPendingIntent
                 )

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/PendingIntentFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/PendingIntentFactory.kt
@@ -8,6 +8,7 @@ import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.os.Bundle
 import com.clevertap.android.pushtemplates.PTConstants
+import com.clevertap.android.pushtemplates.PTConstants.KEY_CLICKED_STAR
 import com.clevertap.android.pushtemplates.PTLog
 import com.clevertap.android.pushtemplates.PTPushNotificationReceiver
 import com.clevertap.android.pushtemplates.PushTemplateReceiver
@@ -185,7 +186,7 @@ internal object PendingIntentFactory {
             RATING_CLICK1_PENDING_INTENT -> {
                 launchIntent!!.putExtras(extras)
                 launchIntent!!.putExtra("click1", true)
-                launchIntent!!.putExtra("clickedStar", 1)//TODO Change the key to public constants.
+                launchIntent!!.putExtra(KEY_CLICKED_STAR, 1)
                 launchIntent!!.putExtra(PTConstants.PT_NOTIF_ID, notificationId)
                 launchIntent!!.putExtra("config", renderer?.config)
                 return PendingIntent.getBroadcast(
@@ -199,7 +200,7 @@ internal object PendingIntentFactory {
             RATING_CLICK2_PENDING_INTENT -> {
                 launchIntent!!.putExtras(extras)
                 launchIntent!!.putExtra("click2", true)
-                launchIntent!!.putExtra("clickedStar", 2)
+                launchIntent!!.putExtra(KEY_CLICKED_STAR, 2)
                 launchIntent!!.putExtra(PTConstants.PT_NOTIF_ID, notificationId)
                 launchIntent!!.putExtra("config", renderer?.config)
                 return PendingIntent.getBroadcast(
@@ -213,7 +214,7 @@ internal object PendingIntentFactory {
             RATING_CLICK3_PENDING_INTENT -> {
                 launchIntent!!.putExtras(extras)
                 launchIntent!!.putExtra("click3", true)
-                launchIntent!!.putExtra("clickedStar", 3)
+                launchIntent!!.putExtra(KEY_CLICKED_STAR, 3)
                 launchIntent!!.putExtra(PTConstants.PT_NOTIF_ID, notificationId)
                 launchIntent!!.putExtra("config", renderer?.config)
                 return PendingIntent.getBroadcast(
@@ -227,7 +228,7 @@ internal object PendingIntentFactory {
             RATING_CLICK4_PENDING_INTENT -> {
                 launchIntent!!.putExtras(extras)
                 launchIntent!!.putExtra("click4", true)
-                launchIntent!!.putExtra("clickedStar", 4)
+                launchIntent!!.putExtra(KEY_CLICKED_STAR, 4)
                 launchIntent!!.putExtra(PTConstants.PT_NOTIF_ID, notificationId)
                 launchIntent!!.putExtra("config", renderer?.config)
                 return PendingIntent.getBroadcast(
@@ -241,7 +242,7 @@ internal object PendingIntentFactory {
             RATING_CLICK5_PENDING_INTENT -> {
                 launchIntent!!.putExtras(extras)
                 launchIntent!!.putExtra("click5", true)
-                launchIntent!!.putExtra("clickedStar", 5)
+                launchIntent!!.putExtra(KEY_CLICKED_STAR, 5)
                 launchIntent!!.putExtra(PTConstants.PT_NOTIF_ID, notificationId)
                 launchIntent!!.putExtra("config", renderer?.config)
                 return PendingIntent.getBroadcast(

--- a/clevertap-pushtemplates/src/main/res/layout/rating.xml
+++ b/clevertap-pushtemplates/src/main/res/layout/rating.xml
@@ -72,7 +72,7 @@
             android:layout_height="wrap_content"
             android:paddingTop="10dp"
             android:paddingBottom="10dp"
-            tools:text="Confirm"
+            android:text="Confirm"
             android:background="#FFFFFF"
             android:gravity="center"
             android:textAppearance="@style/PushTitle"


### PR DESCRIPTION
- Adds a fix where `Rating Submitted` event is raised once the confirmation button is clicked for Android 11+ devices. This behaviour will be consistent across all Android OS versions.
- Also fixed the confirmation button text visibility for Android 11+ devices. 