### PR TITLE
[SDK-2901] Fix PE flag for development mode.

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -3024,7 +3024,7 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      * @return boolean True if development mode, false otherwise.
      */
     boolean isDevelopmentMode() {
-        return CTVariables.isDevelopmentMode();
+        return CTVariables.isDevelopmentMode(context);
     }
 
     /**

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/CTVariables.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/CTVariables.java
@@ -1,5 +1,7 @@
 package com.clevertap.android.sdk.variables;
 
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -101,9 +103,8 @@ public class CTVariables {
         varCache.clearUserContent();
     }
 
-
-    public static boolean isDevelopmentMode() {
-        return BuildConfig.DEBUG;
+    public static boolean isDevelopmentMode(Context context) {
+        return 0 != (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE);
     }
 
     /**


### PR DESCRIPTION
When using the `BuildConfig.DEBUG` flag the development mode is not working, because when a release version of the SDK is built this flag gets replaced by `true` or `false` value. Using the flag directly from the context fixes it.