### PR TITLE
fix(SDK-3041): Adds a check to prevent in-app on excluded activity

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.java
@@ -642,6 +642,12 @@ public class InAppController implements CTInAppNotification.CTInAppNotificationL
             return;
         }
 
+        if(!inAppController.canShowInAppOnActivity()) {
+            pendingNotifications.add(inAppNotification);
+            Logger.v(config.getAccountId(), "Not showing In App on blacklisted activity, queuing this In App");
+            return;
+        }
+
         if ((System.currentTimeMillis() / 1000) > inAppNotification.getTimeToLive()) {
             Logger.d("InApp has elapsed its time to live, not showing the InApp");
             return;


### PR DESCRIPTION
https://wizrocket.atlassian.net/browse/SDK-3041
https://github.com/CleverTap/clevertap-android-sdk/issues/428
Adds an additional check just before displaying the in-app to prevent the in-app from showing on an excluded activity