### PR TITLE
[SDK-2728] Leanplum Interface

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/CTWrapper.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/CTWrapper.kt
@@ -1,7 +1,5 @@
 package com.clevertap.android.sdk.leanplum
 
-import android.app.Application
-import com.clevertap.android.sdk.ActivityLifecycleCallback
 import com.clevertap.android.sdk.Logger
 
 internal class CTWrapper(private val ctProvider: CleverTapProvider) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/CTWrapper.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/CTWrapper.kt
@@ -1,0 +1,164 @@
+package com.clevertap.android.sdk.leanplum
+
+import android.app.Application
+import com.clevertap.android.sdk.ActivityLifecycleCallback
+import com.clevertap.android.sdk.Logger
+
+internal class CTWrapper(private val ctProvider: CleverTapProvider) {
+
+  fun setUserId(userId: String?) {
+    if (userId.isNullOrEmpty()) return
+
+    val profile = mapOf(Constants.IDENTITY to userId)
+
+    Logger.d("CTWrapper", "setUserId will call onUserLogin with $profile")
+    ctProvider.getCleverTap()?.onUserLogin(profile)
+  }
+
+  /**
+   * LP doesn't allow iterables in params.
+   */
+  fun track(
+    event: String?,
+    value: Double,
+    info: String?,
+    params: Map<String, Any?>?
+  ) {
+    if (event == null) return
+
+    val properties =
+      params?.mapValues(::mapNotSupportedValues)?.toMutableMap()
+        ?: mutableMapOf()
+
+    properties[Constants.VALUE_PARAM] = value
+
+    if (info != null) {
+      properties[Constants.INFO_PARAM] = info
+    }
+
+    Logger.d("CTWrapper", "track(...) will call pushEvent with $event and $properties")
+    ctProvider.getCleverTap()?.pushEvent(event, properties)
+  }
+
+  /**
+   * LP doesn't allow iterables in params.
+   */
+  fun trackPurchase(
+    event: String,
+    value: Double,
+    currencyCode: String?,
+    params: Map<String, Any?>?
+  ) {
+    val filteredParams =
+      params?.mapValues(::mapNotSupportedValues)?.toMutableMap()
+        ?: mutableMapOf()
+
+    val details = HashMap<String, Any?>(filteredParams).apply {
+      this[Constants.CHARGED_EVENT_PARAM] = event
+      this[Constants.VALUE_PARAM] = value
+      if (currencyCode != null) {
+        this[Constants.CURRENCY_CODE_PARAM] = currencyCode
+      }
+    }
+
+    val items = arrayListOf<HashMap<String, Any?>>()
+
+    Logger.d("CTWrapper", "trackPurchase will call pushChargedEvent with $details and $items")
+    ctProvider.getCleverTap()?.pushChargedEvent(details, items)
+  }
+
+  /**
+   * LP doesn't allow iterables in params.
+   */
+  fun trackGooglePlayPurchase(
+    event: String,
+    item: String?,
+    value: Double,
+    currencyCode: String?,
+    purchaseData: String?,
+    dataSignature: String?,
+    params: Map<String, Any?>?
+  ) {
+    val filteredParams =
+      params?.mapValues(::mapNotSupportedValues)?.toMutableMap()
+        ?: mutableMapOf()
+
+    val details = HashMap<String, Any?>(filteredParams).apply {
+      this[Constants.CHARGED_EVENT_PARAM] = event
+      this[Constants.VALUE_PARAM] = value
+      this[Constants.CURRENCY_CODE_PARAM] = currencyCode
+      this[Constants.GP_PURCHASE_DATA_PARAM] = purchaseData
+      this[Constants.GP_PURCHASE_DATA_SIGNATURE_PARAM] = dataSignature
+      this[Constants.IAP_ITEM_PARAM] = item
+    }
+
+    val items = arrayListOf<HashMap<String, Any?>>()
+
+    Logger.d("CTWrapper", "trackGooglePlayPurchase will call pushChargedEvent with $details and $items")
+    ctProvider.getCleverTap()?.pushChargedEvent(details, items)
+  }
+
+  /**
+   * LP doesn't allow iterables in params.
+   */
+  fun advanceTo(state: String?, info: String?, params: Map<String, Any?>?) {
+    if (state == null) return;
+
+    val event = Constants.STATE_PREFIX + state
+    val properties =
+      params?.mapValues(::mapNotSupportedValues)?.toMutableMap()
+        ?: mutableMapOf()
+
+    if (info != null) {
+      properties[Constants.INFO_PARAM] = info
+    }
+
+    Logger.d("CTWrapper", "advance(...) will call pushEvent with $event and $properties")
+    ctProvider.getCleverTap()?.pushEvent(event, properties)
+  }
+
+  /**
+   * To remove an attribute CT.removeValueForKey is used.
+   */
+  fun setUserAttributes(attributes: Map<String, Any?>?) {
+    if (attributes.isNullOrEmpty()) {
+      return
+    }
+
+    val profile = attributes
+      .filterValues { value -> value != null }
+      .mapValues(::mapNotSupportedValues)
+
+    Logger.d("CTWrapper", "setUserAttributes will call pushProfile with $profile")
+    ctProvider.getCleverTap()?.pushProfile(profile)
+
+    attributes
+      .filterValues { value -> value == null}
+      .forEach {
+        Logger.d("CTWrapper", "setUserAttributes will call removeValueForKey with ${it.key}")
+        ctProvider.getCleverTap()?.removeValueForKey(it.key)
+      }
+  }
+
+  private fun mapNotSupportedValues(entry: Map.Entry<String, Any?>): Any? {
+    return when (val value = entry.value) {
+      is Iterable<*> ->
+        value
+          .filterNotNull()
+          .joinToString(separator = ",", prefix = "[", postfix = "]")
+      is Byte -> value.toInt()
+      is Short -> value.toInt()
+      else -> value
+    }
+  }
+
+  fun setTrafficSourceInfo(info: Map<String, String>) {
+    val source = info["publisherName"]
+    val medium = info["publisherSubPublisher"]
+    val campaign = info["publisherSubCampaign"]
+    Logger.d("CTWrapper", "setTrafficSourceInfo will call pushInstallReferrer with " +
+        "$source, $medium, and $campaign")
+    ctProvider.getCleverTap()?.pushInstallReferrer(source, medium, campaign)
+  }
+
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/CleverTapProvider.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/CleverTapProvider.kt
@@ -3,16 +3,14 @@ package com.clevertap.android.sdk.leanplum
 import android.content.Context
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.Logger
-import java.lang.ref.WeakReference
 
 internal class CleverTapProvider {
 
-  private var contextRef: WeakReference<Context>? = null
   private var customInstance: CleverTapAPI? = null
+  private var defaultInstance: CleverTapAPI? = null
 
   constructor(context: Context) {
-    this.contextRef = WeakReference(context)
-    CleverTapAPI.getDefaultInstance(context) // create default instance
+    this.defaultInstance = CleverTapAPI.getDefaultInstance(context)
   }
 
   constructor(customInstance: CleverTapAPI) {
@@ -22,11 +20,8 @@ internal class CleverTapProvider {
   fun getCleverTap(): CleverTapAPI? {
     if (customInstance != null) {
       return customInstance
-    } else {
-      val context = contextRef?.get()
-      if (context != null) {
-        return CleverTapAPI.getDefaultInstance(context)
-      }
+    } else if (defaultInstance != null) {
+      return defaultInstance
     }
     Logger.i("CTWrapper", "Please initialize LeanplumCT, because CleverTap instance is missing.")
     return null

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/CleverTapProvider.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/CleverTapProvider.kt
@@ -1,0 +1,35 @@
+package com.clevertap.android.sdk.leanplum
+
+import android.content.Context
+import com.clevertap.android.sdk.CleverTapAPI
+import com.clevertap.android.sdk.Logger
+import java.lang.ref.WeakReference
+
+internal class CleverTapProvider {
+
+  private var contextRef: WeakReference<Context>? = null
+  private var customInstance: CleverTapAPI? = null
+
+  constructor(context: Context) {
+    this.contextRef = WeakReference(context)
+    CleverTapAPI.getDefaultInstance(context) // create default instance
+  }
+
+  constructor(customInstance: CleverTapAPI) {
+    this.customInstance = customInstance
+  }
+
+  fun getCleverTap(): CleverTapAPI? {
+    if (customInstance != null) {
+      return customInstance
+    } else {
+      val context = contextRef?.get()
+      if (context != null) {
+        return CleverTapAPI.getDefaultInstance(context)
+      }
+    }
+    Logger.i("CTWrapper", "Please initialize LeanplumCT, because CleverTap instance is missing.")
+    return null
+  }
+
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/Constants.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/Constants.kt
@@ -1,0 +1,14 @@
+package com.clevertap.android.sdk.leanplum
+
+internal object Constants {
+  const val IDENTITY = "Identity"
+  const val STATE_PREFIX = "state_"
+
+  const val CHARGED_EVENT_PARAM = "event"
+  const val VALUE_PARAM = "value"
+  const val CURRENCY_CODE_PARAM = "currencyCode"
+  const val INFO_PARAM = "info"
+  const val GP_PURCHASE_DATA_PARAM = "googlePlayPurchaseData"
+  const val GP_PURCHASE_DATA_SIGNATURE_PARAM = "googlePlayPurchaseDataSignature"
+  const val IAP_ITEM_PARAM = "item"
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/LeanplumCT.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/LeanplumCT.kt
@@ -1,0 +1,218 @@
+package com.clevertap.android.sdk.leanplum
+
+import android.content.Context
+import com.clevertap.android.sdk.CleverTapAPI
+import com.clevertap.android.sdk.Logger
+
+/**
+ * For Java compatibility we must have all of the function parameters as nullable.
+ */
+object LeanplumCT {
+
+  private var wrapper: CTWrapper? = null
+    get() {
+      if (field == null) {
+        Logger.i("LeanplumCT", "Please initialize LeanplumCT before using it.")
+      }
+      return field
+    }
+
+  @JvmStatic
+  fun getPurchaseEventName() = "Purchase"
+
+  /**
+   * Initialization with Context would cause the CleverTap SDK to be initialized too.
+   */
+  @JvmStatic
+  fun initWithContext(context: Context?) {
+    if (context != null) {
+      val ctProvider = CleverTapProvider(context)
+      wrapper = CTWrapper(ctProvider)
+    }
+  }
+
+  @JvmStatic
+  fun initWithInstance(cleverTapInstance: CleverTapAPI?) {
+    if (cleverTapInstance != null) {
+      val ctProvider = CleverTapProvider(cleverTapInstance)
+      wrapper = CTWrapper(ctProvider)
+    }
+  }
+
+  @JvmStatic
+  fun addStartResponseHandler(callback: StartCallback?) {
+    // TODO
+  }
+
+  @JvmStatic
+  fun advanceTo(state: String?) {
+    advanceTo(state, null, null)
+  }
+
+  @JvmStatic
+  fun advanceTo(state: String?, info: String?) {
+    advanceTo(state, info, null)
+  }
+
+  @JvmStatic
+  fun advanceTo(state: String?, params: Map<String, Any?>?) {
+    advanceTo(state, null, params)
+  }
+
+  @JvmStatic
+  fun advanceTo(state: String?, info: String?, params: Map<String, Any?>?) {
+    wrapper?.advanceTo(state, info, params)
+  }
+
+  @JvmStatic
+  fun hasStarted(): Boolean {
+    // TODO return whether App Launched is tracked?
+    return false;
+  }
+
+  @JvmStatic
+  fun removeStartResponseHandler(callback: StartCallback?) {
+    // TODO ?
+  }
+
+  @JvmStatic
+  fun setLogLevel(logLevel: CleverTapAPI.LogLevel) {
+    CleverTapAPI.setDebugLevel(logLevel)
+  }
+
+  @JvmStatic
+  fun setTrafficSourceInfo(info: Map<String, String>?) {
+    if (info != null) {
+      wrapper?.setTrafficSourceInfo(info)
+    }
+  }
+
+  @JvmStatic
+  fun setUserAttributes(attributes: Map<String, Any?>?) {
+    wrapper?.setUserAttributes(attributes)
+  }
+
+  @JvmStatic
+  fun setUserAttributes(userId: String?, attributes: Map<String, Any?>?) {
+    if (userId != null) {
+      setUserId(userId)
+    }
+    setUserAttributes(attributes)
+  }
+
+  @JvmStatic
+  fun setUserId(userId: String?) {
+    wrapper?.setUserId(userId)
+  }
+
+  @JvmStatic
+  fun track(event: String?) {
+    track(event, .0, null, null)
+  }
+
+  @JvmStatic
+  fun track(event: String?, value: Double) {
+    track(event, value, null, null)
+  }
+
+  @JvmStatic
+  fun track(event: String?, info: String?) {
+    track(event, .0, info, null)
+  }
+
+  @JvmStatic
+  fun track(event: String?, params: Map<String, Any?>?) {
+    track(event, .0, null, params)
+  }
+
+  @JvmStatic
+  fun track(event: String?, value: Double, params: Map<String, Any?>?) {
+    track(event, value, null, params)
+  }
+
+  @JvmStatic
+  fun track(event: String?, value: Double, info: String?) {
+    track(event, value, info, null)
+  }
+
+  @JvmStatic
+  fun track(event: String?, value: Double, info: String?, params: Map<String, Any?>?) {
+    wrapper?.track(event, value, info, params)
+  }
+
+  @JvmStatic
+  fun trackGooglePlayPurchase(
+    item: String?,
+    priceMicros: Long,
+    currencyCode: String?,
+    purchaseData: String?,
+    dataSignature: String?
+  ) {
+    trackGooglePlayPurchase(
+      getPurchaseEventName(),
+      item,
+      priceMicros,
+      currencyCode,
+      purchaseData,
+      dataSignature,
+      null
+    )
+  }
+
+  @JvmStatic
+  fun trackGooglePlayPurchase(
+    item: String,
+    priceMicros: Long,
+    currencyCode: String,
+    purchaseData: String,
+    dataSignature: String,
+    params: Map<String, Any?>?
+  ) {
+    trackGooglePlayPurchase(
+      getPurchaseEventName(),
+      item,
+      priceMicros,
+      currencyCode,
+      purchaseData,
+      dataSignature,
+      params
+    )
+  }
+
+  @JvmStatic
+  fun trackGooglePlayPurchase(
+    eventName: String?,
+    item: String?,
+    priceMicros: Long,
+    currencyCode: String?,
+    purchaseData: String?,
+    dataSignature: String?,
+    params: Map<String, Any?>?
+  ) {
+    if (eventName.isNullOrEmpty()) {
+      Logger.i("LeanplumCT", "Failed to call trackGooglePlayPurchase, event name is null");
+      return
+    }
+
+    wrapper?.trackGooglePlayPurchase(
+      eventName,
+      item,
+      priceMicros / 1000000.0,
+      currencyCode,
+      purchaseData,
+      dataSignature,
+      params
+    )
+  }
+
+  @JvmStatic
+  fun trackPurchase(
+    event: String,
+    value: Double,
+    currencyCode: String?,
+    params: Map<String, Any?>?
+  ) {
+    wrapper?.trackPurchase(event, value, currencyCode, params)
+  }
+
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/LeanplumCT.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/LeanplumCT.kt
@@ -40,11 +40,6 @@ object LeanplumCT {
   }
 
   @JvmStatic
-  fun addStartResponseHandler(callback: StartCallback?) {
-    // TODO
-  }
-
-  @JvmStatic
   fun advanceTo(state: String?) {
     advanceTo(state, null, null)
   }
@@ -62,17 +57,6 @@ object LeanplumCT {
   @JvmStatic
   fun advanceTo(state: String?, info: String?, params: Map<String, Any?>?) {
     wrapper?.advanceTo(state, info, params)
-  }
-
-  @JvmStatic
-  fun hasStarted(): Boolean {
-    // TODO return whether App Launched is tracked?
-    return false;
-  }
-
-  @JvmStatic
-  fun removeStartResponseHandler(callback: StartCallback?) {
-    // TODO ?
   }
 
   @JvmStatic

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/StartCallback.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/StartCallback.kt
@@ -1,0 +1,6 @@
+package com.clevertap.android.sdk.leanplum
+
+// TODO Think about replacing this one with callback after App Launched is triggered
+interface StartCallback {
+  fun onResponse(success: Boolean)
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/StartCallback.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/leanplum/StartCallback.kt
@@ -1,6 +1,0 @@
-package com.clevertap.android.sdk.leanplum
-
-// TODO Think about replacing this one with callback after App Launched is triggered
-interface StartCallback {
-  fun onResponse(success: Boolean)
-}

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/leanplum/LeanplumCtTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/leanplum/LeanplumCtTest.kt
@@ -1,0 +1,226 @@
+package com.clevertap.android.sdk.leanplum
+
+import com.clevertap.android.shared.test.BaseTestCase
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LeanplumCtTest : BaseTestCase() {
+
+  @Before
+  fun setup() {
+    LeanplumCT.initWithInstance(cleverTapAPI)
+  }
+
+  @Test
+  fun testTrack() {
+    LeanplumCT.track(
+      event = "event",
+      value = 1.0,
+      info = "info",
+      params = mapOf("param" to "value")
+    )
+
+    Mockito.verify(cleverTapAPI).pushEvent(
+      "event",
+      mapOf("value" to 1.0, "info" to "info", "param" to "value")
+    )
+  }
+
+  @Test
+  fun testTrack_not_supported_values() {
+    LeanplumCT.track(
+      event = "event",
+      params = mapOf(
+        "param" to "value",
+        "byte_param" to 1.toByte(),
+        "short_param" to 2.toShort(),
+        "list" to listOf(1, 2, "three", null),
+      )
+    )
+
+    Mockito.verify(cleverTapAPI).pushEvent(
+      "event",
+      mapOf(
+        "value" to .0,
+        "param" to "value",
+        "byte_param" to 1,
+        "short_param" to 2,
+        "list" to "[1,2,three]",
+      )
+    )
+  }
+
+  @Test
+  fun testAdvanceTo() {
+    LeanplumCT.advanceTo(
+      state = "state",
+      info = "info",
+      params = mapOf("param" to "value"))
+
+    Mockito.verify(cleverTapAPI).pushEvent(
+      "state_state",
+      mapOf("info" to "info", "param" to "value")
+    )
+  }
+
+  @Test
+  fun testAdvanceTo_not_supported_values() {
+    LeanplumCT.advanceTo(
+      state = "state",
+      params = mapOf(
+        "param" to "value",
+        "list" to listOf(1, 2, 3),
+      )
+    )
+
+    Mockito.verify(cleverTapAPI).pushEvent(
+      "state_state",
+      mapOf(
+        "param" to "value",
+        "list" to "[1,2,3]",
+      )
+    )
+  }
+
+  @Test
+  fun testSetTrafficSourceInfo() {
+    LeanplumCT.setTrafficSourceInfo(mapOf(
+      "publisherName" to "source",
+      "publisherSubPublisher" to "medium",
+      "publisherSubCampaign" to "campaign",
+    ))
+
+    Mockito.verify(cleverTapAPI).pushInstallReferrer("source", "medium", "campaign")
+  }
+
+  @Test
+  fun testSetUserAttributes() {
+    LeanplumCT.setUserAttributes(mapOf(
+      "attr1" to "value1",
+      "attr2" to "value2"
+    ))
+
+    Mockito.verify(cleverTapAPI).pushProfile(mapOf(
+      "attr1" to "value1",
+      "attr2" to "value2"
+    ))
+  }
+
+  @Test
+  fun testSetUserAttributes_not_supported_values() {
+    LeanplumCT.setUserAttributes(mapOf(
+      "list" to listOf(1, 2, 3)
+    ))
+
+    Mockito.verify(cleverTapAPI).pushProfile(mapOf(
+      "list" to "[1,2,3]",
+    ))
+  }
+
+  @Test
+  fun testSetUserAttributes_remove_attribute() {
+    LeanplumCT.setUserAttributes(mapOf(
+      "attr" to "value",
+      "attr_to_remove" to null,
+    ))
+
+    Mockito.verify(cleverTapAPI).pushProfile(mapOf(
+      "attr" to "value",
+    ))
+    Mockito.verify(cleverTapAPI).removeValueForKey(
+      "attr_to_remove"
+    )
+  }
+
+  @Test
+  fun testSetUserAttributes_with_userId() {
+    LeanplumCT.setUserAttributes(
+      userId = "userId",
+      attributes = mapOf("attr" to "value"),
+    )
+
+    Mockito.verify(cleverTapAPI).onUserLogin(
+      mapOf("Identity" to "userId")
+    )
+    Mockito.verify(cleverTapAPI).pushProfile(
+      mapOf("attr" to "value")
+    )
+  }
+
+  @Test
+  fun testSetUserId() {
+    LeanplumCT.setUserId("userId")
+
+    Mockito.verify(cleverTapAPI).onUserLogin(
+      mapOf("Identity" to "userId")
+    )
+  }
+
+  @Test
+  fun testTrackGooglePlayPurchase() {
+    LeanplumCT.trackGooglePlayPurchase(
+      eventName = "event",
+      item = "item",
+      priceMicros = 1000000,
+      currencyCode = "currency",
+      purchaseData = "data",
+      dataSignature = "signature",
+      params = mapOf("param" to "value"),
+    )
+
+    Mockito.verify(cleverTapAPI).pushChargedEvent(hashMapOf(
+      "event" to "event",
+      "value" to 1.0,
+      "currencyCode" to "currency",
+      "googlePlayPurchaseData" to "data",
+      "googlePlayPurchaseDataSignature" to "signature",
+      "item" to "item",
+      "param" to "value",
+    ), arrayListOf())
+  }
+
+  @Test
+  fun testTrackGooglePlayPurchase_not_supported_values() {
+    LeanplumCT.trackGooglePlayPurchase(
+      item = "item",
+      priceMicros = 1000000,
+      currencyCode = "currency",
+      purchaseData = "data",
+      dataSignature = "signature",
+      params = mapOf("list" to listOf(1, 2, 3)),
+    )
+
+    Mockito.verify(cleverTapAPI).pushChargedEvent(hashMapOf(
+      "event" to "Purchase",
+      "value" to 1.0,
+      "currencyCode" to "currency",
+      "googlePlayPurchaseData" to "data",
+      "googlePlayPurchaseDataSignature" to "signature",
+      "item" to "item",
+      "list" to "[1,2,3]",
+    ), arrayListOf())
+  }
+
+  @Test
+  fun testTrackPurchase() {
+    LeanplumCT.trackPurchase(
+      event = "event",
+      value = 1.0,
+      currencyCode = "currency",
+      params = mapOf("param" to "value", "list" to "[1,2,3]"),
+    )
+
+    Mockito.verify(cleverTapAPI).pushChargedEvent(hashMapOf(
+      "event" to "event",
+      "value" to 1.0,
+      "currencyCode" to "currency",
+      "param" to "value",
+      "list" to "[1,2,3]",
+    ), arrayListOf())
+  }
+
+}


### PR DESCRIPTION
Main interface is `LeanplumCT`, which implements most of the methods of `Leanplum` class from Leanplum SDK.
It can be initialized using the following code:
```
ActivityLifecycleCallback.register(this);
LeanplumCT.initWithContext(this);
```
or by using `CleverTapAPI` instance:
```
ActivityLifecycleCallback.register(this);
LeanplumCT.initWithInstance(instance);
```

Some of the transformation code from CTWrapper in Leanplum repo has been reused.
Most use cases are handled by unit tests.
There are some notes in the [doc](https://docs.google.com/document/d/1639NoXp98ZXCyT1uuIhoVPXB_4dm2U95QylbswRdjNQ/edit).