### PR TITLE
[SDK-3064] Track events raised from webView interface

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTWebInterface.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTWebInterface.java
@@ -25,7 +25,7 @@ public class CTWebInterface {
         if (cleverTapAPI != null) {
             CoreState coreState = cleverTapAPI.getCoreState();
             if(coreState != null) {
-                coreState.getConfig().setWebInterfaceInitializedExternally(true);
+                coreState.getCoreMetaData().setWebInterfaceInitializedExternally(true);
             }
         }
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTWebInterface.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTWebInterface.java
@@ -21,6 +21,13 @@ public class CTWebInterface {
 
     public CTWebInterface(CleverTapAPI instance) {
         this.weakReference = new WeakReference<>(instance);
+        CleverTapAPI cleverTapAPI = weakReference.get();
+        if (cleverTapAPI != null) {
+            CoreState coreState = cleverTapAPI.getCoreState();
+            if(coreState != null) {
+                coreState.getConfig().setWebInterfaceInitializedExternally(true);
+            }
+        }
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -44,6 +51,7 @@ public class CTWebInterface {
             cleverTapAPI.promptForPushPermission(shouldShowFallbackSettings);
         }
     }
+
     /**
      * Method to be called from WebView Javascript to dismiss the InApp notification
      */
@@ -105,11 +113,6 @@ public class CTWebInterface {
             cleverTapAPI.decrementValue(key, value);
         }
     }
-
-
-
-
-
 
     /**
      * Method to be called from WebView Javascript to add profile properties in CleverTap
@@ -350,7 +353,6 @@ public class CTWebInterface {
             }
         }
     }
-
 
     /**
      * Method to be called from WebView Javascript to push profile/properties in CleverTap after

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapInstanceConfig.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapInstanceConfig.java
@@ -73,14 +73,6 @@ public class CleverTapInstanceConfig implements Parcelable {
 
     private boolean useGoogleAdId;
 
-    /**
-     * Flag indicating whether the {@link CTWebInterface} is initialized from outside of the SDK.
-     * <p>
-     * When this flag is true, it means that the {@link CTWebInterface} has been initialized externally, typically by the application.
-     * </p>
-     */
-    private boolean webInterfaceInitializedExternally;
-
     @SuppressWarnings("unused")
     public static CleverTapInstanceConfig createInstance(Context context, @NonNull String accountId,
             @NonNull String accountToken) {
@@ -118,7 +110,6 @@ public class CleverTapInstanceConfig implements Parcelable {
         this.createdPostAppLaunch = config.createdPostAppLaunch;
         this.sslPinning = config.sslPinning;
         this.backgroundSync = config.backgroundSync;
-        this.webInterfaceInitializedExternally = config.webInterfaceInitializedExternally;
         this.enableCustomCleverTapId = config.enableCustomCleverTapId;
         this.fcmSenderId = config.fcmSenderId;
         this.packageName = config.packageName;
@@ -237,7 +228,6 @@ public class CleverTapInstanceConfig implements Parcelable {
         createdPostAppLaunch = in.readByte() != 0x00;
         sslPinning = in.readByte() != 0x00;
         backgroundSync = in.readByte() != 0x00;
-        webInterfaceInitializedExternally = in.readByte() != 0x00;
         enableCustomCleverTapId = in.readByte() != 0x00;
         fcmSenderId = in.readString();
         packageName = in.readString();
@@ -370,7 +360,6 @@ public class CleverTapInstanceConfig implements Parcelable {
         dest.writeByte((byte) (createdPostAppLaunch ? 0x01 : 0x00));
         dest.writeByte((byte) (sslPinning ? 0x01 : 0x00));
         dest.writeByte((byte) (backgroundSync ? 0x01 : 0x00));
-        dest.writeByte((byte) (webInterfaceInitializedExternally ? 0x01 : 0x00));
         dest.writeByte((byte) (enableCustomCleverTapId ? 0x01 : 0x00));
         dest.writeString(fcmSenderId);
         dest.writeString(packageName);
@@ -421,14 +410,6 @@ public class CleverTapInstanceConfig implements Parcelable {
 
     boolean isUseGoogleAdId() {
         return useGoogleAdId;
-    }
-
-    public void setWebInterfaceInitializedExternally(boolean isInitialized) {
-        this.webInterfaceInitializedExternally = isInitialized;
-    }
-
-    public boolean isWebInterfaceInitializedExternally() {
-        return webInterfaceInitializedExternally;
     }
 
     void setCreatedPostAppLaunch() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapInstanceConfig.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapInstanceConfig.java
@@ -73,6 +73,14 @@ public class CleverTapInstanceConfig implements Parcelable {
 
     private boolean useGoogleAdId;
 
+    /**
+     * Flag indicating whether the {@link CTWebInterface} is initialized from outside of the SDK.
+     * <p>
+     * When this flag is true, it means that the {@link CTWebInterface} has been initialized externally, typically by the application.
+     * </p>
+     */
+    private boolean webInterfaceInitializedExternally;
+
     @SuppressWarnings("unused")
     public static CleverTapInstanceConfig createInstance(Context context, @NonNull String accountId,
             @NonNull String accountToken) {
@@ -110,6 +118,7 @@ public class CleverTapInstanceConfig implements Parcelable {
         this.createdPostAppLaunch = config.createdPostAppLaunch;
         this.sslPinning = config.sslPinning;
         this.backgroundSync = config.backgroundSync;
+        this.webInterfaceInitializedExternally = config.webInterfaceInitializedExternally;
         this.enableCustomCleverTapId = config.enableCustomCleverTapId;
         this.fcmSenderId = config.fcmSenderId;
         this.packageName = config.packageName;
@@ -228,6 +237,7 @@ public class CleverTapInstanceConfig implements Parcelable {
         createdPostAppLaunch = in.readByte() != 0x00;
         sslPinning = in.readByte() != 0x00;
         backgroundSync = in.readByte() != 0x00;
+        webInterfaceInitializedExternally = in.readByte() != 0x00;
         enableCustomCleverTapId = in.readByte() != 0x00;
         fcmSenderId = in.readString();
         packageName = in.readString();
@@ -360,6 +370,7 @@ public class CleverTapInstanceConfig implements Parcelable {
         dest.writeByte((byte) (createdPostAppLaunch ? 0x01 : 0x00));
         dest.writeByte((byte) (sslPinning ? 0x01 : 0x00));
         dest.writeByte((byte) (backgroundSync ? 0x01 : 0x00));
+        dest.writeByte((byte) (webInterfaceInitializedExternally ? 0x01 : 0x00));
         dest.writeByte((byte) (enableCustomCleverTapId ? 0x01 : 0x00));
         dest.writeString(fcmSenderId);
         dest.writeString(packageName);
@@ -410,6 +421,14 @@ public class CleverTapInstanceConfig implements Parcelable {
 
     boolean isUseGoogleAdId() {
         return useGoogleAdId;
+    }
+
+    public void setWebInterfaceInitializedExternally(boolean isInitialized) {
+        this.webInterfaceInitializedExternally = isInitialized;
+    }
+
+    public boolean isWebInterfaceInitializedExternally() {
+        return webInterfaceInitializedExternally;
     }
 
     void setCreatedPostAppLaunch() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CoreMetaData.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CoreMetaData.java
@@ -56,6 +56,14 @@ public class CoreMetaData extends CleverTapMetaData {
     private boolean offline;
 
     /**
+     * Flag indicating whether the {@link CTWebInterface} is initialized from outside of the SDK.
+     * <p>
+     * When this flag is true, it means that the {@link CTWebInterface} has been initialized externally, typically by the application.
+     * </p>
+     */
+    private boolean webInterfaceInitializedExternally;
+
+    /**
      * Last notification received on device from CleverTap in an active session of a process(before process is killed)
      */
     private String lastNotificationId;
@@ -339,6 +347,14 @@ public class CoreMetaData extends CleverTapMetaData {
 
     public boolean isOffline() {
         return offline;
+    }
+
+    public void setWebInterfaceInitializedExternally(boolean isInitialized) {
+        this.webInterfaceInitializedExternally = isInitialized;
+    }
+
+    public boolean isWebInterfaceInitializedExternally() {
+        return webInterfaceInitializedExternally;
     }
 
     public static void setActivityCount(final int count) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.java
@@ -413,6 +413,9 @@ public class NetworkManager extends BaseNetworkManager {
             header.put("type", "meta");
 
             JSONObject appFields = deviceInfo.getAppLaunchedFields();
+            if(config.isWebInterfaceInitializedExternally()) {
+                appFields.put("wv_init", true);
+            }
             header.put("af", appFields);
 
             HashMap<String, Integer> allCustomSdkVersions = coreMetaData.getAllCustomSdkVersions();

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.java
@@ -413,7 +413,7 @@ public class NetworkManager extends BaseNetworkManager {
             header.put("type", "meta");
 
             JSONObject appFields = deviceInfo.getAppLaunchedFields();
-            if(config.isWebInterfaceInitializedExternally()) {
+            if(coreMetaData.isWebInterfaceInitializedExternally()) {
                 appFields.put("wv_init", true);
             }
             header.put("af", appFields);


### PR DESCRIPTION
- Passes a flag in the appFields to capture the external initialization/usage of webViewInterface done from application.