### PR TITLE
task(SDK-3215) - Updates Logger implementation to static for PT module

### DIFF
--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PTConstants.java
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PTConstants.java
@@ -4,7 +4,7 @@ package com.clevertap.android.pushtemplates;
 //Using common keys from core-sdk constants
 public class PTConstants {
 
-    public static final String LOG_TAG = "PTLog";
+    public static final String LOG_TAG = "PT";
 
     public static final String PT_MANUAL_CAROUSEL_CURRENT = "pt_manual_carousel_current";
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PTLog.java
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PTLog.java
@@ -2,6 +2,17 @@ package com.clevertap.android.pushtemplates;
 
 import android.util.Log;
 
+import com.clevertap.android.sdk.Constants;
+import com.clevertap.android.sdk.Logger;
+
+/**
+ * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
+ * This class has been deprecated since v1.x to make logging static across the SDK
+ * and will be removed in the future versions of the SDK.
+ * Use Logger class of the core-sdk instead"
+ * </p>
+ */
+@Deprecated
 public final class PTLog {
 
     private final int debugLevel;
@@ -21,37 +32,49 @@ public final class PTLog {
 
     public static void debug(String message) {
         if (getStaticDebugLevel() >= TemplateRenderer.LogLevel.DEBUG.intValue()) {
-            Log.d(PTConstants.LOG_TAG, message);
+            Log.d(Constants.CLEVERTAP_LOG_TAG + ":" + PTConstants.LOG_TAG, message);
+        } else if (getStaticDebugLevel() == -2) {
+            Logger.debug(PTConstants.LOG_TAG, message);
         }
     }
 
     static void info(String message) {
         if (getStaticDebugLevel() >= TemplateRenderer.LogLevel.INFO.intValue()) {
-            Log.i(PTConstants.LOG_TAG, message);
+            Log.i(Constants.CLEVERTAP_LOG_TAG + ":" + PTConstants.LOG_TAG, message);
+        } else if (getStaticDebugLevel() == -2) {
+            Logger.info(PTConstants.LOG_TAG, message);
         }
     }
 
     public static void verbose(String message) {
         if (getStaticDebugLevel() >= TemplateRenderer.LogLevel.VERBOSE.intValue()) {
-            Log.v(PTConstants.LOG_TAG, message);
+            Log.v(Constants.CLEVERTAP_LOG_TAG + ":" + PTConstants.LOG_TAG, message);
+        } else if (getStaticDebugLevel() == -2) {
+            Logger.verbose(PTConstants.LOG_TAG, message);
         }
     }
 
     static void debug(String message, Throwable t) {
-        if (getStaticDebugLevel() >= TemplateRenderer.LogLevel.INFO.intValue()) {
-            Log.d(PTConstants.LOG_TAG, message, t);
+        if (getStaticDebugLevel() >= TemplateRenderer.LogLevel.DEBUG.intValue()) {
+            Log.d(Constants.CLEVERTAP_LOG_TAG + ":" + PTConstants.LOG_TAG, message, t);
+        } else if (getStaticDebugLevel() == -2) {
+            Logger.debug(PTConstants.LOG_TAG, message, t);
         }
     }
 
     static void info(String message, Throwable t) {
         if (getStaticDebugLevel() >= TemplateRenderer.LogLevel.INFO.intValue()) {
-            Log.i(PTConstants.LOG_TAG, message, t);
+            Log.i(Constants.CLEVERTAP_LOG_TAG + ":" + PTConstants.LOG_TAG, message, t);
+        } else if (getStaticDebugLevel() == -2) {
+            Logger.info(PTConstants.LOG_TAG, message, t);
         }
     }
 
     public static void verbose(String message, Throwable t) {
         if (getStaticDebugLevel() >= TemplateRenderer.LogLevel.VERBOSE.intValue()) {
-            Log.v(PTConstants.LOG_TAG, message, t);
+            Log.v(Constants.CLEVERTAP_LOG_TAG + ":" + PTConstants.LOG_TAG, message, t);
+        } else if (getStaticDebugLevel() == -2) {
+            Logger.verbose(PTConstants.LOG_TAG, message, t);
         }
     }
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PushTemplateReceiver.java
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PushTemplateReceiver.java
@@ -38,7 +38,6 @@ import com.clevertap.android.pushtemplates.content.PendingIntentFactory;
 import com.clevertap.android.sdk.CleverTapAPI;
 import com.clevertap.android.sdk.CleverTapInstanceConfig;
 import com.clevertap.android.sdk.Constants;
-import com.clevertap.android.sdk.Logger;
 import com.clevertap.android.sdk.interfaces.NotificationHandler;
 import com.clevertap.android.sdk.pushnotification.CTNotificationIntentService;
 import com.clevertap.android.sdk.pushnotification.LaunchPendingIntentFactory;

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
@@ -21,7 +21,6 @@ import com.clevertap.android.pushtemplates.validators.ValidatorFactory
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.CleverTapInstanceConfig
 import com.clevertap.android.sdk.Constants
-import com.clevertap.android.sdk.Logger
 import com.clevertap.android.sdk.ManifestInfo
 import com.clevertap.android.sdk.interfaces.AudibleNotification
 import com.clevertap.android.sdk.pushnotification.CTNotificationIntentService
@@ -252,7 +251,7 @@ class TemplateRenderer : INotificationRenderer, AudibleNotification {
                         try {
                             ptJsonObj = JSONObject(ptJsonStr)
                         } catch (e: Exception) {
-                            Logger.v("Unable to convert JSON to String")
+                            PTLog.verbose("Unable to convert JSON to String")
                         }
                     }
 
@@ -349,7 +348,7 @@ class TemplateRenderer : INotificationRenderer, AudibleNotification {
                 }
             }
         } catch (t: Throwable) {
-            config.logger.debug(config.accountId, "Could not process sound parameter", t)
+            PTLog.debug(config.accountId + " Could not process sound parameter", t)
         }
         return nb
     }
@@ -463,14 +462,14 @@ class TemplateRenderer : INotificationRenderer, AudibleNotification {
                 try {
                     clazz = Class.forName("com.clevertap.android.sdk.pushnotification.CTNotificationIntentService")
                 } catch (ex: ClassNotFoundException) {
-                    Logger.d("No Intent Service found")
+                    PTLog.debug("No Intent Service found")
                 }
             }
         } else {
             try {
                 clazz = Class.forName("com.clevertap.android.sdk.pushnotification.CTNotificationIntentService")
             } catch (ex: ClassNotFoundException) {
-                Logger.d("No Intent Service found")
+                PTLog.debug("No Intent Service found")
             }
         }
         val isCTIntentServiceAvailable = com.clevertap.android.sdk.Utils.isServiceAvailable(context, clazz)
@@ -484,7 +483,7 @@ class TemplateRenderer : INotificationRenderer, AudibleNotification {
                     val id = action.optString("id")
                     val autoCancel = action.optBoolean("ac", true)
                     if (label.isEmpty() || id.isEmpty()) {
-                        Logger.d("not adding push notification action: action label or id missing")
+                        PTLog.debug("not adding push notification action: action label or id missing")
                         continue
                     }
                     var icon = 0
@@ -492,7 +491,7 @@ class TemplateRenderer : INotificationRenderer, AudibleNotification {
                         try {
                             icon = context.resources.getIdentifier(ico, "drawable", context.packageName)
                         } catch (t: Throwable) {
-                            Logger.d("unable to add notification action icon: " + t.localizedMessage)
+                            PTLog.debug("unable to add notification action icon: " + t.localizedMessage)
                         }
                     }
                     var sendToCTIntentService = (VERSION.SDK_INT < VERSION_CODES.S && autoCancel
@@ -570,7 +569,7 @@ class TemplateRenderer : INotificationRenderer, AudibleNotification {
                     }
                     nb.addAction(icon, label, actionIntent)
                 } catch (t: Throwable) {
-                    Logger.d("error adding notification action : " + t.localizedMessage)
+                    PTLog.debug("error adding notification action : " + t.localizedMessage)
                 }
             }
         } // Uncommon - END

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
@@ -348,7 +348,7 @@ class TemplateRenderer : INotificationRenderer, AudibleNotification {
                 }
             }
         } catch (t: Throwable) {
-            PTLog.debug(config.accountId + " Could not process sound parameter", t)
+            PTLog.debug("Could not process sound parameter for ${config.accountId}", t)
         }
         return nb
     }
@@ -578,18 +578,20 @@ class TemplateRenderer : INotificationRenderer, AudibleNotification {
 
     companion object {
         /**
-         * Returns the log level set for PushTemplates
-         *
-         * @return The int value
-         */
-        /**
          * Enables or disables debugging. If enabled, see debug messages in Android's logcat utility.
-         * Debug messages are tagged as PTLog.
+         * Debug messages are tagged as CleverTap:PT.
          *
          * @param level Can be one of the following:  -1 (disables all debugging), 0 (default, shows minimal SDK integration related logging),
          * 2(shows debug output)
          */
+        @Deprecated
+            (
+            message = "This method has been deprecated since v1.x to make logging static across the SDK and will be removed in the future versions of the SDK. " +
+                    "In the future all clevertap modules will have one global debugLevel. " +
+                    "Use CleverTapAPI.setDebugLevel() to set the same",
+            level = DeprecationLevel.WARNING
+        )
         @JvmStatic
-        var debugLevel = LogLevel.INFO.intValue()
+        var debugLevel = -2
     }
 }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/Utils.java
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/Utils.java
@@ -34,7 +34,6 @@ import androidx.core.content.ContextCompat;
 import com.clevertap.android.sdk.CleverTapAPI;
 import com.clevertap.android.sdk.CleverTapInstanceConfig;
 import com.clevertap.android.sdk.Constants;
-import com.clevertap.android.sdk.Logger;
 import com.clevertap.android.sdk.network.NetworkManager;
 import com.clevertap.android.sdk.task.CTExecutorFactory;
 import com.clevertap.android.sdk.task.Task;
@@ -107,7 +106,7 @@ public class Utils {
         if (context != null) {
             boolean isNetworkOnline = NetworkManager.isNetworkOnline(context);
             if (!isNetworkOnline) {
-                Logger.v("Network connectivity unavailable. Not downloading bitmap. URL was: " + srcUrl);
+                PTLog.verbose("Network connectivity unavailable. Not downloading bitmap. URL was: " + srcUrl);
                 return null;
             }
         }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/PendingIntentFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/PendingIntentFactory.kt
@@ -14,7 +14,6 @@ import com.clevertap.android.pushtemplates.PTPushNotificationReceiver
 import com.clevertap.android.pushtemplates.PushTemplateReceiver
 import com.clevertap.android.pushtemplates.TemplateRenderer
 import com.clevertap.android.sdk.Constants
-import com.clevertap.android.sdk.Logger
 import com.clevertap.android.sdk.Utils
 import com.clevertap.android.sdk.pushnotification.CTNotificationIntentService
 import com.clevertap.android.sdk.pushnotification.LaunchPendingIntentFactory


### PR DESCRIPTION
Updates Logger implementation to static for PT module
The deprecation is such that the PT loglevel is still respected if set. If it is not set, logs are displayed according to the ClevertapAPI.debugLevel
In the next version, plan is to remove PT logging completely