### PR TITLE
task(SDK-3215) - Makes Logging static for Geofence module

### DIFF
--- a/clevertap-geofence/src/main/java/com/clevertap/android/geofence/CTGeofenceAPI.java
+++ b/clevertap-geofence/src/main/java/com/clevertap/android/geofence/CTGeofenceAPI.java
@@ -85,6 +85,14 @@ public class CTGeofenceAPI implements GeofenceCallback {
         return ctGeofenceAPI;
     }
 
+    /**
+     * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
+     * Note: This method has been deprecated since v1.3.0 to make logging static across the SDK.
+     * It will be removed in the future versions of this SDK.
+     * Use Logger class of the core-sdk instead"
+     * </p>
+     */
+    @Deprecated
     public static Logger getLogger() {
         return logger;
     }
@@ -536,6 +544,6 @@ public class CTGeofenceAPI implements GeofenceCallback {
     }
 
     static {
-        logger = new Logger(Logger.DEBUG);
+        logger = new Logger(Logger.UNSET);
     }
 }

--- a/clevertap-geofence/src/main/java/com/clevertap/android/geofence/CTGeofenceSettings.java
+++ b/clevertap-geofence/src/main/java/com/clevertap/android/geofence/CTGeofenceSettings.java
@@ -1,7 +1,6 @@
 package com.clevertap.android.geofence;
 
-import static com.clevertap.android.geofence.Logger.DEBUG;
-
+import static com.clevertap.android.geofence.Logger.UNSET;
 import com.clevertap.android.geofence.Logger.LogLevel;
 import com.clevertap.android.sdk.CleverTapAPI;
 
@@ -34,8 +33,9 @@ public class CTGeofenceSettings {
 
         private byte locationFetchMode = FETCH_LAST_LOCATION_PERIODIC;
 
+        @Deprecated
         private @LogLevel
-        int logLevel = DEBUG;
+        int logLevel = UNSET;
 
         private float smallestDisplacement = GoogleLocationAdapter.SMALLEST_DISPLACEMENT_IN_METERS;
 
@@ -180,11 +180,16 @@ public class CTGeofenceSettings {
 
         /**
          * Set log level
-         *
+         * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
+         * Note: This method has been deprecated since v1.3.0 to make logging static across the SDK.
+         * It will be removed in the future versions of this SDK.
+         * In the future all clevertap modules will have one global debugLevel. Use ClevertapAPI.setDebugLevel() to set the same"
+         * </p>
          * @param logLevel can be one of {@link Logger#DEBUG}, {@link Logger#INFO}, {@link Logger#VERBOSE} or
-         *                 {@link Logger#OFF}. Default value is {@link Logger#DEBUG}
+         *                 {@link Logger#OFF}. Default value is {@link Logger#UNSET}
          * @return {@link CTGeofenceSettings.Builder}
          */
+        @Deprecated
         public CTGeofenceSettings.Builder setLogLevel(@LogLevel int logLevel) {
             this.logLevel = logLevel;
             return this;
@@ -348,6 +353,7 @@ public class CTGeofenceSettings {
         return locationFetchMode;
     }
 
+    @Deprecated
     public @LogLevel
     int getLogLevel() {
         return logLevel;

--- a/clevertap-geofence/src/main/java/com/clevertap/android/geofence/Logger.java
+++ b/clevertap-geofence/src/main/java/com/clevertap/android/geofence/Logger.java
@@ -2,16 +2,27 @@ package com.clevertap.android.geofence;
 
 import android.util.Log;
 import androidx.annotation.IntDef;
+import com.clevertap.android.sdk.Constants;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
+/**
+ * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
+ * Note: This class has been deprecated since v1.3.0 to make logging static across the SDK.
+ * It will be removed in the future versions of this SDK.
+ * Use Logger class of the core-sdk instead"
+ * </p>
+ */
+@Deprecated
 public final class Logger {
 
-    @IntDef({OFF, INFO, DEBUG, VERBOSE})
+    @IntDef({UNSET, OFF, INFO, DEBUG, VERBOSE})
     @Retention(RetentionPolicy.SOURCE)
     public @interface LogLevel {
 
     }
+
+    public static final int UNSET = -2;
 
     public static final int OFF = -1;
 
@@ -20,6 +31,8 @@ public final class Logger {
     public static final int DEBUG = 2;
 
     public static final int VERBOSE = 3;
+
+    public static final String COMBINED_LOG_TAG = Constants.CLEVERTAP_LOG_TAG + ":" + CTGeofenceAPI.GEOFENCE_LOG_TAG;
 
     private @LogLevel
     int debugLevel;
@@ -34,30 +47,38 @@ public final class Logger {
 
     public void debug(String message) {
         if (debugLevel > INFO) {
-            Log.d(CTGeofenceAPI.GEOFENCE_LOG_TAG, message);
+            Log.d(COMBINED_LOG_TAG, message);
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.debug(CTGeofenceAPI.GEOFENCE_LOG_TAG, message);
         }
     }
 
     public void debug(String suffix, String message) {
         if (debugLevel > INFO) {
             if (message.length() > 4000) {
-                Log.d(CTGeofenceAPI.GEOFENCE_LOG_TAG + ":" + suffix, message.substring(0, 4000));
+                Log.d(Constants.CLEVERTAP_LOG_TAG  + ":" + suffix, message.substring(0, 4000));
                 debug(suffix, message.substring(4000));
             } else {
-                Log.d(CTGeofenceAPI.GEOFENCE_LOG_TAG + ":" + suffix, message);
+                Log.d(Constants.CLEVERTAP_LOG_TAG  + ":" + suffix, message);
             }
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.debug(suffix, message);
         }
     }
 
     public void debug(String suffix, String message, Throwable t) {
         if (debugLevel > INFO) {
-            Log.d(CTGeofenceAPI.GEOFENCE_LOG_TAG + ":" + suffix, message, t);
+            Log.d(Constants.CLEVERTAP_LOG_TAG  + ":" + suffix, message, t);
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.debug(suffix, message, t);
         }
     }
 
     public void debug(String message, Throwable t) {
         if (debugLevel > INFO) {
-            Log.d(CTGeofenceAPI.GEOFENCE_LOG_TAG, message, t);
+            Log.d(COMBINED_LOG_TAG, message, t);
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.debug(CTGeofenceAPI.GEOFENCE_LOG_TAG, message, t);
         }
     }
 
@@ -67,25 +88,33 @@ public final class Logger {
 
     public void info(String message) {
         if (debugLevel >= INFO) {
-            Log.i(CTGeofenceAPI.GEOFENCE_LOG_TAG, message);
+            Log.i(COMBINED_LOG_TAG, message);
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.info(CTGeofenceAPI.GEOFENCE_LOG_TAG, message);
         }
     }
 
     public void info(String suffix, String message) {
         if (debugLevel >= INFO) {
-            Log.i(CTGeofenceAPI.GEOFENCE_LOG_TAG + ":" + suffix, message);
+            Log.i(Constants.CLEVERTAP_LOG_TAG  + ":" + suffix, message);
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.info(suffix, message);
         }
     }
 
     public void info(String suffix, String message, Throwable t) {
         if (debugLevel >= INFO) {
-            Log.i(CTGeofenceAPI.GEOFENCE_LOG_TAG + ":" + suffix, message, t);
+            Log.i(Constants.CLEVERTAP_LOG_TAG  + ":" + suffix, message, t);
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.info(suffix, message, t);
         }
     }
 
     public void info(String message, Throwable t) {
         if (debugLevel >= INFO) {
-            Log.i(CTGeofenceAPI.GEOFENCE_LOG_TAG, message, t);
+            Log.i(COMBINED_LOG_TAG, message, t);
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.info(CTGeofenceAPI.GEOFENCE_LOG_TAG, message, t);
         }
     }
 
@@ -100,7 +129,9 @@ public final class Logger {
 
     public void verbose(String message) {
         if (debugLevel > DEBUG) {
-            Log.v(CTGeofenceAPI.GEOFENCE_LOG_TAG, message);
+            Log.v(COMBINED_LOG_TAG, message);
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.verbose(CTGeofenceAPI.GEOFENCE_LOG_TAG, message);
         }
     }
 
@@ -108,24 +139,30 @@ public final class Logger {
     public void verbose(String suffix, String message) {
         if (debugLevel > DEBUG) {
             if (message.length() > 4000) {
-                Log.v(CTGeofenceAPI.GEOFENCE_LOG_TAG + ":" + suffix, message.substring(0, 4000));
+                Log.v(Constants.CLEVERTAP_LOG_TAG  + ":" + suffix, message.substring(0, 4000));
                 verbose(suffix, message.substring(4000));
             } else {
-                Log.v(CTGeofenceAPI.GEOFENCE_LOG_TAG + ":" + suffix, message);
+                Log.v(Constants.CLEVERTAP_LOG_TAG  + ":" + suffix, message);
             }
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.verbose(suffix, message);
         }
     }
 
     @SuppressWarnings("WeakerAccess")
     public void verbose(String suffix, String message, Throwable t) {
         if (debugLevel > DEBUG) {
-            Log.v(CTGeofenceAPI.GEOFENCE_LOG_TAG + ":" + suffix, message, t);
+            Log.v(Constants.CLEVERTAP_LOG_TAG  + ":" + suffix, message, t);
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.verbose(suffix, message, t);
         }
     }
 
     public void verbose(String message, Throwable t) {
         if (debugLevel > DEBUG) {
-            Log.v(CTGeofenceAPI.GEOFENCE_LOG_TAG, message, t);
+            Log.v(COMBINED_LOG_TAG, message, t);
+        } else if(debugLevel == UNSET) {
+            com.clevertap.android.sdk.Logger.verbose(CTGeofenceAPI.GEOFENCE_LOG_TAG, message, t);
         }
     }
 


### PR DESCRIPTION
Updates Logger implementation to static for Geofence modules and deprecates the Geofence Logger class. 
The deprecation is such that the Geofence loglevel is still respected if set. If it is not set, logs are displayed according to the ClevertapAPI.debugLevel
In the next version, plan is to remove Geofence logging completely
