### PR TITLE
[SDK-3328] Fix classCastException from while reading PE variable

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -3264,10 +3264,6 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      * @return Returns the Var instance.
      */
     public <T> Var<T> defineVariable(String name, T defaultValue) {
-        if (defaultValue == null) {
-            Logger.d("Invalid Operation! Null values are not allowed as default values when defining the variable '" + name + "'.");
-            return null;
-        }
         return Var.define(name, defaultValue,coreState.getCTVariables());
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -3264,6 +3264,10 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      * @return Returns the Var instance.
      */
     public <T> Var<T> defineVariable(String name, T defaultValue) {
+        if (defaultValue == null) {
+            Logger.d("Invalid Operation! Null values are not allowed as default values when defining the variable '" + name + "'.");
+            return null;
+        }
         return Var.define(name, defaultValue,coreState.getCTVariables());
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Parser.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Parser.java
@@ -159,7 +159,7 @@ public class Parser {
     // we first call var.define(..) with field name, value and kind
     final Var<T> var = Var.define(name, value, kind, ctVariables);
     if (var == null) {
-      log("Something went wrong, var is null, returning");
+      log("Something went wrong, variable '" + name + "' is null, returning");
       return;
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
@@ -70,6 +70,11 @@ public class Var<T> {
             log("Variable name starts or ends with a `.` which is not allowed: " + name);
             return null;
         }
+        if (defaultValue == null) {
+            Logger.d("Invalid Operation! Null values are not allowed as default values when defining the variable '"
+                    + name + "'.");
+            return null;
+        }
 
         Var<T> existing = ctVariables.getVarCache().getVariable(name);
         if (existing != null) {

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/variables/VarCacheTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/variables/VarCacheTest.kt
@@ -49,7 +49,7 @@ class VarCacheTest : BaseTestCase() {
 
     parser.parseVariables(NullDefaultValue())
 
-    assertNull(varCache.getVariable<Int>("string_with_null").value())
+    assertNull(varCache.getVariable<Int>("string_with_null"))
   }
 
   @Test
@@ -58,7 +58,7 @@ class VarCacheTest : BaseTestCase() {
 
     Var.define<String>("var_string", null, ctVariables)
 
-    assertNull(varCache.getVariable<Int>("var_string").value())
+    assertNull(varCache.getVariable<Int>("var_string"))
   }
 
   @Test


### PR DESCRIPTION
**Issue Summary:**
When a PE variable of `Long` type is defined with a null default value, and the dashboard overrides it with a Double value, The SDK throws a ClassCastException (Double cannot be cast to Long).

**Fix:**
Restricted the null usage as default value for PE variables.
