### PR TITLE
docs(SDK-3382) - Updates docs for five icons image resolution limit

### DIFF
--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -534,6 +534,7 @@ Product Catalog | 1:1 | .JPG
 
 * For Auto and Manual Carousel the image dimensions should not exceed more than 840x560 for Android 11 and Android 12 devices and with 3:2 image aspect ratio
 * For images in Basic, Auto/Manual Carousel templates the image dimensions should not exceed more than 400x200 for only Android 13+ devices.
+* For images in Five Icons template the image dimensions should not exceed more than 300x300 for only Android 13+ devices.
 * For Product Catalog image aspect ratio should be 1:1 and image size should be less than 80kb for Android 11 and Android 12 devices
 * For Zero Bezel it's recommended that if your image has any text it should be present in the middle of the image for Android 12+ devices. 
 * For Android 12+ devices it's recommended that if your image has any text it should be present in the middle of the image.

--- a/templates/CTPUSHTEMPLATES.md
+++ b/templates/CTPUSHTEMPLATES.md
@@ -534,6 +534,7 @@ Product Catalog | 1:1 | .JPG
 
 * For Auto and Manual Carousel the image dimensions should not exceed more than 840x560 for Android 11 and Android 12 devices and with 3:2 image aspect ratio
 * For images in Basic, Auto/Manual Carousel templates the image dimensions should not exceed more than 400x200 for only Android 13+ devices.
+* For images in Five Icons template the image dimensions should not exceed more than 300x300 for only Android 13+ devices.
 * For Product Catalog image aspect ratio should be 1:1 and image size should be less than 80kb for Android 11 and Android 12 devices
 * For Zero Bezel it's recommended that if your image has any text it should be present in the middle of the image for Android 12+ devices. 
 * For Android 12+ devices it's recommended that if your image has any text it should be present in the middle of the image.


### PR DESCRIPTION
Updates docs for image resolution limit for five icons pt. The exact limit was found out to be 353x353 but updating docs with a limit of 300x300