### PR TITLE
task(SDK-3422) - Handles NPE for inbox messages

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/db/DBAdapter.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/db/DBAdapter.java
@@ -515,10 +515,10 @@ public class DBAdapter {
             return messageDAOArrayList;
         } catch (final SQLiteException e) {
             getConfigLogger().verbose("Error retrieving records from " + tName, e);
-            return null;
+            return messageDAOArrayList;
         } catch (JSONException e) {
             getConfigLogger().verbose("Error retrieving records from " + tName, e.getMessage());
-            return null;
+            return messageDAOArrayList;
         } finally {
             dbHelper.close();
         }


### PR DESCRIPTION
Handles NPE for inbox messages. If an exception was caught earlier when retrieving the messages from DB, a null was returned. Now instead, an empty list is returned