### PR TITLE
Task/sdk 3514/fallback channel resource name conflict

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
@@ -94,7 +94,7 @@ fun NotificationManager.getOrCreateChannel(
         if (getNotificationChannel(Constants.FCM_FALLBACK_NOTIFICATION_CHANNEL_ID) == null) {
 
             val defaultChannelName = try {
-                  context.getString(R.string.fcm_fallback_notification_channel_label)
+                  context.getString(R.string.ct_fcm_fallback_notification_channel_label)
             } catch (e: Exception) {
                 Constants.FCM_FALLBACK_NOTIFICATION_CHANNEL_NAME
             }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/validation/ValidationResultFactory.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/validation/ValidationResultFactory.java
@@ -59,12 +59,12 @@ public class ValidationResultFactory {
                         case Constants.CHANNEL_ID_MISSING_IN_PAYLOAD:
                             msg
                                     =
-                                    "Unable to render notification, channelId is required but not provided in the notification payload: "
+                                    "ChannelId is required for API 26+ but not provided in the notification payload. Falling to default channel: "
                                             + values[0];
                             break;
                         case Constants.CHANNEL_ID_NOT_REGISTERED:
                             msg = "Unable to render notification on channelId: " + values[0]
-                                    + " as it is not registered by the app.";
+                                    + " as it is not registered by the app. Falling to default channel: ";
                             break;
                         case Constants.NOTIFICATION_VIEWED_DISABLED:
                             msg

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -8,5 +8,5 @@
 
     <string name="notification_permission_name_for_title">Notifications</string>
     <string name="notification_permission_settings_message">Notifications</string>
-    <string name="fcm_fallback_notification_channel_label">Miscellaneous</string>
+    <string name="ct_fcm_fallback_notification_channel_label">Miscellaneous</string>
 </resources>

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/validation/ValidationResultFactoryTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/validation/ValidationResultFactoryTest.kt
@@ -94,13 +94,13 @@ class ValidationResultFactoryTest : BaseTestCase() {
                 512,
                 Constants.CHANNEL_ID_MISSING_IN_PAYLOAD,
                 keysArr,
-                "Unable to render notification, channelId is required but not provided in the notification payload: $key"
+                "ChannelId is required for API 26+ but not provided in the notification payload. Falling to default channel: $key"
             ),
             ValidationIO(
                 512,
                 Constants.CHANNEL_ID_NOT_REGISTERED,
                 keysArr,
-                "Unable to render notification on channelId: $key as it is not registered by the app."
+                "Unable to render notification on channelId: $key as it is not registered by the app. Falling to default channel: "
             ),
             ValidationIO(
                 512,


### PR DESCRIPTION
https://wizrocket.atlassian.net/browse/SDK-3514
Adds ct as prefix to a default channel resource name because of conflict