### PR TITLE
task(SDK-3530) - Moves initialisation of ctVariables to an IO thread

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.java
@@ -96,7 +96,21 @@ class CleverTapFactory {
             }
         });
 
+        VarCache varCache = new VarCache(config, context);
+        coreState.setVarCache(varCache);
 
+        CTVariables ctVariables = new CTVariables(varCache);
+        coreState.setCTVariables(ctVariables);
+        coreState.getControllerManager().setCtVariables(ctVariables);
+
+        Parser parser = new Parser(ctVariables);
+        coreState.setParser(parser);
+
+        Task<Void> taskVariablesInit = CTExecutorFactory.executors(config).ioTask();
+        taskVariablesInit.execute("initCTVariables", () -> {
+            ctVariables.init();
+            return null;
+        });
 
         NetworkManager networkManager = new NetworkManager(context, config, deviceInfo, coreMetaData,
                 validationResultStack, controllerManager, baseDatabaseManager,
@@ -151,18 +165,6 @@ class CleverTapFactory {
                 coreMetaData, controllerManager, sessionManager,
                 localDataStore, callbackManager, baseDatabaseManager, ctLockManager, cryptHandler);
         coreState.setLoginController(loginController);
-
-        VarCache varCache = new VarCache(config,context);
-        coreState.setVarCache(varCache);
-
-        CTVariables ctVariables = new CTVariables(varCache );
-        coreState.setCTVariables(ctVariables);
-        coreState.getControllerManager().setCtVariables(ctVariables);
-
-        Parser parser = new Parser(ctVariables);
-        coreState.setParser(parser);
-
-        ctVariables.init();
 
         return coreState;
     }


### PR DESCRIPTION
StrictMode violation was seen because `ctVariables.init()` led to prefs being accessed on the main thread
https://wizrocket.atlassian.net/browse/SDK-3530
