### PR TITLE
task(SDK-3559) - Fixes no empty message for app inbox without tabs

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
@@ -139,14 +139,14 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
         if (!styleConfig.isUsingTabs()) {
             viewPager.setVisibility(View.GONE);
             tabLayout.setVisibility(View.GONE);
-            final FrameLayout listViewFragmentLayout = findViewById(R.id.list_view_fragment);
-            listViewFragmentLayout.setVisibility(View.VISIBLE);
             if (cleverTapAPI != null && cleverTapAPI.getInboxMessageCount() == 0) {
                 noMessageView.setBackgroundColor(Color.parseColor(styleConfig.getInboxBackgroundColor()));
                 noMessageView.setVisibility(View.VISIBLE);
                 noMessageView.setText(styleConfig.getNoMessageViewText());
                 noMessageView.setTextColor(Color.parseColor(styleConfig.getNoMessageViewTextColor()));
             } else {
+                final FrameLayout listViewFragmentLayout = findViewById(R.id.list_view_fragment);
+                listViewFragmentLayout.setVisibility(View.VISIBLE);
                 boolean fragmentExists = false;
                 noMessageView.setVisibility(View.GONE);
                 for (Fragment fragment : getSupportFragmentManager().getFragments()) {

--- a/clevertap-core/src/main/res/layout/inbox_activity.xml
+++ b/clevertap-core/src/main/res/layout/inbox_activity.xml
@@ -33,13 +33,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:visibility="gone" />
-    </LinearLayout>
 
-    <TextView
-        android:id="@+id/no_message_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:layout_gravity="center"
-        android:gravity="center"
-        android:text="No Message(s) to show" />
+        <TextView
+            android:id="@+id/no_message_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:visibility="gone"
+            android:text="@string/no_messages_to_show" />
+    </LinearLayout>
 </LinearLayout>

--- a/clevertap-core/src/main/res/layout/inbox_list_view.xml
+++ b/clevertap-core/src/main/res/layout/inbox_list_view.xml
@@ -22,6 +22,6 @@
             android:layout_height="match_parent"
             android:layout_gravity="center"
             android:gravity="center"
-            android:text="No Message(s) to show" />
+            android:text="@string/no_messages_to_show" />
     </LinearLayout>
 </LinearLayout>

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="notification_permission_name_for_title">Notifications</string>
     <string name="notification_permission_settings_message">Notifications</string>
     <string name="ct_fcm_fallback_notification_channel_label">Miscellaneous</string>
+    <string name="no_messages_to_show">No Message(s) to show</string>
 </resources>


### PR DESCRIPTION
Fixes no empty message for app inbox without tabs
The view for no empty message was being overlapped by the LinearLayout. It was fixed by moving it inside the linear layout
https://wizrocket.atlassian.net/browse/SDK-3559