### PR TITLE
task(SDK-3580) - Removes onClickListener for Image of Cover InApp

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppNativeCoverFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppNativeCoverFragment.java
@@ -44,7 +44,6 @@ public class CTInAppNativeCoverFragment extends CTInAppBaseFullNativeFragment {
                 imageView.setImageBitmap(inAppNotification
                         .getImage(inAppNotification.getInAppMediaForOrientation(currentOrientation)));
                 imageView.setTag(0);
-                imageView.setOnClickListener(new CTInAppNativeButtonClickListener());
             }
         }
 


### PR DESCRIPTION
https://wizrocket.atlassian.net/browse/SDK-3580
(This doesn’t pertain to InApp CoverImageOnly type)
