### PR TITLE
remove push impressions events from being considered for session length calculation SDK-3538

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/events/EventQueueManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/events/EventQueueManager.java
@@ -3,9 +3,7 @@ package com.clevertap.android.sdk.events;
 import static com.clevertap.android.sdk.utils.CTJsonConverter.getErrorObject;
 
 import android.content.Context;
-
 import androidx.annotation.Nullable;
-
 import com.clevertap.android.sdk.BaseCallbackManager;
 import com.clevertap.android.sdk.CTLockManager;
 import com.clevertap.android.sdk.CleverTapInstanceConfig;
@@ -30,15 +28,13 @@ import com.clevertap.android.sdk.task.MainLooperHandler;
 import com.clevertap.android.sdk.task.Task;
 import com.clevertap.android.sdk.validation.ValidationResult;
 import com.clevertap.android.sdk.validation.ValidationResultStack;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.util.Iterator;
 import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 public class EventQueueManager extends BaseEventQueueManager implements FailureFlushListener {
 
@@ -474,7 +470,7 @@ public class EventQueueManager extends BaseEventQueueManager implements FailureF
                         }
                     }, 2000);
                 } else {
-                    if (eventType == Constants.FETCH_EVENT) {
+                    if (eventType == Constants.FETCH_EVENT || eventType == Constants.NV_EVENT) {
                         addToQueue(context, event, eventType);
                     } else {
                         sessionManager.lazyCreateSession(context);


### PR DESCRIPTION
1. session creation will be skip for push impression events and sessionId will be passed as 0 for push impression events when app is in killed state.