### PR TITLE
Fix concurrent modification exception for availableCTPushProviders list SDK-3604

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushProviders.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushProviders.java
@@ -876,7 +876,7 @@ public class PushProviders implements CTPushProviderListener {
      * Fetches latest tokens from various providers and send to Clevertap's server
      */
     private void refreshAllTokens() {
-        Task<Void> task = CTExecutorFactory.executors(config).ioTask();
+        Task<Void> task = CTExecutorFactory.executors(config).postAsyncSafelyTask();
         task.execute("PushProviders#refreshAllTokens", new Callable<Void>() {
             @Override
             public Void call() {


### PR DESCRIPTION
Moved refreshCTProviderTokens() from iO() to postAsyncSafely() to avoid parallel access to availableCTPushProviders