### PR TITLE
Lp/knock/anr jio

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/ActivityLifecycleCallback.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/ActivityLifecycleCallback.java
@@ -5,8 +5,6 @@ import android.app.Activity;
 import android.app.Application;
 import android.os.Build;
 import android.os.Bundle;
-import android.util.Log;
-
 
 /**
  * Class for handling activity lifecycle events
@@ -38,7 +36,6 @@ public final class ActivityLifecycleCallback {
 
         @Override
         public void onActivityResumed(Activity activity) {
-            Log.i("axa", "onActivityResumed -> ALCC");
             if (cleverTapId != null) {
                 CleverTapAPI.onActivityResumed(activity, cleverTapId);
             } else {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/ActivityLifecycleCallback.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/ActivityLifecycleCallback.java
@@ -2,10 +2,11 @@ package com.clevertap.android.sdk;
 
 import android.annotation.TargetApi;
 import android.app.Activity;
-import android.content.Context;
+import android.app.Application;
 import android.os.Build;
 import android.os.Bundle;
-import java.util.HashSet;
+import android.util.Log;
+
 
 /**
  * Class for handling activity lifecycle events
@@ -14,6 +15,50 @@ import java.util.HashSet;
 public final class ActivityLifecycleCallback {
 
     public static boolean registered = false;
+    private static String cleverTapId = null;
+    private static final Application.ActivityLifecycleCallbacks lifecycleCallbacks = new Application.ActivityLifecycleCallbacks() {
+
+        @Override
+        public void onActivityCreated(Activity activity, Bundle bundle) {
+            if (cleverTapId != null) {
+                CleverTapAPI.onActivityCreated(activity, cleverTapId);
+            } else {
+                CleverTapAPI.onActivityCreated(activity);
+            }
+        }
+
+        @Override
+        public void onActivityDestroyed(Activity activity) {
+        }
+
+        @Override
+        public void onActivityPaused(Activity activity) {
+            CleverTapAPI.onActivityPaused();
+        }
+
+        @Override
+        public void onActivityResumed(Activity activity) {
+            Log.i("axa", "onActivityResumed -> ALCC");
+            if (cleverTapId != null) {
+                CleverTapAPI.onActivityResumed(activity, cleverTapId);
+            } else {
+                CleverTapAPI.onActivityResumed(activity);
+            }
+        }
+
+        @Override
+        public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
+        }
+
+        @Override
+        public void onActivityStarted(Activity activity) {
+        }
+
+        @Override
+        public void onActivityStopped(Activity activity) {
+        }
+    };
+
     /**
      * Enables lifecycle callbacks for Android devices
      *
@@ -21,7 +66,7 @@ public final class ActivityLifecycleCallback {
      * @param cleverTapID Custom CleverTap ID
      */
     @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
-    public static synchronized void register(android.app.Application application, final String cleverTapID) {
+    public static void register(android.app.Application application, final String cleverTapID) {
         if (application == null) {
             Logger.i("Application instance is null/system API is too old");
             return;
@@ -32,51 +77,11 @@ public final class ActivityLifecycleCallback {
             return;
         }
 
+        cleverTapId = cleverTapID;
         registered = true;
-        application.registerActivityLifecycleCallbacks(
-                new android.app.Application.ActivityLifecycleCallbacks() {
 
-                    @Override
-                    public void onActivityCreated(Activity activity, Bundle bundle) {
-                        if (cleverTapID != null) {
-                            CleverTapAPI.onActivityCreated(activity, cleverTapID);
-                        } else {
-                            CleverTapAPI.onActivityCreated(activity);
-                        }
-                    }
-
-                    @Override
-                    public void onActivityDestroyed(Activity activity) {
-                    }
-
-                    @Override
-                    public void onActivityPaused(Activity activity) {
-                        CleverTapAPI.onActivityPaused();
-                    }
-
-                    @Override
-                    public void onActivityResumed(Activity activity) {
-                        if (cleverTapID != null) {
-                            CleverTapAPI.onActivityResumed(activity, cleverTapID);
-                        } else {
-                            CleverTapAPI.onActivityResumed(activity);
-                        }
-                    }
-
-                    @Override
-                    public void onActivitySaveInstanceState(Activity activity, Bundle bundle) {
-                    }
-
-                    @Override
-                    public void onActivityStarted(Activity activity) {
-                    }
-
-                    @Override
-                    public void onActivityStopped(Activity activity) {
-                    }
-                }
-
-        );
+        application.unregisterActivityLifecycleCallbacks(lifecycleCallbacks);
+        application.registerActivityLifecycleCallbacks(lifecycleCallbacks);
         Logger.i("Activity Lifecycle Callback successfully registered");
     }
 
@@ -86,7 +91,7 @@ public final class ActivityLifecycleCallback {
      * @param application App's Application object
      */
     @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
-    public static synchronized void register(android.app.Application application) {
+    public static void register(android.app.Application application) {
         register(application, null);
     }
 }


### PR DESCRIPTION
The register method of SDK is synchronised. This might theoretically cause ANR but seems not the cause for client. We have removed the syncronised keyword so main or any thread is not blocked.

Code snippet used to test
`val scope = CoroutineScope(Dispatchers.Default)
        GlobalScope.launch(Dispatchers.Default) {
            val lis = mutableListOf<Deferred<Unit>>()

            (1..1000).map { c ->
                lis.add(
                    scope.async {
                        ActivityLifecycleCallback.register(this@MyApplication)
                        registerActivityLifecycleCallbacks(this@MyApplication)
                    }
                )
            }
            lis.awaitAll()
        }`