### PR TITLE
Bug/sdk 3671

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -2767,13 +2767,13 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
         StoreProvider storeProvider = StoreProvider.getInstance();
 
         if (storeRegistry.getInAppStore() == null) {
-            InAppStore inAppStore = storeProvider.provideInAppStore(context, cryptHandler, deviceInfo,
+            InAppStore inAppStore = storeProvider.provideInAppStore(context, cryptHandler, deviceId,
                     accountId);
             storeRegistry.setInAppStore(inAppStore);
             coreState.getCallbackManager().addChangeUserCallback(inAppStore);
         }
         if (storeRegistry.getImpressionStore() == null) {
-            ImpressionStore impStore = storeProvider.provideImpressionStore(context, deviceInfo,
+            ImpressionStore impStore = storeProvider.provideImpressionStore(context, deviceId,
                     accountId);
             storeRegistry.setImpressionStore(impStore);
             coreState.getCallbackManager().addChangeUserCallback(impStore);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.java
@@ -86,6 +86,7 @@ class CleverTapFactory {
 
         DeviceInfo deviceInfo = new DeviceInfo(context, config, cleverTapID, coreMetaData);
         coreState.setDeviceInfo(deviceInfo);
+        deviceInfo.onInitDeviceInfo(cleverTapID);
 
         CTPreferenceCache.getInstance(context, config);
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.java
@@ -125,14 +125,14 @@ class CleverTapFactory {
             }
             if (coreState.getDeviceInfo() != null && coreState.getDeviceInfo().getDeviceID() != null) {
                 if (storeRegistry.getInAppStore() == null) {
-                    InAppStore inAppStore = storeProvider.provideInAppStore(context, cryptHandler, deviceInfo,
+                    InAppStore inAppStore = storeProvider.provideInAppStore(context, cryptHandler, deviceInfo.getDeviceID(),
                             config.getAccountId());
                     storeRegistry.setInAppStore(inAppStore);
                     evaluationManager.loadSuppressedCSAndEvaluatedSSInAppsIds();
                     callbackManager.addChangeUserCallback(inAppStore);
                 }
                 if (storeRegistry.getImpressionStore() == null) {
-                    ImpressionStore impStore = storeProvider.provideImpressionStore(context, deviceInfo,
+                    ImpressionStore impStore = storeProvider.provideImpressionStore(context, deviceInfo.getDeviceID(),
                             config.getAccountId());
                     storeRegistry.setImpressionStore(impStore);
                     callbackManager.addChangeUserCallback(impStore);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
@@ -503,8 +503,6 @@ public class DeviceInfo {
         this.library = null;
         this.customLocale = null;
         mCoreMetaData = coreMetaData;
-        onInitDeviceInfo(cleverTapID);
-        getConfigLogger().verbose(config.getAccountId() + ":async_deviceID", "DeviceInfo() called");
     }
 
     public void forceNewDeviceID() {
@@ -758,6 +756,7 @@ public class DeviceInfo {
     }
 
     void onInitDeviceInfo(final String cleverTapID) {
+        getConfigLogger().verbose(config.getAccountId() + ":async_deviceID", "DeviceInfo() called");
         Task<Void> taskDeviceCachedInfo = CTExecutorFactory.executors(config).ioTask();
         taskDeviceCachedInfo.execute("getDeviceCachedInfo", new Callable<Void>() {
             @Override

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
@@ -510,16 +510,19 @@ public class DeviceInfo {
         forceUpdateDeviceId(deviceID);
     }
 
-    public void forceUpdateCustomCleverTapID(String cleverTapID) {
+    public String forceUpdateCustomCleverTapID(String cleverTapID) {
         if (Utils.validateCTID(cleverTapID)) {
             getConfigLogger()
                     .info(config.getAccountId(), "Setting CleverTap ID to custom CleverTap ID : " + cleverTapID);
-            forceUpdateDeviceId(Constants.CUSTOM_CLEVERTAP_ID_PREFIX + cleverTapID);
+            String id = Constants.CUSTOM_CLEVERTAP_ID_PREFIX + cleverTapID;
+            forceUpdateDeviceId(id);
+            return id;
         } else {
-            setOrGenerateFallbackDeviceID();
+            String fallbackId = generateFallbackDeviceID();
             removeDeviceID();
             String error = recordDeviceError(Constants.INVALID_CT_CUSTOM_ID, cleverTapID, getFallBackDeviceID());
             getConfigLogger().info(config.getAccountId(), error);
+            return fallbackId;
         }
     }
 
@@ -766,22 +769,21 @@ public class DeviceInfo {
             }
         });
 
-        Task<Void> task = CTExecutorFactory.executors(config).ioTask();
-        task.addOnSuccessListener(new OnSuccessListener<Void>() {
+        Task<String> task = CTExecutorFactory.executors(config).ioTask();
+        task.addOnSuccessListener(new OnSuccessListener<String>() {
             // callback on main thread
             @Override
-            public void onSuccess(final Void aVoid) {
+            public void onSuccess(final String deviceId) {
                 getConfigLogger().verbose(config.getAccountId() + ":async_deviceID",
                         "DeviceID initialized successfully!" + Thread.currentThread());
                 // No need to put getDeviceID() on background thread because prefs already loaded
-                CleverTapAPI.instanceWithConfig(context, config).deviceIDCreated(getDeviceID());
+                CleverTapAPI.instanceWithConfig(context, config).deviceIDCreated(deviceId);
             }
         });
-        task.execute("initDeviceID", new Callable<Void>() {
+        task.execute("initDeviceID", new Callable<String>() {
             @Override
-            public Void call() throws Exception {
-                initDeviceID(cleverTapID);
-                return null;
+            public String call() throws Exception {
+                return initDeviceID(cleverTapID);
             }
         });
 
@@ -862,7 +864,7 @@ public class DeviceInfo {
         }
     }
 
-    private synchronized void generateDeviceID() {
+    private synchronized String generateDeviceID() {
         getConfigLogger().verbose(config.getAccountId() + ":async_deviceID", "generateDeviceID() called!");
         String generatedDeviceID;
         String adId = getGoogleAdID();
@@ -875,6 +877,7 @@ public class DeviceInfo {
         }
         forceUpdateDeviceId(generatedDeviceID);
         getConfigLogger().verbose(config.getAccountId() + ":async_deviceID", "generateDeviceID() done executing!");
+        return generatedDeviceID;
     }
 
     private String generateGUID() {
@@ -904,7 +907,7 @@ public class DeviceInfo {
         return Constants.FALLBACK_ID_TAG + ":" + this.config.getAccountId();
     }
 
-    private void initDeviceID(String cleverTapID) {
+    private String initDeviceID(String cleverTapID) {
         getConfigLogger().verbose(config.getAccountId() + ":async_deviceID", "Called initDeviceID()");
         //Show logging as per Manifest flag
         if (config.getEnableCustomCleverTapId()) {
@@ -928,27 +931,27 @@ public class DeviceInfo {
                 String error = recordDeviceError(Constants.UNABLE_TO_SET_CT_CUSTOM_ID, deviceID, cleverTapID);
                 getConfigLogger().info(config.getAccountId(), error);
             }
-            return;
+            return deviceID;
         }
 
         if (this.config.getEnableCustomCleverTapId()) {
-            forceUpdateCustomCleverTapID(cleverTapID);
-            return;
+            return forceUpdateCustomCleverTapID(cleverTapID);
         }
 
         if (!this.config.isUseGoogleAdId()) {
             getConfigLogger().verbose(config.getAccountId() + ":async_deviceID", "Calling generateDeviceID()");
-            generateDeviceID();
+            String genId = generateDeviceID();
             getConfigLogger().verbose(config.getAccountId() + ":async_deviceID", "Called generateDeviceID()");
-            return;
+            return genId;
         }
 
         // fetch the googleAdID to generate GUID
         //has to be called on background thread
         fetchGoogleAdID();
-        generateDeviceID();
+        String genId = generateDeviceID();
 
         getConfigLogger().verbose(config.getAccountId() + ":async_deviceID", "initDeviceID() done executing!");
+        return genId;
     }
 
     private String recordDeviceError(int messageCode, String... varargs) {
@@ -961,18 +964,18 @@ public class DeviceInfo {
         StorageHelper.remove(this.context, getDeviceIdStorageKey());
     }
 
-    private synchronized void setOrGenerateFallbackDeviceID() {
-        if (getFallBackDeviceID() == null) {
-            synchronized (deviceIDLock) {
-                String fallbackDeviceID = Constants.ERROR_PROFILE_PREFIX + UUID.randomUUID().toString()
-                        .replace("-", "");
-                if (fallbackDeviceID.trim().length() > 2) {
-                    updateFallbackID(fallbackDeviceID);
-                } else {
-                    getConfigLogger()
-                            .verbose(this.config.getAccountId(), "Unable to generate fallback error device ID");
-                }
-            }
+    private synchronized String generateFallbackDeviceID() {
+        String existingId = getFallBackDeviceID();
+
+        if (existingId != null) {
+            return existingId;
+        }
+
+        synchronized (deviceIDLock) {
+            String fallbackDeviceID = Constants.ERROR_PROFILE_PREFIX + UUID.randomUUID().toString()
+                    .replace("-", "");
+            updateFallbackID(fallbackDeviceID);
+            return fallbackDeviceID;
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
@@ -583,7 +583,8 @@ public class DeviceInfo {
     }
 
     public String getDeviceID() {
-        return _getDeviceID() != null ? _getDeviceID() : getFallBackDeviceID();
+        String currentId = _getDeviceID();
+        return currentId != null ? currentId : getFallBackDeviceID();
     }
 
     public String getGoogleAdID() {
@@ -806,8 +807,12 @@ public class DeviceInfo {
     }
 
     private String _getDeviceID() {
-        synchronized (deviceIDLock) {
-            return StorageHelper.getString(this.context, getDeviceIdStorageKey(), null);
+        String _new = StorageHelper.getString(this.context, getDeviceIdStorageKey(), null);
+
+        if (this.config.isDefaultInstance()) {
+            return _new != null ? _new : StorageHelper.getString(this.context, Constants.DEVICE_ID_TAG, null);
+        } else {
+            return _new;
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
@@ -807,12 +807,7 @@ public class DeviceInfo {
 
     private String _getDeviceID() {
         synchronized (deviceIDLock) {
-            if (this.config.isDefaultInstance()) {
-                String _new = StorageHelper.getString(this.context, getDeviceIdStorageKey(), null);
-                return _new != null ? _new : StorageHelper.getString(this.context, Constants.DEVICE_ID_TAG, null);
-            } else {
-                return StorageHelper.getString(this.context, getDeviceIdStorageKey(), null);
-            }
+            return StorageHelper.getString(this.context, getDeviceIdStorageKey(), null);
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/StoreProvider.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/StoreProvider.kt
@@ -70,17 +70,17 @@ class StoreProvider {
      *
      * @param context The Android application context.
      * @param cryptHandler The handler used for encryption and decryption of In-App messages.
-     * @param deviceInfo The information about the device.
+     * @param deviceId The device id for user.
      * @param accountId The unique account identifier.
      * @return An instance of [InAppStore].
      */
     fun provideInAppStore(
         context: Context,
         cryptHandler: CryptHandler,
-        deviceInfo: DeviceInfo,
+        deviceId: String,
         accountId: String
     ): InAppStore {
-        val prefName = constructStorePreferenceName(STORE_TYPE_INAPP, deviceInfo.deviceID, accountId)
+        val prefName = constructStorePreferenceName(STORE_TYPE_INAPP, deviceId, accountId)
         return InAppStore(getCTPreference(context, prefName), cryptHandler)
     }
 
@@ -88,16 +88,16 @@ class StoreProvider {
      * Provides an instance of [ImpressionStore] using the given parameters.
      *
      * @param context The Android application context.
-     * @param deviceInfo The information about the device.
+     * @param deviceId The device id for user.
      * @param accountId The unique account identifier.
      * @return An instance of [ImpressionStore].
      */
     fun provideImpressionStore(
         context: Context,
-        deviceInfo: DeviceInfo,
+        deviceId: String,
         accountId: String
     ): ImpressionStore {
-        val prefName = constructStorePreferenceName(STORE_TYPE_IMPRESSION, deviceInfo.deviceID, accountId)
+        val prefName = constructStorePreferenceName(STORE_TYPE_IMPRESSION, deviceId, accountId)
         return ImpressionStore(getCTPreference(context, prefName))
     }
 

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/ImpressionManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/ImpressionManagerTest.kt
@@ -41,7 +41,7 @@ class ImpressionManagerTest : BaseTestCase() {
         `when`(deviceInfo.deviceID).thenReturn("device_id")
 
         impressionStore = StoreProvider.getInstance().provideImpressionStore(
-            appCtx, deviceInfo, "account_id"
+            appCtx, deviceInfo.deviceID, "account_id"
         )
 
         storeRegistry.impressionStore = impressionStore

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/StoreProviderTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/StoreProviderTest.kt
@@ -39,7 +39,7 @@ class StoreProviderTest {
         every { storeProvider.constructStorePreferenceName(STORE_TYPE_INAPP, mockDeviceInfo.deviceID, accountId) } returns prefName
 
         // Act
-        val inAppStore = storeProvider.provideInAppStore(mockContext, mockCryptHandler, mockDeviceInfo, accountId)
+        val inAppStore = storeProvider.provideInAppStore(mockContext, mockCryptHandler, mockDeviceInfo.deviceID, accountId)
 
         // Assert
         verify { storeProvider.getCTPreference(mockContext, prefName) }
@@ -54,7 +54,7 @@ class StoreProviderTest {
         every { storeProvider.constructStorePreferenceName(STORE_TYPE_IMPRESSION, mockDeviceInfo.deviceID, accountId) } returns prefName
 
         // Act
-        val impressionStore = storeProvider.provideImpressionStore(mockContext, mockDeviceInfo, accountId)
+        val impressionStore = storeProvider.provideImpressionStore(mockContext, mockDeviceInfo.deviceID, accountId)
 
         // Assert
         verify { storeProvider.getCTPreference(mockContext, prefName) }


### PR DESCRIPTION
https://wizrocket.atlassian.net/browse/SDK-3671

fixed init of variables in class first before using them in deviceInfo
did not use device id from state variable (shared pref map)
instead passed device id back from func as it is created on fly
this reduces risk of state variable changing over time as it is accessed in future
simplified ternary as it would always return null in both cases
the device id passed as method return type to be used
did not fetch device id from state (shared pref map)