### PR TITLE
Fragment activity dependency

### DIFF
--- a/clevertap-core/build.gradle
+++ b/clevertap-core/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     compileOnly(libs.androidx.core.core)
     compileOnly(libs.androidx.viewpager)
     compileOnly(libs.android.material)
-    compileOnly(libs.androidx.fragment)
 
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.recyclerview)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -20,14 +20,19 @@ import android.view.WindowManager;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentActivity;
-import com.clevertap.android.sdk.inapp.CTInAppBaseFullFragment;
+
+import com.clevertap.android.sdk.inapp.CTInAppBaseFragment;
 import com.clevertap.android.sdk.inapp.CTInAppHtmlCoverFragment;
+import com.clevertap.android.sdk.inapp.CTInAppHtmlFooterFragment;
 import com.clevertap.android.sdk.inapp.CTInAppHtmlHalfInterstitialFragment;
+import com.clevertap.android.sdk.inapp.CTInAppHtmlHeaderFragment;
 import com.clevertap.android.sdk.inapp.CTInAppHtmlInterstitialFragment;
 import com.clevertap.android.sdk.inapp.CTInAppNativeCoverFragment;
 import com.clevertap.android.sdk.inapp.CTInAppNativeCoverImageFragment;
+import com.clevertap.android.sdk.inapp.CTInAppNativeFooterFragment;
 import com.clevertap.android.sdk.inapp.CTInAppNativeHalfInterstitialFragment;
 import com.clevertap.android.sdk.inapp.CTInAppNativeHalfInterstitialImageFragment;
+import com.clevertap.android.sdk.inapp.CTInAppNativeHeaderFragment;
 import com.clevertap.android.sdk.inapp.CTInAppNativeInterstitialFragment;
 import com.clevertap.android.sdk.inapp.CTInAppNativeInterstitialImageFragment;
 import com.clevertap.android.sdk.inapp.CTInAppNotification;
@@ -126,7 +131,7 @@ public final class InAppNotificationActivity extends FragmentActivity implements
             }
         }
 
-        CTInAppBaseFullFragment contentFragment;
+        CTInAppBaseFragment contentFragment;
         if (savedInstanceState == null) {
             contentFragment = createContentFragment();
             if (contentFragment != null) {
@@ -306,9 +311,9 @@ public final class InAppNotificationActivity extends FragmentActivity implements
         pushPermissionResultCallbackWeakReference = new WeakReference<>(callback);
     }
 
-    private CTInAppBaseFullFragment createContentFragment() {
+    private CTInAppBaseFragment createContentFragment() {
         CTInAppType type = inAppNotification.getInAppType();
-        CTInAppBaseFullFragment viewFragment = null;
+        CTInAppBaseFragment viewFragment = null;
         switch (type) {
             case CTInAppTypeCoverHTML: {
                 viewFragment = new CTInAppHtmlCoverFragment();
@@ -499,6 +504,18 @@ public final class InAppNotificationActivity extends FragmentActivity implements
                 }
                 break;
             }
+            case CTInAppTypeFooterHTML:
+                viewFragment = new CTInAppHtmlFooterFragment();
+                break;
+            case CTInAppTypeHeaderHTML:
+                viewFragment = new CTInAppHtmlHeaderFragment();
+                break;
+            case CTInAppTypeFooter:
+                viewFragment = new CTInAppNativeFooterFragment();
+                break;
+            case CTInAppTypeHeader:
+                viewFragment = new CTInAppNativeHeaderFragment();
+                break;
             default: {
                 config.getLogger().verbose("InAppNotificationActivity: Unhandled InApp Type: " + type);
                 break;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppBasePartialFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppBasePartialFragment.java
@@ -17,16 +17,6 @@ public abstract class CTInAppBasePartialFragment extends CTInAppBaseFragment {
     }
 
     @Override
-    public void onPause() {
-        super.onPause();
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-    }
-
-    @Override
     void cleanup() {
         if (!Utils.isActivityDead(getActivity()) && !isCleanedUp.get()) {
             final FragmentManager fragmentManager = getFragmentManager();

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.java
@@ -729,6 +729,10 @@ public class InAppController implements CTInAppNotification.CTInAppNotificationL
             case CTInAppTypeInterstitialImageOnly:
             case CTInAppTypeHalfInterstitialImageOnly:
             case CTInAppTypeCoverImageOnly:
+            case CTInAppTypeFooterHTML:
+            case CTInAppTypeHeaderHTML:
+            case CTInAppTypeFooter:
+            case CTInAppTypeHeader:
 
                 Intent intent = new Intent(context, InAppNotificationActivity.class);
                 intent.putExtra(Constants.INAPP_KEY, inAppNotification);
@@ -750,49 +754,10 @@ public class InAppController implements CTInAppNotification.CTInAppNotificationL
                             " It is not setup to support in-app notifications yet.", t);
                 }
                 break;
-            case CTInAppTypeFooterHTML:
-                inAppFragment = new CTInAppHtmlFooterFragment();
-                break;
-            case CTInAppTypeHeaderHTML:
-                inAppFragment = new CTInAppHtmlHeaderFragment();
-                break;
-            case CTInAppTypeFooter:
-                inAppFragment = new CTInAppNativeFooterFragment();
-                break;
-            case CTInAppTypeHeader:
-                inAppFragment = new CTInAppNativeHeaderFragment();
-                break;
-            default:
+            case CTInAppTypeHTML:
                 Logger.d(config.getAccountId(), "Unknown InApp Type found: " + type);
                 currentlyDisplayingInApp = null;
-                return;
-        }
-
-        if (inAppFragment != null) {
-            Logger.d("Displaying In-App: " + inAppNotification.getJsonDescription());
-            try {
-                //noinspection Constant Conditions
-                FragmentTransaction fragmentTransaction = ((FragmentActivity) CoreMetaData.getCurrentActivity())
-                        .getSupportFragmentManager()
-                        .beginTransaction();
-                Bundle bundle = new Bundle();
-                bundle.putParcelable("inApp", inAppNotification);
-                bundle.putParcelable("config", config);
-                inAppFragment.setArguments(bundle);
-                fragmentTransaction.setCustomAnimations(android.R.animator.fade_in, android.R.animator.fade_out);
-                fragmentTransaction.add(android.R.id.content, inAppFragment, inAppNotification.getType());
-                Logger.v(config.getAccountId(), "calling InAppFragment " + inAppNotification.getCampaignId());
-                fragmentTransaction.commitNow();
-
-            } catch (ClassCastException e) {
-                Logger.v(config.getAccountId(),
-                        "Fragment not able to render, please ensure your Activity is an instance of AppCompatActivity"
-                                + e.getMessage());
-                currentlyDisplayingInApp = null;
-            } catch (Throwable t) {
-                Logger.v(config.getAccountId(), "Fragment not able to render", t);
-                currentlyDisplayingInApp = null;
-            }
+                break;
         }
     }
 


### PR DESCRIPTION
Feat: Remove fragment activity dependency

- client needs to use appcompat activity to host fragments
- routing through our own activity so client has no restrictions
- code cleanup and redundant overides removed
- tested with footer and it seems there are no problems, need to test other cases