### PR TITLE
Fix ANR SDK-3717

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
@@ -10,6 +10,7 @@ import android.content.SharedPreferences
 import android.location.Location
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
+import androidx.annotation.MainThread
 import androidx.annotation.RequiresApi
 import androidx.annotation.WorkerThread
 import androidx.core.app.NotificationManagerCompat
@@ -128,6 +129,7 @@ fun NotificationManager.getOrCreateChannel(
  * @param caller The caller.
  * @param context The application context.
  */
+@MainThread
 fun CleverTapAPI.flushPushImpressionsOnPostAsyncSafely(logTag: String, caller: String, context: Context) {
     val flushTask = CTExecutorFactory.executors(coreState.config).postAsyncSafelyTask<Void?>()
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -1301,6 +1301,7 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      * @param scDomainListener - the {@link SCDomainListener} instance
      */
     @RestrictTo(Scope.LIBRARY_GROUP)
+    @WorkerThread
     public void setSCDomainListener(SCDomainListener scDomainListener) {
         coreState.getCallbackManager().setSCDomainListener(scDomainListener);
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.java
@@ -199,7 +199,6 @@ class CleverTapFactory {
                 ctLockManager,
                 validator,
                 localDataStore,
-                cryptHandler,
                 inAppResponse,
                 ctApiWrapper
         );

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.java
@@ -24,7 +24,7 @@ import com.clevertap.android.sdk.network.AppLaunchListener;
 import com.clevertap.android.sdk.network.CompositeBatchListener;
 import com.clevertap.android.sdk.network.FetchInAppListener;
 import com.clevertap.android.sdk.network.NetworkManager;
-import com.clevertap.android.sdk.network.api.CtApiProviderKt;
+import com.clevertap.android.sdk.network.api.CtApiWrapper;
 import com.clevertap.android.sdk.pushnotification.PushProviders;
 import com.clevertap.android.sdk.pushnotification.work.CTWorkManager;
 import com.clevertap.android.sdk.response.InAppResponse;
@@ -186,6 +186,7 @@ class CleverTapFactory {
                 coreMetaData
         );
 
+        final CtApiWrapper ctApiWrapper = new CtApiWrapper(context, config, deviceInfo);
         NetworkManager networkManager = new NetworkManager(
                 context,
                 config,
@@ -194,13 +195,13 @@ class CleverTapFactory {
                 validationResultStack,
                 controllerManager,
                 baseDatabaseManager,
-                CtApiProviderKt.provideDefaultTestCtApi(context, config, deviceInfo),
                 callbackManager,
                 ctLockManager,
                 validator,
                 localDataStore,
                 cryptHandler,
-                inAppResponse
+                inAppResponse,
+                ctApiWrapper
         );
         coreState.setNetworkManager(networkManager);
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Utils.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Utils.java
@@ -31,6 +31,7 @@ import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
+import androidx.annotation.WorkerThread;
 import androidx.core.content.ContextCompat;
 import com.clevertap.android.sdk.bitmap.BitmapDownloadRequest;
 import com.clevertap.android.sdk.bitmap.HttpBitmapLoader;
@@ -510,6 +511,7 @@ public final class Utils {
         haveVideoPlayerSupport = checkForExoPlayer();
     }
 
+    @WorkerThread
     public static boolean isMainProcess(Context context, String mainProcessName) {
 
         try {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/events/BaseEventQueueManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/events/BaseEventQueueManager.java
@@ -1,13 +1,17 @@
 package com.clevertap.android.sdk.events;
 
 import android.content.Context;
+import androidx.annotation.AnyThread;
+import androidx.annotation.WorkerThread;
 import java.util.concurrent.Future;
 import org.json.JSONObject;
 
 public abstract class BaseEventQueueManager {
 
+    @AnyThread
     public abstract Future<?> queueEvent(final Context context, final JSONObject event, final int eventType);
 
+    @WorkerThread
     public abstract void addToQueue(final Context context, final JSONObject event, final int eventType);
 
     public abstract void flush();
@@ -17,10 +21,12 @@ public abstract class BaseEventQueueManager {
     public abstract void pushBasicProfile(JSONObject baseProfile, boolean removeFromSharedPrefs);
 
     public abstract void pushInitialEventsAsync();
-
+    @WorkerThread
     public abstract void flushQueueSync(final Context context, final EventGroup eventGroup);
+    @WorkerThread
     public abstract void flushQueueSync(final Context context, final EventGroup eventGroup,final String caller);
 
+    @WorkerThread
     public abstract void sendImmediately(Context context, EventGroup eventGroup, JSONObject eventData);
 
     public abstract void scheduleQueueFlush(final Context context);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/BaseNetworkManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/BaseNetworkManager.java
@@ -1,22 +1,24 @@
 package com.clevertap.android.sdk.network;
 
 import android.content.Context;
-
+import androidx.annotation.WorkerThread;
 import com.clevertap.android.sdk.events.EventGroup;
-
 import org.json.JSONArray;
 
 public abstract class BaseNetworkManager {
 
+    @WorkerThread
     public abstract void flushDBQueue(final Context context, final EventGroup eventGroup,final String caller);
 
     public abstract int getDelayFrequency();
 
+    @WorkerThread
     public abstract void initHandshake(final EventGroup eventGroup,
-            final Runnable handshakeSuccessCallback);
+            final @WorkerThread Runnable handshakeSuccessCallback);
 
     public abstract boolean needsHandshakeForDomain(final EventGroup eventGroup);
 
+    @WorkerThread
     public abstract boolean sendQueue(final Context context, final EventGroup eventGroup, final JSONArray queue, final String caller);
 
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.java
@@ -13,6 +13,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
+import androidx.annotation.WorkerThread;
 import com.clevertap.android.sdk.BaseCallbackManager;
 import com.clevertap.android.sdk.CTLockManager;
 import com.clevertap.android.sdk.CTXtensions;
@@ -274,6 +275,7 @@ public class NetworkManager extends BaseNetworkManager {
     }
 
     @Override
+    @WorkerThread
     public void initHandshake(final EventGroup eventGroup, final Runnable handshakeSuccessCallback) {
         // Always set this to 0 so that the handshake is not performed during a HTTP failure
         responseFailureCount = 0;
@@ -281,6 +283,7 @@ public class NetworkManager extends BaseNetworkManager {
     }
 
     @Override
+    @WorkerThread
     public boolean needsHandshakeForDomain(final EventGroup eventGroup) {
         final String domain = getDomain(eventGroup);
         boolean needHandshakeDueToFailure = responseFailureCount > 5;
@@ -306,10 +309,12 @@ public class NetworkManager extends BaseNetworkManager {
         StorageHelper.persist(editor);
     }
 
+    @WorkerThread
     int getCurrentRequestTimestamp() {
         return ctApi.getCurrentRequestTimestampSeconds();
     }
 
+    @WorkerThread
     public String getDomain(final EventGroup eventGroup) {
         return ctApi.getActualDomain(eventGroup == EventGroup.PUSH_NOTIFICATION_VIEWED);
     }
@@ -485,6 +490,7 @@ public class NetworkManager extends BaseNetworkManager {
         }
     }
 
+    @WorkerThread
     private void performHandshakeForDomain(final Context context, final EventGroup eventGroup,
             final Runnable handshakeSuccessCallback) {
 
@@ -511,6 +517,7 @@ public class NetworkManager extends BaseNetworkManager {
      *
      * @return True to continue sending requests, false otherwise.
      */
+    @WorkerThread
     private boolean processIncomingHeaders(final Context context, Response response) {
         final String muteCommand = response.getHeaderValue(Constants.HEADER_MUTE);
         if (muteCommand != null && muteCommand.trim().length() > 0) {
@@ -608,6 +615,7 @@ public class NetworkManager extends BaseNetworkManager {
         }
     }
 
+    @WorkerThread
     private Response callApiForEventGroup(EventGroup eventGroup, SendQueueRequestBody body) {
         if (eventGroup == EventGroup.VARIABLES) {
             return ctApi.defineVars(body);
@@ -654,6 +662,7 @@ public class NetworkManager extends BaseNetworkManager {
         }
     }
 
+    @WorkerThread
     private boolean handleSendQueueResponse(@NonNull Response response, SendQueueRequestBody body,
             EndpointId endpointId) {
         if (!response.isSuccess()) {
@@ -761,6 +770,7 @@ public class NetworkManager extends BaseNetworkManager {
         }
     }
 
+    @WorkerThread
     private void setDomain(final Context context, String domainName) {
         logger.verbose(config.getAccountId(), "Setting domain to " + domainName);
         StorageHelper.putString(context, StorageHelper.storageKeyWithSuffix(config, Constants.KEY_DOMAIN_NAME),
@@ -783,6 +793,7 @@ public class NetworkManager extends BaseNetworkManager {
         StorageHelper.putInt(context, StorageHelper.storageKeyWithSuffix(config, Constants.KEY_FIRST_TS), ts);
     }
 
+    @WorkerThread
     private void setSpikyDomain(final Context context, String spikyDomainName) {
         logger.verbose(config.getAccountId(), "Setting spiky domain to " + spikyDomainName);
         StorageHelper.putString(context, StorageHelper.storageKeyWithSuffix(config, Constants.SPIKY_KEY_DOMAIN_NAME),
@@ -888,6 +899,7 @@ public class NetworkManager extends BaseNetworkManager {
         return newPrefs;
     }
 
+    @WorkerThread
     private void setMuted(final Context context, boolean mute) {
         if (mute) {
             final int now = (int) (System.currentTimeMillis() / 1000);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.java
@@ -26,7 +26,6 @@ import com.clevertap.android.sdk.DeviceInfo;
 import com.clevertap.android.sdk.LocalDataStore;
 import com.clevertap.android.sdk.Logger;
 import com.clevertap.android.sdk.StorageHelper;
-import com.clevertap.android.sdk.cryption.CryptHandler;
 import com.clevertap.android.sdk.db.BaseDatabaseManager;
 import com.clevertap.android.sdk.db.QueueData;
 import com.clevertap.android.sdk.events.EventGroup;
@@ -135,7 +134,6 @@ public class NetworkManager extends BaseNetworkManager {
             CTLockManager ctLockManager,
             Validator validator,
             LocalDataStore localDataStore,
-            CryptHandler cryptHandler,
             InAppResponse inAppResponse,
             final CtApiWrapper ctApiWrapper) {
         this.context = context;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/api/CtApiProvider.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/api/CtApiProvider.kt
@@ -1,12 +1,14 @@
 package com.clevertap.android.sdk.network.api
 
 import android.content.Context
+import androidx.annotation.WorkerThread
 import com.clevertap.android.sdk.CleverTapInstanceConfig
 import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.DeviceInfo
 import com.clevertap.android.sdk.StorageHelper
 import com.clevertap.android.sdk.network.http.UrlConnectionHttpClient
 
+@WorkerThread
 fun provideDefaultTestCtApi(
     context: Context,
     config: CleverTapInstanceConfig,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/api/CtApiWrapper.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/api/CtApiWrapper.kt
@@ -5,6 +5,16 @@ import androidx.annotation.WorkerThread
 import com.clevertap.android.sdk.CleverTapInstanceConfig
 import com.clevertap.android.sdk.DeviceInfo
 
+/**
+ * Wrapper class for accessing the [CtApi] instance.
+ *
+ * This class provides lazy initialization of the [CtApi] instance, ensuring that it is only
+ * initialized when accessed.
+ *
+ * @param context The application context.
+ * @param config The configuration for the CleverTap instance.
+ * @param deviceInfo The device information required for CleverTap initialization.
+ */
 class CtApiWrapper internal constructor(
     private val context: Context,
     private val config: CleverTapInstanceConfig,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/api/CtApiWrapper.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/api/CtApiWrapper.kt
@@ -1,0 +1,18 @@
+package com.clevertap.android.sdk.network.api
+
+import android.content.Context
+import androidx.annotation.WorkerThread
+import com.clevertap.android.sdk.CleverTapInstanceConfig
+import com.clevertap.android.sdk.DeviceInfo
+
+class CtApiWrapper internal constructor(
+    private val context: Context,
+    private val config: CleverTapInstanceConfig,
+    private val deviceInfo: DeviceInfo
+) {
+
+    @get:WorkerThread
+    val ctApi: CtApi by lazy {
+        provideDefaultTestCtApi(context, config, deviceInfo)
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushProviders.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushProviders.java
@@ -738,9 +738,6 @@ public class PushProviders implements CTPushProviderListener {
     }
 
     private void initPushAmp() {
-        // Prevent PushAmp initialisation on xiaomi's thread
-        if(!Utils.isMainProcess(context, context.getPackageName()))
-            return;
 
         Task<Void> task = CTExecutorFactory.executors(config).postAsyncSafelyTask();
         task.execute("createOrResetWorker", new Callable<Void>() {

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/network/NetworkManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/network/NetworkManagerTest.kt
@@ -17,6 +17,7 @@ import com.clevertap.android.sdk.events.EventGroup.VARIABLES
 import com.clevertap.android.sdk.inapp.TriggerManager
 import com.clevertap.android.sdk.network.api.CtApi
 import com.clevertap.android.sdk.network.api.CtApiTestProvider
+import com.clevertap.android.sdk.network.api.CtApiWrapper
 import com.clevertap.android.sdk.network.http.MockHttpClient
 import com.clevertap.android.sdk.response.InAppResponse
 import com.clevertap.android.sdk.validation.ValidationResultStack
@@ -26,6 +27,7 @@ import org.json.JSONObject
 import org.junit.*
 import org.junit.runner.*
 import org.mockito.*
+import org.mockito.Mockito.*
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -37,12 +39,15 @@ class NetworkManagerTest : BaseTestCase() {
     private lateinit var networkManager: NetworkManager
     private lateinit var ctApi: CtApi
     private lateinit var mockHttpClient: MockHttpClient
+    @Mock private lateinit var ctApiWrapper : CtApiWrapper
 
     @Before
     fun setUpNetworkManager() {
+        MockitoAnnotations.openMocks(this)
         mockHttpClient = MockHttpClient()
         ctApi = CtApiTestProvider.provideTestCtApiForConfig(cleverTapInstanceConfig, mockHttpClient)
         networkManager = provideNetworkManager()
+        `when`(ctApiWrapper.ctApi).thenReturn(ctApi)
     }
 
     @Test
@@ -151,13 +156,12 @@ class NetworkManagerTest : BaseTestCase() {
             ValidationResultStack(),
             controllerManager,
             dbManager,
-            ctApi,
             callbackManager,
             lockManager,
             Validator(),
             localDataStore,
-            cryptHandler,
-            inAppResponse
+            inAppResponse,
+            ctApiWrapper
         )
     }
 }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/network/api/CtApiWrapperTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/network/api/CtApiWrapperTest.kt
@@ -1,0 +1,63 @@
+package com.clevertap.android.sdk.network.api
+
+import com.clevertap.android.sdk.CoreMetaData
+import com.clevertap.android.sdk.DeviceInfo
+import com.clevertap.android.sdk.MockDeviceInfo
+import com.clevertap.android.shared.test.BaseTestCase
+import org.junit.*
+import org.junit.Test
+import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.runner.*
+import org.mockito.*
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CtApiWrapperTest : BaseTestCase() {
+
+    private lateinit var ctApiWrapper: CtApiWrapper
+    private lateinit var coreMetaData: CoreMetaData
+    private lateinit var deviceInfo: DeviceInfo
+    private lateinit var guid: String
+    @Before
+    override fun setUp() {
+        super.setUp()
+        guid = "1212121221"
+        coreMetaData = CoreMetaData()
+        deviceInfo = MockDeviceInfo(application, cleverTapInstanceConfig, guid, coreMetaData)
+        ctApiWrapper = CtApiWrapper(application, cleverTapInstanceConfig, deviceInfo)
+    }
+
+    @Test
+    fun `test ctApi initialization`() {
+        assertNotNull(ctApiWrapper.ctApi)
+    }
+    @Test
+    fun `test ctApi when multiple times get is called returns same CtApi instance`() {
+        val ctApi1 = ctApiWrapper.ctApi
+        val ctApi2 = ctApiWrapper.ctApi
+        val ctApi3 = ctApiWrapper.ctApi
+        assertNotNull(ctApi1)
+        assertNotNull(ctApi2)
+        assertNotNull(ctApi3)
+        assertEquals(ctApi1,ctApi2)
+        assertEquals(ctApi1,ctApi3)
+        assertEquals(ctApi2,ctApi3)
+    }
+    @Test
+    fun `test ctApi when different CtApiWrapper creates unique CtApi instance`() {
+
+        val ctApiWrapper1 = CtApiWrapper(application, cleverTapInstanceConfig, deviceInfo)
+        val ctApiWrapper2 = CtApiWrapper(application, cleverTapInstanceConfig, deviceInfo)
+        val ctApiWrapper3 = CtApiWrapper(application, cleverTapInstanceConfig, deviceInfo)
+        val ctApi1 = ctApiWrapper1.ctApi
+        val ctApi2 = ctApiWrapper2.ctApi
+        val ctApi3 = ctApiWrapper3.ctApi
+        assertNotNull(ctApi1)
+        assertNotNull(ctApi2)
+        assertNotNull(ctApi3)
+        assertNotEquals(ctApi1,ctApi2)
+        assertNotEquals(ctApi1,ctApi3)
+        assertNotEquals(ctApi2,ctApi3)
+    }
+}

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -97,6 +97,7 @@ dependencies {
     localImplementation(project(":clevertap-xps")) // For Xiaomi Push use
     localImplementation(project(":clevertap-pushtemplates"))
     localImplementation(project(":clevertap-hms")) // For Huawei Push use
+    localImplementation(implementation 'com.github.anrwatchdog:anrwatchdog:1.4.0')
 
     implementation("com.google.android.gms:play-services-location:21.0.0") // Needed for geofence
     implementation("androidx.work:work-runtime:2.7.1") // Needed for geofence

--- a/sample/src/main/java/com/clevertap/demo/MyApplication.kt
+++ b/sample/src/main/java/com/clevertap/demo/MyApplication.kt
@@ -20,6 +20,7 @@ import com.clevertap.android.sdk.inbox.CTInboxMessage
 import com.clevertap.android.sdk.interfaces.NotificationHandler
 import com.clevertap.android.sdk.pushnotification.CTPushNotificationListener
 import com.clevertap.demo.ui.main.NotificationUtils
+import com.github.anrwatchdog.ANRWatchDog
 import com.google.android.gms.security.ProviderInstaller
 import com.google.android.gms.security.ProviderInstaller.ProviderInstallListener
 import org.json.JSONObject
@@ -44,6 +45,7 @@ class MyApplication : MultiDexApplication(), CTPushNotificationListener, Activit
                 //.penaltyDeath()
                 .build()
         )*/
+        ANRWatchDog().start()
 
         CleverTapAPI.setDebugLevel(VERBOSE)
         //CleverTapAPI.changeXiaomiCredentials("your xiaomi app id","your xiaomi app key")


### PR DESCRIPTION
1. add threading annotation for ease of understanding like which method must run on which thread
2. add CtApiWrapper class to lazily initialize CtApi. Eager initialization of CtApi is causing ANR during CleverTapAPI instance creation triggered by DeviceId generation callback
3. add AnrWatchDog to sample app
4. remove isMainProcess check for xiaomi which is causing
5. fix failing test case and add new test cases