### PR TITLE
task(SDK-3713) - Removes entries for pushamp related classes

### DIFF
--- a/clevertap-core/src/main/AndroidManifest.xml
+++ b/clevertap-core/src/main/AndroidManifest.xml
@@ -20,20 +20,6 @@
             android:enabled="true"
             android:exported="false" />
 
-        <service
-            android:name=".pushnotification.amp.CTBackgroundIntentService"
-            android:exported="false"
-            android:permission="android.permission.BIND_JOB_SERVICE">
-            <intent-filter>
-                <action android:name="com.clevertap.BG_EVENT" />
-            </intent-filter>
-        </service>
-
-        <service
-            android:name=".pushnotification.amp.CTBackgroundJobService"
-            android:exported="false"
-            android:permission="android.permission.BIND_JOB_SERVICE" />
-
         <receiver
             android:name=".pushnotification.fcm.CTFirebaseMessagingReceiver"
             android:exported="true"


### PR DESCRIPTION
Removes CTBackgroundIntentService and CTBackgroundJobService from AndroidManifest.xml

- These entries caused crashes in v6.1.0 and v6.1.1. Workaround was provided for client then. 
- It will now be fixed in the SDK itself