### PR TITLE
Release core v6.2.1 SDK-3760 SDK-3759

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGE LOG.
 
+### April 11, 2024
+
+* [CleverTap Android SDK v6.2.1](docs/CTCORECHANGELOG.md)
+
 ### April 3, 2024
 > ⚠️ **NOTE**
 6.2.0 produces a crash, please update to 6.2.1 and above.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We publish the SDK to `mavenCentral` as an `AAR` file. Just declare it as depend
 
 ```groovy
     dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:6.2.0"
+         implementation "com.clevertap.android:clevertap-android-sdk:6.2.1"
     }
 ```
 
@@ -34,7 +34,7 @@ Alternatively, you can download and add the AAR file included in this repo in yo
     
  ```groovy
     dependencies {      
-        implementation (name: "clevertap-android-sdk-6.2.0", ext: 'aar')
+        implementation (name: "clevertap-android-sdk-6.2.1", ext: 'aar')
     }
 ```
 
@@ -46,7 +46,7 @@ Add the Firebase Messaging library and Android Support Library v4 as dependencie
 
 ```groovy
      dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:6.2.0"
+         implementation "com.clevertap.android:clevertap-android-sdk:6.2.1"
          implementation "androidx.core:core:1.9.0"
          implementation "com.google.firebase:firebase-messaging:23.0.6"
          implementation "com.google.android.gms:play-services-ads:22.3.0" // Required only if you enable Google ADID collection in the SDK (turned off by default).

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapInstanceConfig.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapInstanceConfig.java
@@ -127,7 +127,6 @@ public class CleverTapInstanceConfig implements Parcelable {
         this.fcmSenderId = config.fcmSenderId;
         this.packageName = config.packageName;
         this.beta = config.beta;
-        this.allowedPushTypes = config.allowedPushTypes;
         this.identityKeys = config.identityKeys;
         this.encryptionLevel = config.encryptionLevel;
     }
@@ -225,10 +224,6 @@ public class CleverTapInstanceConfig implements Parcelable {
             }
             if (configJsonObject.has(Constants.KEY_BETA)) {
                 this.beta = configJsonObject.getBoolean(Constants.KEY_BETA);
-            }
-            if (configJsonObject.has(Constants.KEY_ALLOWED_PUSH_TYPES)) {
-                this.allowedPushTypes = (ArrayList<String>) toList(
-                        configJsonObject.getJSONArray(Constants.KEY_ALLOWED_PUSH_TYPES));
             }
             if (configJsonObject.has(Constants.KEY_IDENTITY_TYPES)) {
                 this.identityKeys = (String[]) toArray(configJsonObject.getJSONArray(Constants.KEY_IDENTITY_TYPES));
@@ -492,7 +487,6 @@ public class CleverTapInstanceConfig implements Parcelable {
             configJsonObject.put(Constants.KEY_ENABLE_CUSTOM_CT_ID, getEnableCustomCleverTapId());
             configJsonObject.put(Constants.KEY_PACKAGE_NAME, getPackageName());
             configJsonObject.put(Constants.KEY_BETA, isBeta());
-            configJsonObject.put(Constants.KEY_ALLOWED_PUSH_TYPES, toJsonArray(allowedPushTypes));
             configJsonObject.put(Constants.KEY_ENCRYPTION_LEVEL , getEncryptionLevel());
             return configJsonObject.toString();
         } catch (Throwable e) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -236,7 +236,6 @@ public interface Constants {
     String KEY_ENABLE_CUSTOM_CT_ID = "getEnableCustomCleverTapId";
     String KEY_BETA = "beta";
     String KEY_PACKAGE_NAME = "packageName";
-    String KEY_ALLOWED_PUSH_TYPES = "allowedPushTypes";
     String KEY_IDENTITY_TYPES = "identityTypes";
     String KEY_ENCRYPTION_LEVEL = "encryptionLevel";
     String KEY_ENCRYPTION_FLAG_STATUS = "encryptionFlagStatus";

--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -1,5 +1,11 @@
 ## CleverTap Android SDK CHANGE LOG
 
+### Version 6.2.1 (April 11, 2024)
+This hotfix release addresses the following issue in `v6.2.0`:
+
+#### Bug Fixes
+* Fixes a crash `IllegalArgumentException` caused by `allowedPushType` XPS enum.
+
 ### Version 6.2.0 (April 3, 2024)
 > ⚠️ **NOTE**
 6.2.0 produces a crash, please update to 6.2.1 and above.

--- a/docs/CTGEOFENCE.md
+++ b/docs/CTGEOFENCE.md
@@ -17,7 +17,7 @@ Add the following dependencies to the `build.gradle`
 
 ```Groovy
 implementation "com.clevertap.android:clevertap-geofence-sdk:1.3.0"
-implementation "com.clevertap.android:clevertap-android-sdk:6.2.0" // 3.9.0 and above
+implementation "com.clevertap.android:clevertap-android-sdk:6.2.1" // 3.9.0 and above
 implementation "com.google.android.gms:play-services-location:21.0.0"
 implementation "androidx.work:work-runtime:2.7.1" // required for FETCH_LAST_LOCATION_PERIODIC
 implementation "androidx.concurrent:concurrent-futures:1.1.0" // required for FETCH_LAST_LOCATION_PERIODIC

--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -21,7 +21,7 @@ CleverTap Push Templates SDK helps you engage with your users using fancy push n
 
 ```groovy
 implementation "com.clevertap.android:push-templates:1.2.3"
-implementation "com.clevertap.android:clevertap-android-sdk:6.2.0" // 4.4.0 and above
+implementation "com.clevertap.android:clevertap-android-sdk:6.2.1" // 4.4.0 and above
 ```
 
 2. Add the following line to your Application class before the `onCreate()`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ coroutines_test = "1.7.3"
 installreferrer = "2.2"
 
 #SDK Versions
-clevertap_android_sdk = "6.2.0"
+clevertap_android_sdk = "6.2.1"
 clevertap_rendermax_sdk = "1.0.3"
 clevertap_geofence_sdk = "1.3.0"
 clevertap_hms_sdk = "1.3.4"

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -1,5 +1,11 @@
 ## CleverTap Android SDK CHANGE LOG
 
+### Version 6.2.1 (April 11, 2024)
+This hotfix release addresses the following issue in `v6.2.0`:
+
+#### Bug Fixes
+* Fixes a crash `IllegalArgumentException` caused by `allowedPushType` XPS enum.
+
 ### Version 6.2.0 (April 3, 2024)
 > ⚠️ **NOTE**
 6.2.0 produces a crash, please update to 6.2.1 and above.


### PR DESCRIPTION
This hotfix release addresses the following issue in `v6.2.0`:

#### Bug Fixes
* Fixes a crash `IllegalArgumentException` caused by `allowedPushType` XPS enum.