### PR TITLE
remove unused notification icon url SDK-3772

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -61,7 +61,6 @@ public interface Constants {
     int DEFINE_VARS_EVENT = 8;
     String variablePayloadType = "varsPayload";
     String WZRK_FETCH = "wzrk_fetch";
-    String ICON_BASE_URL = "http://static.wizrocket.com/android/ico/";
     String NOTIFICATION_CLICKED_EVENT_NAME = "Notification Clicked";
     String NOTIFICATION_VIEWED_EVENT_NAME = "Notification Viewed";
     String SC_OUTGOING_EVENT_NAME = "SCOutgoing";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/NotificationBitmapDownloadRequestHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/NotificationBitmapDownloadRequestHandler.kt
@@ -25,12 +25,6 @@ class NotificationBitmapDownloadRequestHandler(
             )
         }
 
-        // Simply stream the bitmap
-        if (!srcUrl.startsWith("http")) {
-            bitmapDownloadRequest.bitmapPath = "${Constants.ICON_BASE_URL}/$srcUrl"
-        }
-
-
         val downloadedBitmap: DownloadedBitmap = iBitmapDownloadRequestHandler.handleRequest(bitmapDownloadRequest)
 
         return Utils.getDownloadedBitmapPostFallbackIconCheck(fallbackToAppIcon, context, downloadedBitmap)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/Utils.java
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/Utils.java
@@ -63,10 +63,7 @@ public class Utils {
         if (icoPath == null || icoPath.equals("")) {
             return fallbackToAppIcon ? getAppIcon(context) : null;
         }
-        // Simply stream the bitmap
-        if (!icoPath.startsWith("http")) {
-            icoPath = Constants.ICON_BASE_URL + "/" + icoPath;
-        }
+
         Bitmap ic = getBitmapFromURL(icoPath,context);
         return (ic != null) ? ic : ((fallbackToAppIcon) ? getAppIcon(context) : null);
     }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -18,8 +18,8 @@ android {
         applicationId "com.clevertap.demo"
         minSdkVersion 21
         targetSdkVersion 34
-        versionCode 200015
-        versionName "2.0.0-full"
+        versionCode 6020200
+        versionName "6.2.2"
         multiDexEnabled true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -152,13 +152,13 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
     implementation "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.1.1"*/
 
-    remoteImplementation("com.clevertap.android:clevertap-android-sdk:6.2.0")
+    remoteImplementation("com.clevertap.android:clevertap-android-sdk:6.2.1")
     remoteImplementation("com.clevertap.android:clevertap-geofence-sdk:1.3.0")
     //remoteImplementation("com.clevertap.android:clevertap-xiaomi-sdk:1.5.4")
     remoteImplementation("com.clevertap.android:push-templates:1.2.3")
     remoteImplementation("com.clevertap.android:clevertap-hms-sdk:1.3.4")
 
-    stagingImplementation("com.clevertap.android:clevertap-android-sdk:6.2.0")
+    stagingImplementation("com.clevertap.android:clevertap-android-sdk:6.2.1")
     stagingImplementation("com.clevertap.android:clevertap-geofence-sdk:1.3.0")
     //stagingImplementation("com.clevertap.android:clevertap-xiaomi-sdk:1.5.4")
     stagingImplementation("com.clevertap.android:push-templates:1.2.3")


### PR DESCRIPTION
Removed legacy unused notification icon url from core and push templates code base. Url in code was written to fetch notification icon but it's not used anymore.