### PR TITLE
Fix NullPointerException caused during device id fetch SDK-3773

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
@@ -693,7 +693,8 @@ public class DeviceInfo {
     }
 
     public boolean isErrorDeviceId() {
-        return getDeviceID() != null && getDeviceID().startsWith(Constants.ERROR_PROFILE_PREFIX);
+        final String deviceID = getDeviceID();
+        return deviceID != null && deviceID.startsWith(Constants.ERROR_PROFILE_PREFIX);
     }
 
     public boolean isLimitAdTrackingEnabled() {


### PR DESCRIPTION
Calling `getDeviceID()` second time returns null value during AND operation.
This PR fixes it by calling `getDeviceID()` only once and collect it in val for reuse in AND operation.