### PR TITLE
task(MC-1648): Allow map arguments and argument nesting in functions

### DIFF
--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/customtemplates/CustomTemplateContextTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/customtemplates/CustomTemplateContextTest.kt
@@ -76,6 +76,15 @@ class CustomTemplateContextTest {
 
         val innermostMap = templateContext.getMap("map.innerMap.innermostMap")!!
         verifyInnermostMap(notificationVars, innermostMap)
+
+        val functionContext = CustomTemplateContext.createContext(
+            template = functionDefinition,
+            notification = createCtInAppNotification(functionNotificationJson),
+            inAppListener = mockk(),
+            logger = mockk()
+        )
+
+        assertEquals(VARS_OVERRIDE_STRING, functionContext.getMap("map")?.get("string"))
     }
 
     @Test
@@ -234,8 +243,8 @@ class CustomTemplateContextTest {
         mapArgument(
             "map", mapOf(
                 "float" to 15.6.toFloat(),
+                "innerMap.boolean" to false,
                 "innerMap" to mapOf(
-                    "boolean" to false,
                     "string" to "Default",
                     "noOverrideInt" to 15
                 )
@@ -322,6 +331,7 @@ class CustomTemplateContextTest {
                     "byte": $VARS_OVERRIDE_BYTE,
                     "long": $VARS_OVERRIDE_LONG,
                     "double": $VARS_OVERRIDE_DOUBLE,
+                    "map.string": "$VARS_OVERRIDE_STRING",
                     "overrideWithoutDefinitionBoolean": false
                 }
             }
@@ -337,6 +347,11 @@ class CustomTemplateContextTest {
         longArgument("long", 5435050)
         doubleArgument("double", 12.5)
         intArgument("noOverrideInt", 35)
+        mapArgument(
+            "map", mapOf(
+                "string" to "Default"
+            )
+        )
     }
 
     companion object {

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/customtemplates/CustomTemplateTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/customtemplates/CustomTemplateTest.kt
@@ -82,17 +82,6 @@ class CustomTemplateTest {
     }
 
     @Test
-    fun `function builder should throw when arg name contains a dot`() {
-        assertThrows<CustomTemplateException> {
-            function(isVisual = false) {
-                name("function")
-                fileArgument("na.me")
-                presenter(mockFunctionPresenter)
-            }
-        }
-    }
-
-    @Test
     fun `builder should throw when blank argument name is provided`() {
         template {
             name("template")
@@ -146,7 +135,7 @@ class CustomTemplateTest {
     }
 
     @Test
-    fun `builder should throw when name is more than one time`() {
+    fun `builder should throw when name is set more than once`() {
         val name = "template"
         template {
             name(name)
@@ -313,5 +302,24 @@ class CustomTemplateTest {
         }
 
         assertEquals(expectedOrder, template.args.map { it.name })
+    }
+
+    @Test
+    fun `builder should support map keys with dots`() {
+        val expectedArgNames = listOf("e.g.h", "e.j.k.l")
+
+        val template = function(isVisual = false) {
+            name("name")
+            presenter(mockFunctionPresenter)
+            mapArgument(
+                "e",
+                mapOf(
+                    "g.h" to "Text",
+                    "j.k.l" to "Text"
+                )
+            )
+        }
+
+        assertEquals(expectedArgNames, template.args.map { it.name })
     }
 }


### PR DESCRIPTION
Move map argument methods to the base classes CustomTemplateContext and CustomTemplate.Builder