### PR TITLE
task(SDK-3853) - Fixes Stopped/Deleted campaign is not cleared in the SDK in ClientSide mode

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
@@ -216,9 +216,22 @@ inline fun <reified T> JSONArray.iterator(foreach: (element: T) -> Unit) {
  *         The first value of the Pair is `true` if the JSONArray is not null and not empty, `false` otherwise.
  *         The second value of the Pair is the non-empty JSONArray if it exists, or `null` otherwise.
  */
-fun JSONObject.safeGetJSONArray(key: String): Pair<Boolean, JSONArray?> {
+fun JSONObject.safeGetJSONArrayOrNullIfEmpty(key: String): Pair<Boolean, JSONArray?> {
     val list: JSONArray = optJSONArray(key) ?: return Pair(false, null)
     return Pair(list.length() > 0, list.takeIf { it.length() > 0 })
+}
+
+/**
+ * Safely retrieves a JSONArray from the JSONObject using the specified [key].
+ *
+ * @param key The key to retrieve the JSONArray.
+ * @return A [Pair] indicating success and the retrieved JSONArray.
+ *         The first value of the Pair is `true` if the JSONArray is not null, `false` otherwise.
+ *         The second value of the Pair is the non-null JSONArray if it exists, or `null` otherwise.
+ */
+fun JSONObject.safeGetJSONArray(key: String): Pair<Boolean, JSONArray?> {
+    val list: JSONArray = optJSONArray(key) ?: return Pair(false, null)
+    return Pair(list.length() >= 0, list.takeIf { it.length() >= 0 })
 }
 
 /**

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/data/InAppResponseAdapter.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/data/InAppResponseAdapter.kt
@@ -7,6 +7,7 @@ import com.clevertap.android.sdk.inapp.evaluation.LimitAdapter
 import com.clevertap.android.sdk.iterator
 import com.clevertap.android.sdk.orEmptyArray
 import com.clevertap.android.sdk.safeGetJSONArray
+import com.clevertap.android.sdk.safeGetJSONArrayOrNullIfEmpty
 import com.clevertap.android.sdk.toList
 import org.json.JSONArray
 import org.json.JSONObject
@@ -38,13 +39,13 @@ class InAppResponseAdapter(
     val preloadGifs: List<String>
     val preloadAssets: List<String>
 
-    val legacyInApps: Pair<Boolean, JSONArray?> = responseJson.safeGetJSONArray(Constants.INAPP_JSON_RESPONSE_KEY)
+    val legacyInApps: Pair<Boolean, JSONArray?> = responseJson.safeGetJSONArrayOrNullIfEmpty(Constants.INAPP_JSON_RESPONSE_KEY)
 
     val clientSideInApps: Pair<Boolean, JSONArray?> = responseJson.safeGetJSONArray(Constants.INAPP_NOTIFS_KEY_CS)
 
     val serverSideInApps: Pair<Boolean, JSONArray?> = responseJson.safeGetJSONArray(Constants.INAPP_NOTIFS_KEY_SS)
 
-    val appLaunchServerSideInApps: Pair<Boolean, JSONArray?> = responseJson.safeGetJSONArray(Constants.INAPP_NOTIFS_APP_LAUNCHED_KEY)
+    val appLaunchServerSideInApps: Pair<Boolean, JSONArray?> = responseJson.safeGetJSONArrayOrNullIfEmpty(Constants.INAPP_NOTIFS_APP_LAUNCHED_KEY)
 
     init {
         val imageList = mutableListOf<String>()
@@ -103,7 +104,7 @@ class InAppResponseAdapter(
 
     val inAppMode: String = responseJson.optString(Constants.INAPP_DELIVERY_MODE_KEY, "")
 
-    val staleInApps: Pair<Boolean, JSONArray?> = responseJson.safeGetJSONArray(Constants.INAPP_NOTIFS_STALE_KEY)
+    val staleInApps: Pair<Boolean, JSONArray?> = responseJson.safeGetJSONArrayOrNullIfEmpty(Constants.INAPP_NOTIFS_STALE_KEY)
 }
 
 

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/CTXtensionsTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/CTXtensionsTest.kt
@@ -656,6 +656,64 @@ class CTXtensionsTest : BaseTestCase() {
     }
 
     @Test
+    fun `safeGetJSONArrayOrNullIfEmpty returns Pair(true, JSONArray) when key exists and array is not empty`() {
+        // Arrange
+        val jsonObject = JSONObject()
+        val jsonArray = JSONArray().put(1).put(2).put(3)
+        jsonObject.put("key", jsonArray)
+
+        // Act
+        val result = jsonObject.safeGetJSONArrayOrNullIfEmpty("key")
+
+        // Assert
+        assertTrue(result.first)
+        assertEquals(jsonArray.toString(), result.second.toString())
+    }
+
+    @Test
+    fun `safeGetJSONArrayOrNullIfEmpty returns Pair(false, null) when key exists but array is empty`() {
+        // Arrange
+        val jsonObject = JSONObject()
+        val jsonArray = JSONArray()
+        jsonObject.put("key", jsonArray)
+
+        // Act
+        val result = jsonObject.safeGetJSONArrayOrNullIfEmpty("key")
+
+        // Assert
+        assertFalse(result.first)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `safeGetJSONArrayOrNullIfEmpty returns Pair(false, null) when key does not exist`() {
+        // Arrange
+        val jsonObject = JSONObject()
+        jsonObject.put("anotherKey", "value")
+
+        // Act
+        val result = jsonObject.safeGetJSONArrayOrNullIfEmpty("key")
+
+        // Assert
+        assertFalse(result.first)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `safeGetJSONArrayOrNullIfEmpty returns Pair(false, null) when key's value is not a JSON array`() {
+        // Arrange
+        val jsonObject = JSONObject()
+        jsonObject.put("key", "not_an_array")
+
+        // Act
+        val result = jsonObject.safeGetJSONArrayOrNullIfEmpty("key")
+
+        // Assert
+        assertFalse(result.first)
+        assertNull(result.second)
+    }
+
+    @Test
     fun `safeGetJSONArray returns Pair(true, JSONArray) when key exists and array is not empty`() {
         // Arrange
         val jsonObject = JSONObject()
@@ -671,7 +729,7 @@ class CTXtensionsTest : BaseTestCase() {
     }
 
     @Test
-    fun `safeGetJSONArray returns Pair(false, null) when key exists but array is empty`() {
+    fun `safeGetJSONArray returns Pair(true, empty JSONArray()) when key exists but array is empty`() {
         // Arrange
         val jsonObject = JSONObject()
         val jsonArray = JSONArray()
@@ -681,8 +739,8 @@ class CTXtensionsTest : BaseTestCase() {
         val result = jsonObject.safeGetJSONArray("key")
 
         // Assert
-        assertFalse(result.first)
-        assertNull(result.second)
+        assertTrue(result.first)
+        assertEquals(0, result.second?.length())
     }
 
     @Test


### PR DESCRIPTION
https://wizrocket.atlassian.net/browse/SDK-3853

Fix 
- Even when an empty JSoN array is received in response for `inapp_notifs_cs`, save it 
- Same is done for `inapp_notifs_ss`  for clarity even though it will not cause any issue previously