### PR TITLE
task(SDK-3780) - Fix misleading logs for exoplayer

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/VideoLibChecker.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/VideoLibChecker.kt
@@ -2,7 +2,6 @@ package com.clevertap.android.sdk.video
 
 import com.clevertap.android.sdk.Logger
 
-// todo check logs which get printed if methods fail detecing media stream libs
 internal object VideoLibChecker {
 
     private val hasExoplayer = checkForExoPlayer()
@@ -27,7 +26,7 @@ internal object VideoLibChecker {
     /**
      * Method to check whether app has either ExoPlayer or Media3 dependencies
      *
-     * @return boolean - true/false depending on app's availability of ExoPlayer dependencies
+     * @return boolean - true/false depending on app's availability of either ExoPlayer or Media3 dependencies
      */
     private fun checkForVideoPlayerSupport(): Boolean {
         if (!hasMedia3 && !hasExoplayer)
@@ -41,38 +40,50 @@ internal object VideoLibChecker {
      * @return boolean - true/false depending on app's availability of ExoPlayer dependencies
      */
     private fun checkForExoPlayer(): Boolean {
-        var exoPlayerPresent = false
-        var className: Class<*>? = null
-        try {
-            className = Class.forName("com.google.android.exoplayer2.ExoPlayer")
-            className = Class.forName("com.google.android.exoplayer2.source.hls.HlsMediaSource")
-            className = Class.forName("com.google.android.exoplayer2.ui.StyledPlayerView")
-            Logger.d("ExoPlayer is present")
-            exoPlayerPresent = true
-        } catch (t: Throwable) {
-            Logger.d("ExoPlayer library files are missing!!!")
+        val requiredExoplayerClassNames = listOf(
+            "com.google.android.exoplayer2.ExoPlayer",
+            "com.google.android.exoplayer2.source.hls.HlsMediaSource",
+            "com.google.android.exoplayer2.ui.StyledPlayerView"
+        )
+
+        for (className in requiredExoplayerClassNames) {
+            try {
+                Class.forName(className)
+            } catch (t: Throwable) {
+                Logger.d("$className is missing!!!")
+                Logger.d("One or more ExoPlayer library files are missing!!!")
+                return false
+            }
         }
-        return exoPlayerPresent
+
+        Logger.d("ExoPlayer is present")
+        return true
     }
 
     /**
      * Method to check whether app has Media3 dependencies
      *
-     * @return boolean - true/false depending on app's availability of ExoPlayer dependencies
+     * @return boolean - true/false depending on app's availability of Media3 dependencies
      */
     private fun checkForMedia3(): Boolean {
-        var media3ExoplayerPresent = false
-        var className: Class<*>? = null
-        try {
-            className = Class.forName("androidx.media3.exoplayer.ExoPlayer")
-            className = Class.forName("androidx.media3.exoplayer.hls.HlsMediaSource")
-            className = Class.forName("androidx.media3.ui.PlayerView")
-            Logger.d("Media3 is present")
-            media3ExoplayerPresent = true
-        } catch (t: Throwable) {
-            Logger.d("Media3 library files are missing!!!")
+        val requiredMedia3ClassNames = listOf(
+            "androidx.media3.exoplayer.ExoPlayer",
+            "androidx.media3.exoplayer.hls.HlsMediaSource",
+            "androidx.media3.ui.PlayerView"
+        )
+
+        for (className in requiredMedia3ClassNames) {
+            try {
+                Class.forName(className)
+            } catch (t: Throwable) {
+                Logger.d("$className is missing!!!")
+                Logger.d("One or more Media3 library files are missing!!!")
+                return false
+            }
         }
-        return media3ExoplayerPresent
+
+        Logger.d("Media3 is present")
+        return true
     }
 }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/VideoLibChecker.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/VideoLibChecker.kt
@@ -9,7 +9,7 @@ internal object VideoLibChecker {
     private val hasMedia3 = checkForMedia3()
 
     @JvmField
-    val haveVideoPlayerSupport = hasExoplayer || hasMedia3
+    val haveVideoPlayerSupport = checkForVideoPlayerSupport()
 
     @JvmField
     val mediaLibType = when {
@@ -22,6 +22,17 @@ internal object VideoLibChecker {
         else -> {
             VideoLibraryIntegrated.NONE
         }
+    }
+
+    /**
+     * Method to check whether app has either ExoPlayer or Media3 dependencies
+     *
+     * @return boolean - true/false depending on app's availability of ExoPlayer dependencies
+     */
+    private fun checkForVideoPlayerSupport(): Boolean {
+        if (!hasMedia3 && !hasExoplayer)
+            Logger.d("Please add ExoPlayer/Media3 dependencies to render InApp or Inbox messages playing video. For more information checkout CleverTap documentation.")
+        return hasExoplayer || hasMedia3
     }
 
     /**
@@ -40,16 +51,15 @@ internal object VideoLibChecker {
             exoPlayerPresent = true
         } catch (t: Throwable) {
             Logger.d("ExoPlayer library files are missing!!!")
-            Logger.d("Please add ExoPlayer dependencies to render InApp or Inbox messages playing video. For more information checkout CleverTap documentation.")
-            if (className != null) {
-                Logger.d("ExoPlayer classes not found " + className.getName())
-            } else {
-                Logger.d("ExoPlayer classes not found")
-            }
         }
         return exoPlayerPresent
     }
 
+    /**
+     * Method to check whether app has Media3 dependencies
+     *
+     * @return boolean - true/false depending on app's availability of ExoPlayer dependencies
+     */
     private fun checkForMedia3(): Boolean {
         var media3ExoplayerPresent = false
         var className: Class<*>? = null
@@ -57,16 +67,10 @@ internal object VideoLibChecker {
             className = Class.forName("androidx.media3.exoplayer.ExoPlayer")
             className = Class.forName("androidx.media3.exoplayer.hls.HlsMediaSource")
             className = Class.forName("androidx.media3.ui.PlayerView")
-            Logger.d("ExoPlayer from Media3 is present")
+            Logger.d("Media3 is present")
             media3ExoplayerPresent = true
         } catch (t: Throwable) {
-            Logger.d("Media3 ExoPlayer library files are missing!!!")
-            Logger.d("Please add ExoPlayer dependencies to render InApp or Inbox messages playing video. For more information checkout CleverTap documentation.")
-            if (className != null) {
-                Logger.d("ExoPlayer classes not found " + className.getName())
-            } else {
-                Logger.d("ExoPlayer classes not found")
-            }
+            Logger.d("Media3 library files are missing!!!")
         }
         return media3ExoplayerPresent
     }


### PR DESCRIPTION
- Improves redundant logs
- Earlier `Logger.d("ExoPlayer classes not found " + className.getName())` printed not found for incorrect class. This was fixed as well
