### PR TITLE
Feat(SDK-3936): Handles failure in fetch asset api

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -74,6 +74,7 @@ import com.clevertap.android.sdk.variables.CTVariableUtils;
 import com.clevertap.android.sdk.variables.Var;
 import com.clevertap.android.sdk.variables.callbacks.FetchVariablesCallback;
 import com.clevertap.android.sdk.variables.callbacks.VariablesChangedCallback;
+import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.firebase.messaging.FirebaseMessaging;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -1616,21 +1617,23 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
             FirebaseMessaging
                     .getInstance()
                     .getToken()
-                    .addOnCompleteListener
-                            (task -> {
-                                if (!task.isSuccessful()) {
-                                    Logger.v(LOG_TAG,
-                                            FCM_LOG_TAG + "FCM token using googleservices.json failed",
-                                            task.getException());
-                                    requestTokenListener.onDevicePushToken(null, FCM);
-                                    return;
-                                }
-                                String token = task.getResult() != null ? task.getResult() : null;
+                    .addOnCompleteListener(new OnCompleteListener<String>() {
+                        @Override
+                        public void onComplete(@NonNull com.google.android.gms.tasks.Task<String> task) {
+                            if (!task.isSuccessful()) {
                                 Logger.v(LOG_TAG,
-                                        FCM_LOG_TAG + "FCM token using googleservices.json - " + token);
-                                requestTokenListener.onDevicePushToken(token, FCM);
+                                        FCM_LOG_TAG + "FCM token using googleservices.json failed",
+                                        task.getException());
+                                requestTokenListener.onDevicePushToken(null, FCM);
+                                return;
                             }
-                            );
+                            String token = task.getResult() != null ? task.getResult() : null;
+                            Logger.v(LOG_TAG,
+                                    FCM_LOG_TAG + "FCM token using googleservices.json - " + token);
+                            requestTokenListener.onDevicePushToken(token, FCM);
+                        }
+                    });
+
         } catch (Throwable t) {
             Logger.v(LOG_TAG, FCM_LOG_TAG + "Error requesting FCM token", t);
             requestTokenListener.onDevicePushToken(null, FCM);

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/images/FileResourceProviderTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/images/FileResourceProviderTest.kt
@@ -222,7 +222,6 @@ class FileResourceProviderTest {
 
     @Test
     fun `fetchFile does not caches file if it doesn't exist in cache and api call fails as well`() {
-        val mockSavedFile = mockk<File>()
         val url = "https://example.com/document.pdf"
         val downloadFailed = DownloadedBitmap(
             bitmap = null, // Files don't have Bitmaps

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/images/FileResourceProviderTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/images/FileResourceProviderTest.kt
@@ -199,7 +199,7 @@ class FileResourceProviderTest {
     fun `fetchFile fetches and caches file if not cached`() {
         val mockSavedFile = mockk<File>()
         val url = "https://example.com/document.pdf"
-        val mockDownloadedFile = DownloadedBitmap(
+        val downloadSuccess = DownloadedBitmap(
             bitmap = null, // Files don't have Bitmaps
             status = DownloadedBitmap.Status.SUCCESS,
             downloadTime = 0L,
@@ -209,15 +209,36 @@ class FileResourceProviderTest {
             every { it.fetchInMemoryAndTransform(url, MemoryDataTransformationType.ToByteArray) } returns null
             every { it.fetchDiskMemoryAndTransform(url, MemoryDataTransformationType.ToByteArray) } returns null
         }
-        every { mockFileFetchApi.makeApiCallForFile(Pair(url, CtCacheType.FILES)) } returns mockDownloadedFile
+        every { mockFileFetchApi.makeApiCallForFile(Pair(url, CtCacheType.FILES)) } returns downloadSuccess
         every { mockFileMAO.saveDiskMemory(url, any()) } returns mockSavedFile
         every { mockFileMAO.saveInMemory(url, any()) } returns true
 
         val result = fileResourceProvider.fetchFile(url)
 
-        assertEquals(mockDownloadedFile.bytes, result) // Verify file was fetched
-        verify { mockFileMAO.saveDiskMemory(url, mockDownloadedFile.bytes!!) }
-        verify { mockFileMAO.saveInMemory(url, Pair(mockDownloadedFile.bytes!!, mockSavedFile)) } // Verify caching
+        assertEquals(downloadSuccess.bytes, result) // Verify file was fetched
+        verify { mockFileMAO.saveDiskMemory(url, downloadSuccess.bytes!!) }
+        verify { mockFileMAO.saveInMemory(url, Pair(downloadSuccess.bytes!!, mockSavedFile)) } // Verify caching
+    }
+
+    @Test
+    fun `fetchFile does not caches file if it doesn't exist in cache and api call fails as well`() {
+        val mockSavedFile = mockk<File>()
+        val url = "https://example.com/document.pdf"
+        val downloadFailed = DownloadedBitmap(
+            bitmap = null, // Files don't have Bitmaps
+            status = DownloadedBitmap.Status.DOWNLOAD_FAILED,
+            downloadTime = 0L,
+            bytes = null
+        )
+        mapOfMAO[FILES]!!.forEach {
+            every { it.fetchInMemoryAndTransform(url, MemoryDataTransformationType.ToByteArray) } returns null
+            every { it.fetchDiskMemoryAndTransform(url, MemoryDataTransformationType.ToByteArray) } returns null
+        }
+        every { mockFileFetchApi.makeApiCallForFile(Pair(url, CtCacheType.FILES)) } returns downloadFailed
+
+        val result = fileResourceProvider.fetchFile(url)
+
+        assertEquals(expected = null, actual = result) // Verify file was null
     }
 
     @Test

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/images/preload/FilePreloaderCoroutineTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/images/preload/FilePreloaderCoroutineTest.kt
@@ -207,6 +207,84 @@ class FilePreloaderCoroutineTest {
         assertEquals(listOf("p", "q", "r"), startedUrls)
         assertEquals(mapOf("p" to true, "q" to false, "r" to true), finishedStatus)
     }
+
+    @Test
+    fun `check results in case of timeout along with failures`() = testScheduler.run {
+
+        // Prepare data - setup, Given :
+        val filePreloaderCoroutineWithTimeout = FilePreloaderCoroutine(
+            fileResourceProvider = mFileResourceProvider,
+            logger = logger,
+            dispatchers = dispatchers,
+            timeoutForPreload = 100 // 100ms
+        )
+
+        val filesList = buildList {
+            add("p" to CtCacheType.FILES)
+            add("q" to CtCacheType.FILES)
+            add("r" to CtCacheType.FILES)
+        }
+
+        val imagesList = buildList {
+            add("a" to CtCacheType.IMAGE)
+            add("b" to CtCacheType.IMAGE)
+            add("c" to CtCacheType.IMAGE)
+        }
+
+        val gifsList = buildList {
+            add("m" to CtCacheType.GIF)
+            add("n" to CtCacheType.GIF)
+            add("o" to CtCacheType.GIF)
+        }
+
+        val urls = filesList + imagesList + gifsList
+
+        val finishedStatus = mutableMapOf<String, Boolean>()
+
+        every { mFileResourceProvider.fetchFile("p") } returns byteArray
+        every { mFileResourceProvider.fetchFile("q") } returns byteArray
+        every { mFileResourceProvider.fetchFile("r") } returns null // Simulate failure for "r"
+        every { mFileResourceProvider.fetchInAppImageV1("a") } returns mockBitmap
+        every { mFileResourceProvider.fetchInAppImageV1("b") } returns mockBitmap
+        every { mFileResourceProvider.fetchInAppImageV1("c") } returns null
+        every { mFileResourceProvider.fetchInAppGifV1("m") } returns byteArray
+        every { mFileResourceProvider.fetchInAppGifV1("n") } returns byteArray
+        every { mFileResourceProvider.fetchInAppGifV1("o") } returns null
+
+        val successfulExpected = mutableSetOf("p", "q", "a", "b", "m", "n") // expected success
+        val failedExpected = mutableSetOf("c", "r", "o") // expected failures
+        val startedExpected = mutableSetOf("p", "q", "r", "a", "b", "c", "m", "n", "o")
+        val finishedExpected = mapOf(
+            "p" to true,
+            "q" to true,
+            "r" to false,
+            "a" to true,
+            "b" to true,
+            "c" to false,
+            "m" to true,
+            "n" to true,
+            "o" to false,
+        ) // expected final map of statuses
+
+        // Function to test :
+        filePreloaderCoroutineWithTimeout.preloadFilesAndCache(
+            urlMetas = urls,
+            successBlock = { url -> successfulExpected.remove(url.first) },
+            failureBlock = { url -> failedExpected.remove(url.first) },
+            startedBlock = { url -> startedExpected.remove(url.first) },
+            preloadFinished = { status -> finishedStatus.putAll(status) }
+        )
+        advanceUntilIdle()
+
+        // Assertions :
+        assertEquals(expected = 0, actual = successfulExpected.size)
+        assertEquals(expected = 0, actual = failedExpected.size)
+        assertEquals(expected = 0, actual = startedExpected.size)
+        assertEquals(
+            expected = finishedExpected,
+            actual = finishedStatus
+        )
+    }
 }
 
 class MainDispatcherRule @OptIn(ExperimentalCoroutinesApi::class) constructor(


### PR DESCRIPTION
Jira: https://wizrocket.atlassian.net/browse/SDK-3936

- avoids crash cause we checked success status of api before forcing bytes/bitmap from response
- checks for api http status were missing
- adds test cases to validate the failure cases and correctness of responses for succ/failure