### PR TITLE
fix(MC-1881): Fix NPE for Context in in-app dismiss

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -195,7 +195,6 @@ public final class InAppNotificationActivity extends FragmentActivity implements
 
     @Override
     public void inAppNotificationDidDismiss(
-            @NonNull final Context context,
             @NonNull final CTInAppNotification inAppNotification,
             @Nullable Bundle formData) {
         didDismiss(formData);
@@ -270,8 +269,8 @@ public final class InAppNotificationActivity extends FragmentActivity implements
         }
         finish();
         InAppListener listener = getListener();
-        if (listener != null && getBaseContext() != null && inAppNotification != null) {
-            listener.inAppNotificationDidDismiss(getBaseContext(), inAppNotification, data);
+        if (listener != null && inAppNotification != null) {
+            listener.inAppNotificationDidDismiss(inAppNotification, data);
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppBaseFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppBaseFragment.java
@@ -111,8 +111,8 @@ public abstract class CTInAppBaseFragment extends Fragment {
     public void didDismiss(Bundle data) {
         cleanup();
         InAppListener listener = getListener();
-        if (listener != null && getActivity() != null && getActivity().getBaseContext() != null) {
-            listener.inAppNotificationDidDismiss(getActivity().getBaseContext(), inAppNotification, data);
+        if (listener != null) {
+            listener.inAppNotificationDidDismiss(inAppNotification, data);
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.java
@@ -289,7 +289,7 @@ public class InAppController implements InAppListener,
                 mainLooperHandler.postDelayed(mainLooperHandler.getPendingRunnable(), 200);
                 mainLooperHandler.setPendingRunnable(null);
             } else {
-                showNotificationIfAvailable(context);
+                showNotificationIfAvailable();
             }
         } else {
             Logger.d("In-app notifications will not be shown for this activity ("
@@ -460,7 +460,7 @@ public class InAppController implements InAppListener,
     }
 
     @Override
-    public void inAppNotificationDidDismiss(@Nullable final Context context,
+    public void inAppNotificationDidDismiss(
             @NonNull final CTInAppNotification inAppNotification,
             @Nullable final Bundle formData) {
         inAppNotification.didDismiss(resourceProvider);
@@ -504,7 +504,7 @@ public class InAppController implements InAppListener,
             @Override
             public Void call() {
                 inAppDidDismiss(context, config, inAppNotification, InAppController.this);
-                _showNotificationIfAvailable(context);
+                _showNotificationIfAvailable();
                 return null;
             }
         });
@@ -586,7 +586,7 @@ public class InAppController implements InAppListener,
             inAppQueue.enqueueAll(filteredNotifs);
 
             // Fire the first notification, if any
-            showNotificationIfAvailable(context);
+            showNotificationIfAvailable();
         } catch (Exception e) {
             logger.debug(config.getAccountId(), "InAppController: : InApp notification handling error: " + e.getMessage());
         }
@@ -594,13 +594,13 @@ public class InAppController implements InAppListener,
 
 
     //InApp
-    public void showNotificationIfAvailable(final Context context) {
+    public void showNotificationIfAvailable() {
         if (!config.isAnalyticsOnly()) {
             Task<Void> task = CTExecutorFactory.executors(config).postAsyncSafelyTask(Constants.TAG_FEATURE_IN_APPS);
             task.execute("InappController#showNotificationIfAvailable", new Callable<Void>() {
                 @Override
                 public Void call() {
-                    _showNotificationIfAvailable(context);
+                    _showNotificationIfAvailable();
                     return null;
                 }
             });
@@ -613,7 +613,7 @@ public class InAppController implements InAppListener,
     }
 
     //InApp
-    private void _showNotificationIfAvailable(Context context) {
+    private void _showNotificationIfAvailable() {
         try {
             if (!canShowInAppOnActivity()) {
                 Logger.v("Not showing notification on blacklisted activity");
@@ -650,7 +650,7 @@ public class InAppController implements InAppListener,
             return;
         }
         inAppQueue.insertInFront(inApp);
-        showNotificationIfAvailable(context);
+        showNotificationIfAvailable();
     }
 
     private boolean canShowInAppOnActivity() {
@@ -745,7 +745,7 @@ public class InAppController implements InAppListener,
             task.execute("InAppController#showInAppNotificationIfAny", new Callable<Void>() {
                 @Override
                 public Void call() {
-                    _showNotificationIfAvailable(context);
+                    _showNotificationIfAvailable();
                     return null;
                 }
             });
@@ -772,7 +772,7 @@ public class InAppController implements InAppListener,
     }
 
     private static void checkPendingNotifications(
-            final Context context,
+            @NonNull final Context context,
             final CleverTapInstanceConfig config,
             final InAppController inAppController
     ) {
@@ -796,7 +796,7 @@ public class InAppController implements InAppListener,
 
     //InApp
     private static void inAppDidDismiss(
-            Context context,
+            @NonNull Context context,
             CleverTapInstanceConfig config,
             CTInAppNotification inAppNotification,
             InAppController inAppController
@@ -826,7 +826,7 @@ public class InAppController implements InAppListener,
 
     //InApp
     private static void showInApp(
-            Context context,
+            @NonNull Context context,
             final CTInAppNotification inAppNotification,
             CleverTapInstanceConfig config,
             InAppController inAppController

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppListener.kt
@@ -11,7 +11,7 @@ internal interface InAppListener {
         activityContext: Context?
     ): Bundle?
 
-    fun inAppNotificationDidDismiss(context: Context?, inAppNotification: CTInAppNotification, formData: Bundle?)
+    fun inAppNotificationDidDismiss(inAppNotification: CTInAppNotification, formData: Bundle?)
     fun inAppNotificationDidShow(inAppNotification: CTInAppNotification, formData: Bundle?)
     fun inAppNotificationActionTriggered(
         inAppNotification: CTInAppNotification,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/customtemplates/CustomTemplateContext.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/customtemplates/CustomTemplateContext.kt
@@ -227,7 +227,7 @@ sealed class CustomTemplateContext private constructor(
 
         val listener = inAppListenerRef.get()
         if (listener != null) {
-            listener.inAppNotificationDidDismiss(null, notification, null)
+            listener.inAppNotificationDidDismiss(notification, null)
         } else {
             logger.debug("CustomTemplates", "Cannot set template as dismissed")
         }


### PR DESCRIPTION
Remove redundant Context argument from inAppNotificationDidDismiss and use the Context of InAppController every time.