### PR TITLE
bug(MC-2299): Fix c2a param not tracked for open_url and close actions

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -446,4 +446,5 @@ public interface Constants {
 
    String FLUSH_PUSH_IMPRESSIONS_ONE_TIME_WORKER_NAME = "CTFlushPushImpressionsOneTime";
 
+    String URL_PARAM_DL_SEPARATOR = "__dl__";
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppBaseFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppBaseFragment.java
@@ -91,7 +91,7 @@ public abstract class CTInAppBaseFragment extends Fragment {
 
             String callToAction = formData.getString(Constants.KEY_C2A);
             if (callToAction != null) {
-                final String[] parts = callToAction.split("__dl__");
+                final String[] parts = callToAction.split(Constants.URL_PARAM_DL_SEPARATOR);
                 if (parts.length == 2) {
                     // Decode it here as wzrk_c2a is not decoded by UriHelper
                     callToAction = URLDecoder.decode(parts[0], "UTF-8");

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppBaseFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppBaseFragment.java
@@ -89,13 +89,13 @@ public abstract class CTInAppBaseFragment extends Fragment {
         try {
             final Bundle formData = UriHelper.getAllKeyValuePairs(url, false);
 
-            String actionParts = formData.getString(Constants.KEY_C2A);
-            String callToAction = null;
-            if (actionParts != null) {
-                final String[] parts = actionParts.split("__dl__");
+            String callToAction = formData.getString(Constants.KEY_C2A);
+            if (callToAction != null) {
+                final String[] parts = callToAction.split("__dl__");
                 if (parts.length == 2) {
                     // Decode it here as wzrk_c2a is not decoded by UriHelper
                     callToAction = URLDecoder.decode(parts[0], "UTF-8");
+                    formData.putString(Constants.KEY_C2A, callToAction);
                     url = parts[1];
                 }
             }


### PR DESCRIPTION
This fixes tracking callToAction if it exists as a parameter to the links opened from the in-apps webview. There is also a frontend fix directly in the in-app HTML, that would use triggerAction instead of opening links. 