### PR TITLE
feat(SDK-4183): changes normalisation to follow LP logic

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EventAdapter.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EventAdapter.kt
@@ -34,7 +34,7 @@ class EventAdapter(
     val profileAttrName: String? = null // for profile events only
 ) {
 
-    private val systemPropToKey = mapOf(
+    internal val systemPropToKey = mapOf(
         "CT App Version" to CLTAP_APP_VERSION,
         "ct_app_version" to CLTAP_APP_VERSION,
         "CT Latitude" to CLTAP_LATITUDE,


### PR DESCRIPTION
- makes changes to event names and properties and also to charged event logic
- tries exact name match first
- tries match with normalised event name
- tries match after normalising both event name/property and triggers we get from BE