### PR TITLE
Add minor optimiziations to UserEventLog operations

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/LocalDataStore.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/LocalDataStore.java
@@ -56,7 +56,7 @@ public class LocalDataStore {
     private final String eventNamespace = "local_events";
 
     private final DeviceInfo deviceInfo;
-    private final Set<String> userEventLogKeys = Collections.synchronizedSet(new HashSet<>());
+    private final Set<String> userNormalizedEventLogKeys = Collections.synchronizedSet(new HashSet<>());
     private final Map<String, String> normalizedEventNames = new HashMap<>();
 
     LocalDataStore(Context context, CleverTapInstanceConfig config, CryptHandler cryptHandler, DeviceInfo deviceInfo, BaseDatabaseManager baseDatabaseManager) {
@@ -70,7 +70,7 @@ public class LocalDataStore {
 
     @WorkerThread
     public void changeUser() {
-        userEventLogKeys.clear();
+        userNormalizedEventLogKeys.clear();
         resetLocalProfileSync();
     }
 
@@ -273,16 +273,15 @@ public class LocalDataStore {
 
     @WorkerThread
     public boolean isUserEventLogFirstTime(String eventName) {
-        if (userEventLogKeys.contains(eventName)) {
+        String normalizedEventName = getOrPutNormalizedEventName(eventName);
+        if (userNormalizedEventLogKeys.contains(normalizedEventName)) {
             return false;
         }
 
         String deviceID = deviceInfo.getDeviceID();
-        String normalizedEventName = getOrPutNormalizedEventName(eventName);
-
         int count = readEventCountByDeviceIdAndNormalizedEventName(deviceID, normalizedEventName);
         if (count > 1) {
-            userEventLogKeys.add(eventName);
+            userNormalizedEventLogKeys.add(normalizedEventName);
         }
         return count == 1;
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/db/CtDatabase.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/db/CtDatabase.kt
@@ -235,13 +235,13 @@ private val CREATE_EVENTS_TABLE = """
 
 private val CREATE_USER_EVENT_LOGS_TABLE = """
     CREATE TABLE ${Table.USER_EVENT_LOGS_TABLE.tableName} (
+        ${Column.DEVICE_ID} STRING NOT NULL,
         ${Column.EVENT_NAME} STRING NOT NULL,
         ${Column.NORMALIZED_EVENT_NAME} STRING NOT NULL,
         ${Column.FIRST_TS} INTEGER NOT NULL,
         ${Column.LAST_TS} INTEGER NOT NULL,
         ${Column.COUNT} INTEGER NOT NULL,
-        ${Column.DEVICE_ID} STRING NOT NULL,
-        PRIMARY KEY (${Column.NORMALIZED_EVENT_NAME}, ${Column.DEVICE_ID})
+        PRIMARY KEY (${Column.DEVICE_ID}, ${Column.NORMALIZED_EVENT_NAME})
     );
 """
 


### PR DESCRIPTION
Change the cached user event log keys set to contain the normalized event names to match the db logic Reorder deviceID column in the primary key of UserEventLog table to speed up allEventsByDeviceID query