### PR TITLE
fix(ss_inapps) - fix in-app id data type conversion from Int to Long fo SS in-apps SDK-4246

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManager.kt
@@ -555,7 +555,15 @@ internal class EvaluationManager(
     @WorkerThread
     fun loadSuppressedCSAndEvaluatedSSInAppsIds() {
         storeRegistry.inAppStore?.let { store ->
-            evaluatedServerSideCampaignIds.putAll(JsonUtil.mapFromJson(store.readEvaluatedServerSideInAppIds()))
+            // store.readEvaluatedServerSideInAppIds() returns list of Int or Long as InApp IDs
+            val evaluatedSSInAppIdsMap =
+                JsonUtil.mapFromJson<MutableList<Number>>(store.readEvaluatedServerSideInAppIds())
+            // forcefully convert list of InApp IDs to Long as evaluatedServerSideCampaignIds expects Long
+            val evaluatedSsInAppIdsMapWithLongList =
+                evaluatedSSInAppIdsMap.mapValues { entry ->
+                    entry.value.map { number -> number.toLong() }.toMutableList()
+                }
+            evaluatedServerSideCampaignIds.putAll(evaluatedSsInAppIdsMapWithLongList)
             suppressedClientSideInApps.putAll(JsonUtil.mapFromJson(store.readSuppressedClientSideInAppIds()))
         }
     }


### PR DESCRIPTION
Issue happened in below code

    fun loadSuppressedCSAndEvaluatedSSInAppsIds() {
        storeRegistry.inAppStore?.let { store ->
            evaluatedServerSideCampaignIds.putAll(JsonUtil.mapFromJson(store.readEvaluatedServerSideInAppIds()))
            suppressedClientSideInApps.putAll(JsonUtil.mapFromJson(store.readSuppressedClientSideInAppIds()))
        }
    }

1. `store.readEvaluatedServerSideInAppIds()` returns in-app Ids as `Int` instead of `Long` and `evaluatedServerSideCampaignIds` expects in-app Ids as `Long` 
2. Below` 7.2.0` it was working as expected but in `7.2.0` we bumped kotlin version to `2.0.10` which caused an issue.
3. Kotlin created strict rule regarding `Int` and `Long` comparison inside lambda. Basically it’s not allowed to compare `Int` with `Long` in lambda from `1.8.0` onwards. 
    - https://youtrack.jetbrains.com/issue/KTLC-177/NI-False-negative-no-compilation-error-Operator-cannot-be-applied-to-Long-and-Int-is-reported-in-builder-inference-lambdas

     - https://kotlinlang.org/docs/compatibility-guide-18.html#prohibit-using-operator-on-incompatible-numeric-types-in-builder-inference-context 

`store.readEvaluatedServerSideInAppIds()` reads in-app Ids from shared preference as a `String`  and converts it to `JSONObject` using `new JSONObject(string from SP)` . `JSONObject` internally converts in-app id to `Int` instead of `Long` which is the root cause. However nothing can be done here as thats how JSONObject works.

Solution implemented as below:

1. in-app ids will always be a number in `JSONObject`, so consider it as a `Number` 
2. Convert `JSONObject` to a `Map`. `evaluatedServerSideCampaignIds` has generic type declared as `<String,MutableList<Long>>` but at runtime type is erased and hence during conversion `MutableList` contains an `Int`
3. Now covert all `Int`s in `MutableList` to `Long`s and proceed as before.

**Note** 
As per BE contract in-app ids must be passed as numeric and not text hence we are not making any changes to `MutableList` type here. Also `loadSuppressedCSAndEvaluatedSSInAppsIds()` method called only once in a session, during CT instance creation, hence there won't be much performance impact of `Int` to `Long` conversion.

