### PR TITLE
Remove unused didDismiss() from InAppFCManager SDK-3591

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppFCManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppFCManager.java
@@ -102,10 +102,6 @@ public class InAppFCManager {
         init(deviceId);
     }
 
-    public void didDismiss(CTInAppNotification inapp) {
-        // NO-OP
-    }
-
     public void didShow(final Context context, CTInAppNotification inapp) {
         final String id = getInAppID(inapp);
         if (id == null) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.java
@@ -466,7 +466,6 @@ public class InAppController implements InAppListener,
         inAppNotification.didDismiss(resourceProvider);
 
         if (controllerManager.getInAppFCManager() != null) {
-            controllerManager.getInAppFCManager().didDismiss(inAppNotification);
             String templateName = inAppNotification.getCustomTemplateData() != null
                     ? inAppNotification.getCustomTemplateData().getTemplateName() : "";
             logger.verbose(config.getAccountId(),


### PR DESCRIPTION
Removes unused `didDismiss()` from `InAppFCManager`.
Before `didDismiss()` became NO-OP, it was used for tracking in-apps shown in a session.
```    public void didDismiss(CTInAppNotification inapp) {
        final Object id = inapp.getId();
        if (id != null) {
            mDismissedThisSession.add(id.toString());
        }
    }
```
However later on we replaced this entire logic with `ImpressionManager` class and `didDismiss()` kept as a NO-OP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the in-app notification dismissal process by removing unnecessary processing steps while maintaining the logging of dismissal events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->