### PR TITLE
Release 7.1.2 SKD-4348

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGE LOG.
 
+### January 29, 2025
+* [CleverTap Android SDK v7.1.2](docs/CTCORECHANGELOG.md)
+
 ### January 24, 2025
 * [CleverTap Android SDK v7.1.1](docs/CTCORECHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We publish the SDK to `mavenCentral` as an `AAR` file. Just declare it as depend
 
 ```groovy
     dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:7.1.1"
+         implementation "com.clevertap.android:clevertap-android-sdk:7.1.2"
     }
 ```
 
@@ -34,7 +34,7 @@ Alternatively, you can download and add the AAR file included in this repo in yo
     
  ```groovy
     dependencies {      
-        implementation (name: "clevertap-android-sdk-7.1.1", ext: 'aar')
+        implementation (name: "clevertap-android-sdk-7.1.2", ext: 'aar')
     }
 ```
 
@@ -46,7 +46,7 @@ Add the Firebase Messaging library and Android Support Library v4 as dependencie
 
 ```groovy
      dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:7.1.1"
+         implementation "com.clevertap.android:clevertap-android-sdk:7.1.2"
          implementation "androidx.core:core:1.9.0"
          implementation "com.google.firebase:firebase-messaging:23.0.6"
          implementation "com.google.android.gms:play-services-ads:23.6.0" // Required only if you enable Google ADID collection in the SDK (turned off by default).

--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -1,5 +1,8 @@
 ## CleverTap Android SDK CHANGE LOG
 
+### Version 7.1.2 (January 29, 2025)
+This release addresses a fix related to gradle JDK version in `v7.1.1`.
+
 ### Version 7.1.1 (January 24, 2025)
 This release addresses a critical issue in `v7.1.0`:
 

--- a/docs/CTGEOFENCE.md
+++ b/docs/CTGEOFENCE.md
@@ -17,7 +17,7 @@ Add the following dependencies to the `build.gradle`
 
 ```Groovy
 implementation "com.clevertap.android:clevertap-geofence-sdk:1.3.0"
-implementation "com.clevertap.android:clevertap-android-sdk:7.1.1" // 3.9.0 and above
+implementation "com.clevertap.android:clevertap-android-sdk:7.1.2" // 3.9.0 and above
 implementation "com.google.android.gms:play-services-location:21.0.0"
 implementation "androidx.work:work-runtime:2.7.1" // required for FETCH_LAST_LOCATION_PERIODIC
 implementation "androidx.concurrent:concurrent-futures:1.1.0" // required for FETCH_LAST_LOCATION_PERIODIC

--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -21,7 +21,7 @@ CleverTap Push Templates SDK helps you engage with your users using fancy push n
 
 ```groovy
 implementation "com.clevertap.android:push-templates:1.2.4"
-implementation "com.clevertap.android:clevertap-android-sdk:7.1.1" // 4.4.0 and above
+implementation "com.clevertap.android:clevertap-android-sdk:7.1.2" // 4.4.0 and above
 ```
 
 2. Add the following line to your Application class before the `onCreate()`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ coroutines_test = "1.7.3"
 installreferrer = "2.2"
 
 #SDK Versions
-clevertap_android_sdk = "7.1.1"
+clevertap_android_sdk = "7.1.2"
 clevertap_rendermax_sdk = "1.0.3"
 clevertap_geofence_sdk = "1.3.0"
 clevertap_hms_sdk = "1.3.4"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -118,7 +118,7 @@ dependencies {
     implementation("androidx.concurrent:concurrent-futures:1.1.0") // Needed for geofence
 
     implementation("com.google.firebase:firebase-messaging:23.0.6") //Needed for FCM
-    implementation("com.google.android.gms:play-services-ads:23.6.0") //Needed to use Google Ad Ids
+    implementation("com.google.android.gms:play-services-ads:22.6.0") //Needed to use Google Ad Ids
 
     //ExoPlayer Libraries for Audio/Video InApp Notifications
     //implementation("com.google.android.exoplayer:exoplayer:2.19.1")

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -1,5 +1,8 @@
 ## CleverTap Android SDK CHANGE LOG
 
+### Version 7.1.2 (January 29, 2025)
+This release addresses a fix related to gradle JDK version in `v7.1.1`.
+
 ### Version 7.1.1 (January 24, 2025)
 This release addresses a critical issue in `v7.1.0`:
 


### PR DESCRIPTION
Addresses a fix related to JDK version when generating aar for core sdk.
- bump core version to `7.1.2`
- update docs for release `7.1.2`
- downgrade sample app dependency for `google-services-ads` from `23.6.0` to `22.6.0` due to build error.