### PR TITLE
fix(git-673) - Moves recording impressions and counts to an io thread

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppFCManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppFCManager.java
@@ -112,14 +112,18 @@ public class InAppFCManager {
             return;
         }
 
-        impressionManager.recordImpression(id);
+        Task<Void> task = CTExecutorFactory.executors(config).postAsyncSafelyTask(Constants.TAG_FEATURE_IN_APPS);
+        task.execute("recordInAppImpressionsAndCounts", () -> {
+            impressionManager.recordImpression(id);
 
-        incrementInAppCountsInPersistentStore(id);
+            incrementInAppCountsInPersistentStore(id);
 
-        int shownToday = getIntFromPrefs(getKeyWithDeviceId(Constants.KEY_COUNTS_SHOWN_TODAY, deviceId), 0);
-        StorageHelper
-                .putInt(context, storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_COUNTS_SHOWN_TODAY, deviceId)),
-                        ++shownToday);
+            int shownToday = getIntFromPrefs(getKeyWithDeviceId(Constants.KEY_COUNTS_SHOWN_TODAY, deviceId), 0);
+            StorageHelper
+                    .putInt(context, storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_COUNTS_SHOWN_TODAY, deviceId)),
+                            ++shownToday);
+            return null;
+        });
     }
 
     public int getShownTodayCount() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppFCManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppFCManager.java
@@ -112,7 +112,7 @@ public class InAppFCManager {
             return;
         }
 
-        Task<Void> task = CTExecutorFactory.executors(config).postAsyncSafelyTask(Constants.TAG_FEATURE_IN_APPS);
+        Task<Void> task = CTExecutorFactory.executors(config).ioTask();
         task.execute("recordInAppImpressionsAndCounts", () -> {
             impressionManager.recordImpression(id);
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.java
@@ -786,7 +786,7 @@ public class InAppController implements InAppListener,
                 showNotificationIfAvailable();
             }
         });
-        task.execute("checkLimitsBeforeDisplaying", () -> {
+        task.execute("checkLimitsBeforeShowing", () -> {
             if (controllerManager.getInAppFCManager() != null) {
                 final Function2<JSONObject, String, Boolean> hasInAppFrequencyLimitsMaxedOut = (inAppJSON, inAppId) -> {
                     final List<LimitAdapter> listOfWhenLimits = InAppResponseAdapter.getListOfWhenLimits(inAppJSON);

--- a/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenModel.kt
+++ b/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenModel.kt
@@ -86,7 +86,7 @@ object HomeScreenModel {
                 "Hard permission dialog with fallbackToSettings - false",
                 "Hard permission dialog with fallbackToSettings - true"
             ),
-            "INAPP" to listOf("Footer InApp", "Footer InApp without image", "Header"),
+            "INAPP" to listOf("Suspend", "Discard", "Resume"),
             "CS INAPP" to listOf("Fetch CS InApps", "Clear all CS InApp Resources", "Clear expired only InAPP Resources"),
             "VARIABLES" to listOf(
                 "Define Variable",

--- a/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenViewModel.kt
+++ b/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenViewModel.kt
@@ -556,15 +556,15 @@ class HomeScreenViewModel(private val cleverTapAPI: CleverTapAPI?) : ViewModel()
             }
 
             "11-0" -> {
-                cleverTapAPI?.pushEvent("Footer InApp")
+                cleverTapAPI?.suspendInAppNotifications()
             }
 
             "11-1" -> {
-                cleverTapAPI?.pushEvent("Footer InApp without image")
+                cleverTapAPI?.discardInAppNotifications()
             }
 
             "11-2" -> {
-                cleverTapAPI?.pushEvent("Header")
+                cleverTapAPI?.resumeInAppNotifications()
             }
 
             "12-0" -> {


### PR DESCRIPTION
https://github.com/CleverTap/clevertap-android-sdk/issues/673

SDK-4503

After an InApp is displayed, it's impressions are recorded on the main thread. Even though it's simply accessing the shared prefs, this comes up in the StrictModeViolation

Clients are concerned this may be causing ANRs in the worst case. 
There's a possibility that for InApps linked to the AppLaunch event, the prefs might not be loaded into memory yet. This along with slow app startup time might be leading to ANRs

There could be concerns regarding race conditions here?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced in-app notifications for a more responsive and consistent user experience.
  - Streamlined the notification delivery process to ensure timely displays while effectively managing notification frequency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->