### PR TITLE
Default firebase-only initialisation

### DIFF
--- a/clevertap-core/consumer-rules.pro
+++ b/clevertap-core/consumer-rules.pro
@@ -1,6 +1,5 @@
 # For CleverTap SDK's
 -keep class com.clevertap.android.sdk.pushnotification.fcm.FcmPushProvider{*;}
--keep class com.clevertap.android.hms.HmsPushProvider{*;}
 -keep class com.google.firebase.messaging.FirebaseMessagingService{*;}
 -keep class com.clevertap.android.sdk.pushnotification.CTNotificationIntentService{*;}
 -keep class com.google.android.exoplayer2.ExoPlayer{*;}
@@ -15,6 +14,5 @@
     public static final ** CREATOR;
 }
 -dontwarn com.clevertap.android.sdk.**
--dontwarn com.baidu.**
 -keepattributes Exceptions,InnerClasses,Signature,Deprecated,
-                SourceFile,LineNumberTable,*Annotation*,EnclosingMethod
+                SourceFile,LineNumberTable,*Annotation*,EnclosingMetod

--- a/clevertap-core/consumer-rules.pro
+++ b/clevertap-core/consumer-rules.pro
@@ -15,4 +15,4 @@
 }
 -dontwarn com.clevertap.android.sdk.**
 -keepattributes Exceptions,InnerClasses,Signature,Deprecated,
-                SourceFile,LineNumberTable,*Annotation*,EnclosingMetod
+                SourceFile,LineNumberTable,*Annotation*,EnclosingMethod

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -2360,20 +2360,6 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     }
 
     /**
-     * Sends the Baidu registration ID to CleverTap.
-     *
-     * @param regId    The Baidu registration ID
-     * @param register Boolean indicating whether to register
-     *                 or not for receiving push messages from CleverTap.
-     *                 Set this to true to receive push messages from CleverTap,
-     *                 and false to not receive any messages from CleverTap.
-     */
-    @SuppressWarnings("unused")
-    public void pushBaiduRegistrationId(String regId, boolean register) {
-        coreState.getPushProviders().handleToken(regId, PushType.BPS, register);
-    }
-
-    /**
      * Push Charged event, which describes a purchase made.
      *
      * @param chargeDetails A {@link HashMap}, with keys as strings, and values as {@link String},
@@ -2516,20 +2502,6 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     public Future<?> pushGeofenceEnteredEvent(JSONObject geofenceProperties) {
         return coreState.getAnalyticsManager()
                 .raiseEventForGeofences(Constants.GEOFENCE_ENTERED_EVENT_NAME, geofenceProperties);
-    }
-
-    /**
-     * Sends the Huawei registration ID to CleverTap.
-     *
-     * @param regId    The Huawei registration ID
-     * @param register Boolean indicating whether to register
-     *                 or not for receiving push messages from CleverTap.
-     *                 Set this to true to receive push messages from CleverTap,
-     *                 and false to not receive any messages from CleverTap.
-     */
-    @SuppressWarnings("unused")
-    public void pushHuaweiRegistrationId(String regId, boolean register) {
-        coreState.getPushProviders().handleToken(regId, PushType.HPS, register);
     }
 
     /**
@@ -3089,20 +3061,6 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
                     .validate(context, coreState.getDeviceInfo(), coreState.getPushProviders());
             return null;
         });
-    }
-
-    /**
-     * Sends the ADM registration ID to CleverTap.
-     *
-     * @param token    The ADM registration ID
-     * @param register Boolean indicating whether to register
-     *                 or not for receiving push messages from CleverTap.
-     *                 Set this to true to receive push messages from CleverTap,
-     *                 and false to not receive any messages from CleverTap.
-     */
-    @SuppressWarnings("unused")
-    private void pushAmazonRegistrationId(String token, boolean register) {
-        coreState.getPushProviders().handleToken(token, PushType.ADM, register);
     }
 
     static void onActivityCreated(Activity activity) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/interfaces/INotificationParser.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/interfaces/INotificationParser.java
@@ -11,7 +11,7 @@ public interface INotificationParser<T> {
 
     /**
      * Parses notification message to Bundle
-     * @param message notification message received from cloud messaging provider like firebase,huawei etc.
+     * @param message notification message received from cloud messaging provider like firebase etc.
      * @return {@link Bundle} object
      */
     Bundle toBundle(@NonNull T message);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/interfaces/IPushAmpHandler.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/interfaces/IPushAmpHandler.java
@@ -15,7 +15,7 @@ public interface IPushAmpHandler<T> {
     /**
      *  Processes notification message for Pull Notifications
      * @param context application context
-     * @param message notification message received from cloud messaging provider like firebase,huawei etc.
+     * @param message notification message received from cloud messaging provider like firebase etc.
      */
     void processPushAmp(final Context context, @NonNull final T message);
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/CTPushProvider.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/CTPushProvider.java
@@ -48,5 +48,4 @@ public interface CTPushProvider {
      * Requests the push registration token.
      */
     void requestToken();
-
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushConstants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushConstants.java
@@ -8,43 +8,38 @@ import java.lang.annotation.RetentionPolicy;
 
 public interface PushConstants {
 
-    @StringDef({FCM_DELIVERY_TYPE, HMS_DELIVERY_TYPE, BAIDU_DELIVERY_TYPE, ADM_DELIVERY_TYPE})
+    @StringDef({FCM_DELIVERY_TYPE})
     @Retention(RetentionPolicy.SOURCE)
     @interface DeliveryType {
 
     }
 
-    @StringDef({CT_FIREBASE_PROVIDER_CLASS, CT_BAIDU_PROVIDER_CLASS,
-            CT_HUAWEI_PROVIDER_CLASS, CT_ADM_PROVIDER_CLASS})
+    @StringDef({CT_FIREBASE_PROVIDER_CLASS})
     @Retention(RetentionPolicy.SOURCE)
     @interface CTPushProviderClass {
 
     }
 
-    @StringDef({FIREBASE_SDK_CLASS, BAIDU_SDK_CLASS, HUAWEI_SDK_CLASS, ADM_SDK_CLASS})
+    @StringDef({FIREBASE_SDK_CLASS})
     @Retention(RetentionPolicy.SOURCE)
     @interface PushMessagingClass {
 
     }
 
-    @StringDef({FCM_PROPERTY_REG_ID, HPS_PROPERTY_REG_ID, BPS_PROPERTY_REG_ID,
-            ADM_PROPERTY_REG_ID})
+    @StringDef({FCM_PROPERTY_REG_ID})
     @Retention(RetentionPolicy.SOURCE)
     @interface RegKeyType {
 
     }
 
-    @IntDef({ANDROID_PLATFORM, AMAZON_PLATFORM})
+    @IntDef({ANDROID_PLATFORM})
     @Retention(RetentionPolicy.SOURCE)
     @interface Platform {
 
     }
 
     enum PushType {
-        FCM(FCM_DELIVERY_TYPE, FCM_PROPERTY_REG_ID, CT_FIREBASE_PROVIDER_CLASS, FIREBASE_SDK_CLASS),
-        HPS(HMS_DELIVERY_TYPE, HPS_PROPERTY_REG_ID, CT_HUAWEI_PROVIDER_CLASS, HUAWEI_SDK_CLASS),
-        BPS(BAIDU_DELIVERY_TYPE, BPS_PROPERTY_REG_ID, CT_BAIDU_PROVIDER_CLASS, BAIDU_SDK_CLASS),
-        ADM(ADM_DELIVERY_TYPE, ADM_PROPERTY_REG_ID, CT_ADM_PROVIDER_CLASS, ADM_SDK_CLASS);
+        FCM(FCM_DELIVERY_TYPE, FCM_PROPERTY_REG_ID, CT_FIREBASE_PROVIDER_CLASS, FIREBASE_SDK_CLASS);
 
         private final String ctProviderClassName;
 
@@ -54,8 +49,12 @@ public interface PushConstants {
 
         private final String type;
 
-        PushType(@DeliveryType String type, @RegKeyType String prefKey, @CTPushProviderClass String className,
-                @PushMessagingClass String messagingSDKClassName) {
+        PushType(
+                @DeliveryType String type,
+                @RegKeyType String prefKey,
+                @CTPushProviderClass String className,
+                @PushMessagingClass String messagingSDKClassName
+        ) {
             this.type = type;
             this.tokenPrefKey = prefKey;
             this.ctProviderClassName = className;
@@ -94,29 +93,11 @@ public interface PushConstants {
     @NonNull
     String FCM_DELIVERY_TYPE = "fcm";
     @NonNull
-    String BAIDU_DELIVERY_TYPE = "bps";
-    @NonNull
-    String HMS_DELIVERY_TYPE = "hps";
-    @NonNull
-    String ADM_DELIVERY_TYPE = "adm";
     String CT_FIREBASE_PROVIDER_CLASS = "com.clevertap.android.sdk.pushnotification.fcm.FcmPushProvider";
-    String CT_BAIDU_PROVIDER_CLASS = "com.clevertap.android.bps.BaiduPushProvider";
-    String CT_HUAWEI_PROVIDER_CLASS = "com.clevertap.android.hms.HmsPushProvider";
-    String CT_ADM_PROVIDER_CLASS = "com.clevertap.android.adm.AmazonPushProvider";
     String FIREBASE_SDK_CLASS = "com.google.firebase.messaging.FirebaseMessagingService";
-    String BAIDU_SDK_CLASS = "com.baidu.android.pushservice.PushMessageReceiver";
-    String HUAWEI_SDK_CLASS = "com.huawei.hms.push.HmsMessageService";
-    String ADM_SDK_CLASS = "com.amazon.device.messaging.ADM";
     String FCM_PROPERTY_REG_ID = "fcm_token";
-    String BPS_PROPERTY_REG_ID = "bps_token";
-    String HPS_PROPERTY_REG_ID = "hps_token";
-    String ADM_PROPERTY_REG_ID = "adm_token";
     /**
      * Android platform type. Only GCM transport will be allowed.
      */
     int ANDROID_PLATFORM = 1;
-    /**
-     * Amazon platform type. Only ADM transport will be allowed.
-     */
-    int AMAZON_PLATFORM = 2;
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushNotificationHandler.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushNotificationHandler.java
@@ -2,7 +2,6 @@ package com.clevertap.android.sdk.pushnotification;
 
 import static com.clevertap.android.sdk.pushnotification.PushConstants.LOG_TAG;
 import static com.clevertap.android.sdk.pushnotification.PushConstants.PushType.FCM;
-import static com.clevertap.android.sdk.pushnotification.PushConstants.PushType.HPS;
 import static com.clevertap.android.sdk.pushnotification.PushNotificationUtil.getAccountIdFromNotificationBundle;
 
 import android.content.Context;
@@ -50,8 +49,11 @@ public class PushNotificationHandler implements ActionButtonClickHandler {
     }
 
     @Override
-    public synchronized boolean onMessageReceived(final Context applicationContext, final Bundle message,
-            final String pushType) {
+    public synchronized boolean onMessageReceived(
+            final Context applicationContext,
+            final Bundle message,
+            final String pushType
+    ) {
         message.putLong(Constants.OMR_INVOKE_TIME_IN_MILLIS,System.currentTimeMillis());
         CleverTapAPI cleverTapAPI = CleverTapAPI
                 .getGlobalInstance(applicationContext, getAccountIdFromNotificationBundle(message));
@@ -86,8 +88,6 @@ public class PushNotificationHandler implements ActionButtonClickHandler {
     public boolean onNewToken(final Context applicationContext, final String token, final String pushType) {
         if (pushType.equals(FCM.getType())) {
             CleverTapAPI.tokenRefresh(applicationContext, token, FCM);
-        } else if (pushType.equals(HPS.getType())) {
-            CleverTapAPI.tokenRefresh(applicationContext, token, HPS);
         }
         return true;
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushProviders.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushProviders.java
@@ -35,7 +35,6 @@ import com.clevertap.android.sdk.DeviceInfo;
 import com.clevertap.android.sdk.Logger;
 import com.clevertap.android.sdk.ManifestInfo;
 import com.clevertap.android.sdk.StorageHelper;
-import com.clevertap.android.sdk.Utils;
 import com.clevertap.android.sdk.db.BaseDatabaseManager;
 import com.clevertap.android.sdk.db.DBAdapter;
 import com.clevertap.android.sdk.interfaces.AudibleNotification;
@@ -58,10 +57,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import org.json.JSONException;
 import org.json.JSONObject;
-
-/**
- * Single point of contact to load & support all types of Notification messaging services viz. FCM, HMS etc.
- */
 
 @RestrictTo(Scope.LIBRARY_GROUP)
 public class PushProviders implements CTPushProviderListener {
@@ -255,15 +250,6 @@ public class PushProviders implements CTPushProviderListener {
         switch (pushType) {
             case FCM:
                 handleToken(token, PushType.FCM, true);
-                break;
-            case HPS:
-                handleToken(token, PushType.HPS, true);
-                break;
-            case BPS:
-                handleToken(token, PushType.BPS, true);
-                break;
-            case ADM:
-                handleToken(token, PushType.ADM, true);
                 break;
         }
     }
@@ -754,24 +740,12 @@ public class PushProviders implements CTPushProviderListener {
                     "Provider: %s version %s does not match the SDK version %s. Make sure all CleverTap dependencies are the same version.");
             return false;
         }
-        switch (provider.getPushType()) {
-            case FCM:
-            case HPS:
-            case BPS:
-                if (provider.getPlatform() != PushConstants.ANDROID_PLATFORM) {
-                    config.log(PushConstants.LOG_TAG, "Invalid Provider: " + provider.getClass() +
-                            " delivery is only available for Android platforms." + provider.getPushType());
-                    return false;
-                }
-                break;
-            case ADM:
-                if (provider.getPlatform() != PushConstants.AMAZON_PLATFORM) {
-                    config.log(PushConstants.LOG_TAG, "Invalid Provider: " +
-                            provider.getClass() +
-                            " ADM delivery is only available for Amazon platforms." + provider.getPushType());
-                    return false;
-                }
-                break;
+        if (provider.getPushType() == PushType.FCM) {
+            if (provider.getPlatform() != PushConstants.ANDROID_PLATFORM) {
+                config.log(PushConstants.LOG_TAG, "Invalid Provider: " + provider.getClass() +
+                        " delivery is only available for Android platforms." + provider.getPushType());
+                return false;
+            }
         }
 
         return true;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/validation/ManifestValidator.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/validation/ManifestValidator.java
@@ -92,17 +92,6 @@ public final class ManifestValidator {
                 } catch (Error error) {
                     Logger.v("FATAL : " + error.getMessage());
                 }
-            }else if(pushType == PushType.HPS){
-                try {
-                    // use class name string directly here to avoid class not found issues on class import
-                    validateServiceInManifest((Application) context.getApplicationContext(),
-                            "com.clevertap.android.hms.CTHmsMessageService");
-                } catch (Exception e) {
-                    Logger.v("Receiver/Service issue : " + e.toString());
-
-                } catch (Error error) {
-                    Logger.v("FATAL : " + error.getMessage());
-                }
             }
         }
 


### PR DESCRIPTION
Breaking change:
https://wizrocket.atlassian.net/browse/SDK-4446

Removes non FCM push provider from core SDK. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined push notifications to focus solely on Firebase services, with legacy support for alternative providers removed.
  
- **Chore**
  - Updated internal configurations and error handling for improved consistency in notification delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->