### PR TITLE
task(SDK-4520) - Tags the socket with a constant integer

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/BitmapDownloader.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/BitmapDownloader.kt
@@ -1,5 +1,6 @@
 package com.clevertap.android.sdk.bitmap
 
+import android.net.TrafficStats
 import com.clevertap.android.sdk.Logger
 import com.clevertap.android.sdk.Utils
 import com.clevertap.android.sdk.network.DownloadedBitmap
@@ -14,6 +15,9 @@ class BitmapDownloader(
     private val bitmapInputStreamReader: IBitmapInputStreamReader,
     private val sizeConstrainedPair: Pair<Boolean, Int> = Pair(false, 0)
 ) {
+    companion object {
+        const val NETWORK_TAG_DOWNLOAD_REQUESTS = 21
+    }
 
     private var downloadStartTimeInMilliseconds: Long = 0
     private lateinit var connection: HttpURLConnection
@@ -25,6 +29,7 @@ class BitmapDownloader(
         this.srcUrl = srcUrl
         downloadStartTimeInMilliseconds = Utils.getNowInMillis()
         try {
+            TrafficStats.setThreadStatsTag(NETWORK_TAG_DOWNLOAD_REQUESTS)
             connection = URL(srcUrl).run { createConnection(this) }
             connection.run {
                 connect()

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/BitmapDownloader.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/BitmapDownloader.kt
@@ -65,6 +65,7 @@ class BitmapDownloader(
         } finally {
             try {
                 connection.disconnect()
+                TrafficStats.clearThreadStatsTag()
             } catch (t: Throwable) {
                 Logger.v("Couldn't close connection!", t)
             }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/http/UrlConnectionHttpClient.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/http/UrlConnectionHttpClient.kt
@@ -1,5 +1,6 @@
 package com.clevertap.android.sdk.network.http
 
+import android.net.TrafficStats
 import com.clevertap.android.sdk.Logger
 import java.io.BufferedInputStream
 import java.io.InputStream
@@ -22,6 +23,7 @@ class UrlConnectionHttpClient(
     companion object {
         const val READ_TIMEOUT = 10000
         const val CONNECT_TIMEOUT = 10000
+        const val NETWORK_TAG_HTTP_REQUESTS = 17
     }
 
     private val socketFactory: SSLSocketFactory? by lazy {
@@ -72,6 +74,7 @@ class UrlConnectionHttpClient(
     }
 
     private fun openHttpsURLConnection(request: Request): HttpsURLConnection {
+        TrafficStats.setThreadStatsTag(NETWORK_TAG_HTTP_REQUESTS)
         val url = URL(request.url.toString())
         val connection = (url.openConnection() as HttpsURLConnection).apply {
             connectTimeout = CONNECT_TIMEOUT

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/http/UrlConnectionHttpClient.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/http/UrlConnectionHttpClient.kt
@@ -41,6 +41,7 @@ class UrlConnectionHttpClient(
         var connection: HttpsURLConnection? = null
 
         try {
+            TrafficStats.setThreadStatsTag(NETWORK_TAG_HTTP_REQUESTS)
             connection = openHttpsURLConnection(request)
 
             logger.debug(logTag, "Sending request to: ${request.url}")
@@ -76,7 +77,6 @@ class UrlConnectionHttpClient(
     }
 
     private fun openHttpsURLConnection(request: Request): HttpsURLConnection {
-        TrafficStats.setThreadStatsTag(NETWORK_TAG_HTTP_REQUESTS)
         val url = URL(request.url.toString())
         val connection = (url.openConnection() as HttpsURLConnection).apply {
             connectTimeout = CONNECT_TIMEOUT

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/http/UrlConnectionHttpClient.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/http/UrlConnectionHttpClient.kt
@@ -70,6 +70,8 @@ class UrlConnectionHttpClient(
         } catch (e: Exception) {
             connection?.disconnect()
             throw e
+        } finally {
+            TrafficStats.clearThreadStatsTag()
         }
     }
 


### PR DESCRIPTION
https://github.com/square/okhttp/issues/3537#issuecomment-326820981

A constant integer is used. It doesn't add much value but resolves the violation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced network request monitoring by introducing specific tags for HTTP requests and bitmap downloads, improving tracking capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->