### PR TITLE
Add code coverage report in PR comment

### DIFF
--- a/.github/mini_flows/test_and_coverage_debug/action.yml
+++ b/.github/mini_flows/test_and_coverage_debug/action.yml
@@ -2,9 +2,11 @@ inputs:
   github-token:
     description: 'Github token to post JaCoCo report in a PR comment'
     required: false
+    default: ''
   baseline-branch:
     description: 'The branch to compare the JaCoCo report against'
     required: false
+    default: ''
 
 runs:
   using: "composite"

--- a/.github/mini_flows/test_and_coverage_debug/action.yml
+++ b/.github/mini_flows/test_and_coverage_debug/action.yml
@@ -1,6 +1,11 @@
 inputs:
   github-token:
     description: 'Github token to post JaCoCo report in a PR comment'
+    required: false
+  baseline-branch:
+    description: 'The branch to compare the JaCoCo report against'
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -90,22 +95,10 @@ runs:
 
     #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
 
-    - name: Setup Python
-      uses: actions/setup-python@v5.1.1
-      with:
-        python-version: '3.12'
-
-    - name: Publish JaCoCo Report in PR comment
+    - name: Post JaCoCo Report in PR comment
       if: ${{ inputs.github-token != '' }}
-      uses: MoranaApps/jacoco-report@v1.3.0
+      uses: ./.github/mini_flows/test_coverage_report
       with:
-        token: ${{ inputs.github-token }}
-        paths: |
-            **/build/reports/jacoco/**/*.xml
-        min-coverage-overall: 75
-        min-coverage-changed-files: 75
-        title: Code Coverage Debug
-        fail-on-threshold: false
-        sensitivity: 'minimal'
-        update-comment: true
-        skip-not-changed: true
+        github-token: ${{ inputs.github-token }}
+        baseline-branch: ${{ inputs.baseline-branch }}
+        comment-title: 'Code Coverage Debug'

--- a/.github/mini_flows/test_and_coverage_debug/action.yml
+++ b/.github/mini_flows/test_and_coverage_debug/action.yml
@@ -1,3 +1,6 @@
+inputs:
+  github-token:
+    description: 'Github token to post JaCoCo report in a PR comment'
 runs:
   using: "composite"
   steps:
@@ -84,3 +87,25 @@ runs:
       with:
         name: JacocoReportDebug-clevertap-pushtemplates
         path: clevertap-pushtemplates/build/reports/jacoco
+
+    #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
+
+    - name: Setup Python
+      uses: actions/setup-python@v5.1.1
+      with:
+        python-version: '3.12'
+
+    - name: Publish JaCoCo Report in PR comment
+      if: ${{ inputs.github-token != '' }}
+      uses: MoranaApps/jacoco-report@v1.3.0
+      with:
+        token: ${{ inputs.github-token }}
+        paths: |
+            **/build/reports/jacoco/**/*.xml
+        min-coverage-overall: 75
+        min-coverage-changed-files: 75
+        title: Code Coverage Debug
+        fail-on-threshold: false
+        sensitivity: 'minimal'
+        update-comment: true
+        skip-not-changed: true

--- a/.github/mini_flows/test_and_coverage_release/action.yml
+++ b/.github/mini_flows/test_and_coverage_release/action.yml
@@ -1,7 +1,11 @@
 inputs:
   github-token:
     description: 'Github token to post JaCoCo report in a PR comment'
-    required: true
+    required: false
+  baseline-branch:
+    description: 'The branch to compare the JaCoCo report against'
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -89,22 +93,11 @@ runs:
 
 
    #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
-    - name: Setup Python
-      uses: actions/setup-python@v5.1.1
-      with:
-        python-version: '3.12'
-
-    - name: Publish JaCoCo Report in PR comment
+    - name: Post JaCoCo Report in PR comment
       if: ${{ inputs.github-token != '' }}
-      uses: MoranaApps/jacoco-report@v1.3.0
+      uses: ./.github/mini_flows/test_coverage_report
       with:
-        token: ${{ inputs.github-token }}
-        paths: |
-            **/build/reports/jacoco/**/*.xml
-        min-coverage-overall: 75
-        min-coverage-changed-files: 75
-        title: Code Coverage Release
-        fail-on-threshold: false
-        sensitivity: 'minimal'
-        update-comment: true
-        skip-not-changed: true
+        github-token: ${{ inputs.github-token }}
+        baseline-branch: ${{ inputs.baseline-branch }}
+        comment-title: 'Code Coverage Release'
+        test-release: true

--- a/.github/mini_flows/test_and_coverage_release/action.yml
+++ b/.github/mini_flows/test_and_coverage_release/action.yml
@@ -1,3 +1,7 @@
+inputs:
+  github-token:
+    description: 'Github token to post JaCoCo report in a PR comment'
+    required: true
 runs:
   using: "composite"
   steps:
@@ -82,3 +86,25 @@ runs:
       with:
         name: JacocoReportRelease-clevertap-pushtemplates
         path: clevertap-pushtemplates/build/reports/jacoco
+
+
+   #-----#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#----------#-----
+    - name: Setup Python
+      uses: actions/setup-python@v5.1.1
+      with:
+        python-version: '3.12'
+
+    - name: Publish JaCoCo Report in PR comment
+      if: ${{ inputs.github-token != '' }}
+      uses: MoranaApps/jacoco-report@v1.3.0
+      with:
+        token: ${{ inputs.github-token }}
+        paths: |
+            **/build/reports/jacoco/**/*.xml
+        min-coverage-overall: 75
+        min-coverage-changed-files: 75
+        title: Code Coverage Release
+        fail-on-threshold: false
+        sensitivity: 'minimal'
+        update-comment: true
+        skip-not-changed: true

--- a/.github/mini_flows/test_and_coverage_release/action.yml
+++ b/.github/mini_flows/test_and_coverage_release/action.yml
@@ -2,9 +2,11 @@ inputs:
   github-token:
     description: 'Github token to post JaCoCo report in a PR comment'
     required: false
+    default: ''
   baseline-branch:
     description: 'The branch to compare the JaCoCo report against'
     required: false
+    default: ''
 
 runs:
   using: "composite"

--- a/.github/mini_flows/test_coverage_report/action.yml
+++ b/.github/mini_flows/test_coverage_report/action.yml
@@ -1,14 +1,21 @@
+name: 'Test Coverage Comment Report'
+description: 'Action that posts JaCoCo coverage reports as pull request comments'
+
 inputs:
   github-token:
     description: 'Github token to post JaCoCo report in a PR comment'
     required: true
   baseline-branch:
     description: 'The branch to compare the JaCoCo report against'
+    required: false
+    default: ''
   comment-title:
     description: 'The title of the comment with the JaCoCo report'
+    required: false
     default: 'Code Coverage'
   test-release:
     description: 'Run tests and code coverage for release build'
+    required: false
     default: 'false'
 
 runs:
@@ -18,7 +25,7 @@ runs:
     - name: Set variables
       shell: bash
       run: |
-        if [ ${{ inputs.test-release }} == 'true' ]; then
+        if [ "${{ inputs.test-release }}" == 'true' ]; then
           echo "GRADLE_REPORT_TASK=jacocoTestReportRelease" >> $GITHUB_ENV
         else
           echo "GRADLE_REPORT_TASK=jacocoTestReportDebug" >> $GITHUB_ENV

--- a/.github/mini_flows/test_coverage_report/action.yml
+++ b/.github/mini_flows/test_coverage_report/action.yml
@@ -1,0 +1,67 @@
+inputs:
+  github-token:
+    description: 'Github token to post JaCoCo report in a PR comment'
+    required: true
+  baseline-branch:
+    description: 'The branch to compare the JaCoCo report against'
+  comment-title:
+    description: 'The title of the comment with the JaCoCo report'
+    default: 'Code Coverage'
+  test-release:
+    description: 'Run tests and code coverage for release build'
+    default: 'false'
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Set variables
+      shell: bash
+      run: |
+        if [ ${{ inputs.test-release }} == 'true' ]; then
+          echo "GRADLE_REPORT_TASK=jacocoTestReportRelease" >> $GITHUB_ENV
+        else
+          echo "GRADLE_REPORT_TASK=jacocoTestReportDebug" >> $GITHUB_ENV
+        fi
+
+    - name: Checkout baseline branch
+      if: ${{ inputs.baseline-branch != '' }}
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.baseline-branch }}
+        path: baseline
+
+    - name: Generate baseline JaCoCo report
+      if: ${{ inputs.baseline-branch != '' }}
+      shell: bash
+      working-directory: ./baseline
+      run: ./gradlew $GRADLE_REPORT_TASK  -Pcoverage='true'
+
+    - name: Set baseline report path
+      if: ${{ inputs.baseline-branch != '' }}
+      shell: bash
+      run: echo "BASELINE_REPORTS=baseline/clevertap-*/build/reports/jacoco/**/*.xml" >> $GITHUB_ENV
+
+    - name: Setup Python
+      uses: actions/setup-python@v5.1.1
+      with:
+        python-version: '3.12'
+
+    - name: Publish JaCoCo Report in PR comment
+      uses: MoranaApps/jacoco-report@v1.3.0
+      with:
+        token: ${{ inputs.github-token }}
+        paths: clevertap-*/build/reports/jacoco/**/*.xml
+        baseline-paths: ${{ env.BASELINE_REPORTS }}
+        min-coverage-overall: 75
+        min-coverage-changed-files: 75
+        title: ${{ inputs.comment-title }}
+        fail-on-threshold: false
+        sensitivity: 'summary'
+        update-comment: true
+        skip-not-changed: true
+
+    - name: Cleanup baseline directory
+      if: ${{ inputs.baseline-branch != '' }}
+      shell: bash
+      run: rm -rf baseline

--- a/.github/workflows/on_pr_from_develop_to_master.yml
+++ b/.github/workflows/on_pr_from_develop_to_master.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: write
 
     steps:
       - name: Checkout the code from Repo
@@ -32,9 +33,13 @@ jobs:
 
       - name: Unit Tests and Jacoco Coverage (DEBUG)
         uses: ./.github/mini_flows/test_and_coverage_debug
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Unit Tests and Jacoco Coverage (RELEASE)
         uses: ./.github/mini_flows/test_and_coverage_release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build AARs (RELEASE)
         uses: ./.github/mini_flows/build_code_release

--- a/.github/workflows/on_pr_from_develop_to_master.yml
+++ b/.github/workflows/on_pr_from_develop_to_master.yml
@@ -31,15 +31,11 @@ jobs:
       - name: Static Code Check Via checkstyle
         uses: ./.github/mini_flows/codechecks_checkstyle
 
-      - name: Unit Tests and Jacoco Coverage (DEBUG)
-        uses: ./.github/mini_flows/test_and_coverage_debug
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Unit Tests and Jacoco Coverage (RELEASE)
         uses: ./.github/mini_flows/test_and_coverage_release
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          baseline-branch: master
 
       - name: Build AARs (RELEASE)
         uses: ./.github/mini_flows/build_code_release

--- a/.github/workflows/on_pr_from_task_to_develop.yml
+++ b/.github/workflows/on_pr_from_task_to_develop.yml
@@ -32,6 +32,7 @@ jobs:
         uses: ./.github/mini_flows/test_and_coverage_debug
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          baseline-branch: develop
 
       - name: Build AARs (RELEASE)
         uses: ./.github/mini_flows/build_code_release

--- a/.github/workflows/on_pr_from_task_to_develop.yml
+++ b/.github/workflows/on_pr_from_task_to_develop.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      pull-requests: write
 
     steps:
       - name: Checkout the code from Repo
@@ -29,9 +30,8 @@ jobs:
 
       - name: Unit Tests and Jacoco Coverage (DEBUG)
         uses: ./.github/mini_flows/test_and_coverage_debug
-
-      - name: Unit Tests and Jacoco Coverage (RELEASE)
-        uses: ./.github/mini_flows/test_and_coverage_release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build AARs (RELEASE)
         uses: ./.github/mini_flows/build_code_release

--- a/.github/workflows/on_pr_merged_in_master.yml
+++ b/.github/workflows/on_pr_merged_in_master.yml
@@ -32,9 +32,13 @@ jobs:
 
       - name: Unit Tests and Jacoco Coverage (DEBUG)
         uses: ./.github/mini_flows/test_and_coverage_debug
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Unit Tests and Jacoco Coverage (RELEASE)
         uses: ./.github/mini_flows/test_and_coverage_release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build AARs (RELEASE)
         uses: ./.github/mini_flows/build_code_release

--- a/.github/workflows/on_pr_merged_in_master.yml
+++ b/.github/workflows/on_pr_merged_in_master.yml
@@ -32,13 +32,9 @@ jobs:
 
       - name: Unit Tests and Jacoco Coverage (DEBUG)
         uses: ./.github/mini_flows/test_and_coverage_debug
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Unit Tests and Jacoco Coverage (RELEASE)
         uses: ./.github/mini_flows/test_and_coverage_release
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build AARs (RELEASE)
         uses: ./.github/mini_flows/build_code_release

--- a/gradle-scripts/jacoco_root.gradle
+++ b/gradle-scripts/jacoco_root.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'jacoco'
 jacoco {
-    toolVersion = "0.8.8"
+    toolVersion = "0.8.12"
 }
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
@@ -63,6 +63,7 @@ def createVariantCoverage(variant) {
 
         reports {
             html.required = true
+            xml.required = true
         }
 
         def javaClasses = fileTree(dir: variant.javaCompileProvider.get().destinationDir, excludes: project.excludes)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated posting of JaCoCo code coverage reports as comments on pull requests, supporting both debug and release builds.
  - Introduced a new workflow for generating and comparing code coverage against a baseline branch.

- **Improvements**
  - Updated Jacoco plugin version for coverage reporting.
  - Enabled XML report generation for Jacoco coverage.
  - Enhanced workflow permissions to allow posting comments on pull requests.
  - Improved configuration flexibility for specifying GitHub tokens and baseline branches in workflows.

- **Bug Fixes**
  - Ensured XML coverage report generation for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->