### PR TITLE
Add invisible FragmentHostActivity to support custom HTML in-app messages on NativeActivity

### DIFF
--- a/clevertap-core/src/main/AndroidManifest.xml
+++ b/clevertap-core/src/main/AndroidManifest.xml
@@ -15,6 +15,13 @@
             android:configChanges="keyboardHidden"
             android:theme="@style/Theme.AppCompat.DayNight.DarkActionBar" />
 
+        <activity
+            android:name="com.clevertap.android.sdk.FragmentHostActivity"
+            android:theme="@style/CleverTapFragmentHostTheme"
+            android:noHistory="true"
+            android:launchMode="singleTop"
+            android:exported="false" />
+
         <receiver
             android:name=".pushnotification.CTPushNotificationReceiver"
             android:enabled="true"

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/FragmentHostActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/FragmentHostActivity.java
@@ -1,0 +1,58 @@
+package com.clevertap.android.sdk;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+public class FragmentHostActivity extends AppCompatActivity {
+
+    private static boolean hosting = false;
+    public static boolean isHosting() { return hosting; }
+
+    public static void launch(Activity current) {
+        Intent intent = new Intent(current, FragmentHostActivity.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        current.startActivity(intent);
+
+        // try to supress any transitions
+        current.overridePendingTransition(0, 0);
+    }
+
+    @Override protected void onCreate(Bundle b) {
+        super.onCreate(b);
+        hosting = true;
+
+        // try to supress any transitions
+        overridePendingTransition(0, 0); 
+    }
+
+    @Override protected void onResume() {
+        super.onResume();
+
+        // try to supress any transitions
+        getSupportFragmentManager()
+            .registerFragmentLifecycleCallbacks(new FragmentManager.FragmentLifecycleCallbacks() {
+                @Override
+                public void onFragmentPreAttached(@NonNull FragmentManager fm, @NonNull Fragment f, @NonNull Context context) {
+                    f.setEnterTransition(null);
+                    f.setExitTransition(null);
+                    f.setReenterTransition(null);
+                    f.setReturnTransition(null);
+                }
+            }, true);
+    }
+    
+    @Override protected void onDestroy() {
+        super.onDestroy();
+        hosting = false;
+
+        // try to supress any transitions
+        overridePendingTransition(0, 0);
+    }
+}

--- a/clevertap-core/src/main/res/values/styles.xml
+++ b/clevertap-core/src/main/res/values/styles.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="CleverTapFragmentHostTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowFullscreen">true</item>
+    </style>
+</resources>


### PR DESCRIPTION
This PR adds support for rendering CleverTap’s fragment-based in-app notifications (e.g. custom HTML) in Unreal Engine projects that use a NativeActivity, which does not support fragments.

Problem
=======
CleverTap’s SDK assumes that the current activity is a FragmentActivity, but Unreal-based Android apps typically use NativeActivity. As a result, certain in-app notification types (notably HTML-based ones) fail to display or cause runtime exceptions.

Solution
=======
Introduced a minimal FragmentHostActivity that subclasses AppCompatActivity and provides a safe fragment container.

Added logic to detect when the current activity is not a FragmentActivity, defer the notification, and launch FragmentHostActivity instead.

Once launched, the host activity proceeds with CleverTap’s regular rendering logic.

This approach isolates fragment-specific logic to a dedicated host, without modifying the behavior for apps already using FragmentActivity.

