### PR TITLE
fix(SDK-4752,SDK-4872): Handle fullscreen in-apps

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -10,12 +10,15 @@ import android.content.res.Configuration;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
+import android.view.Window;
 import android.view.WindowManager;
 
 import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 import androidx.fragment.app.FragmentActivity;
 
 import com.clevertap.android.sdk.inapp.CTInAppAction;
@@ -92,9 +95,14 @@ public final class InAppNotificationActivity extends FragmentActivity implements
             }
         });
 
-        int orientation = this.getResources().getConfiguration().orientation;
+        int orientation = getResources().getConfiguration().orientation;
         if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-            getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            Window window = getWindow();
+            if (window != null) {
+                window.addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
+                WindowInsetsControllerCompat insetsController = new WindowInsetsControllerCompat(window, window.getDecorView());
+                insetsController.hide(WindowInsetsCompat.Type.systemBars());
+            }
         }
         try {
             Bundle intentExtras = getIntent().getExtras();

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppBaseFullHtmlFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppBaseFullHtmlFragment.java
@@ -1,6 +1,9 @@
 package com.clevertap.android.sdk.inapp;
 
+import static android.view.WindowManager.LayoutParams.FLAG_FULLSCREEN;
+
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.drawable.ColorDrawable;
@@ -8,11 +11,14 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.webkit.WebViewClient;
 import android.widget.RelativeLayout;
 import android.widget.RelativeLayout.LayoutParams;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.clevertap.android.sdk.CTWebInterface;
 import com.clevertap.android.sdk.CleverTapAPI;
 import com.clevertap.android.sdk.Constants;
@@ -23,6 +29,7 @@ import com.clevertap.android.sdk.customviews.CloseImageView;
 public abstract class CTInAppBaseFullHtmlFragment extends CTInAppBaseFullFragment {
 
     protected CTInAppWebView webView;
+    protected boolean isFullscreen = false;
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -38,6 +45,7 @@ public abstract class CTInAppBaseFullHtmlFragment extends CTInAppBaseFullFragmen
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
             Bundle savedInstanceState) {
+        updateFullscreenInfo();
         return displayHTMLView(inflater, container);
     }
 
@@ -56,6 +64,7 @@ public abstract class CTInAppBaseFullHtmlFragment extends CTInAppBaseFullFragmen
     @Override
     public void onConfigurationChanged(@NonNull Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
+        updateFullscreenInfo();
         reDrawInApp();
     }
 
@@ -87,6 +96,7 @@ public abstract class CTInAppBaseFullHtmlFragment extends CTInAppBaseFullFragmen
             webView = new CTInAppWebView(this.context, inAppNotification.getWidth(),
                     inAppNotification.getHeight(), inAppNotification.getWidthPercentage(),
                     inAppNotification.getHeightPercentage());
+            webView.setFullscreen(isFullscreen);
             InAppWebViewClient webViewClient = new InAppWebViewClient(this);
             webView.setWebViewClient(webViewClient);
 
@@ -156,6 +166,7 @@ public abstract class CTInAppBaseFullHtmlFragment extends CTInAppBaseFullFragmen
     }
 
     private void reDrawInApp() {
+        webView.setFullscreen(isFullscreen);
         webView.updateDimension();
 
         if (inAppNotification.getCustomInAppUrl().isEmpty()) {
@@ -191,6 +202,16 @@ public abstract class CTInAppBaseFullHtmlFragment extends CTInAppBaseFullFragmen
         } catch (Exception e) {
             config.getLogger().verbose("cleanupWebView -> there was some crash in cleanup", e);
             //no-op; we are anyway destroying everything. This is just for safety.
+        }
+    }
+
+    private void updateFullscreenInfo() {
+        Activity activity = getActivity();
+        if (activity != null) {
+            Window window = activity.getWindow();
+            if (window != null) {
+                isFullscreen = (window.getAttributes().flags & FLAG_FULLSCREEN) != 0;
+            }
         }
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlCoverFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlCoverFragment.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.RelativeLayout;
 import android.widget.RelativeLayout.LayoutParams;
 
@@ -34,7 +35,7 @@ public class CTInAppHtmlCoverFragment extends CTInAppBaseFullHtmlFragment {
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
         View inAppView = super.onCreateView(inflater, container, savedInstanceState);
-        if (inAppView != null) {
+        if (!isFullscreen && inAppView != null) {
             applyInsetsWithMarginAdjustment(inAppView, (insets, mlp) -> {
                 mlp.leftMargin = insets.left;
                 mlp.rightMargin = insets.right;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlHalfInterstitialFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlHalfInterstitialFragment.java
@@ -15,7 +15,7 @@ public class CTInAppHtmlHalfInterstitialFragment extends CTInAppBaseFullHtmlFrag
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
         View inAppView = super.onCreateView(inflater, container, savedInstanceState);
-        if (inAppView != null) {
+        if (!isFullscreen && inAppView != null) {
             applyInsetsWithMarginAdjustment(inAppView, (insets, mlp) -> {
                 mlp.leftMargin = insets.left;
                 mlp.rightMargin = insets.right;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlInterstitialFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlInterstitialFragment.java
@@ -15,7 +15,7 @@ public class CTInAppHtmlInterstitialFragment extends CTInAppBaseFullHtmlFragment
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, Bundle savedInstanceState) {
         View inAppView = super.onCreateView(inflater, container, savedInstanceState);
-        if (inAppView != null) {
+        if (!isFullscreen && inAppView != null) {
             applyInsetsWithMarginAdjustment(inAppView, (insets, mlp) -> {
                 mlp.leftMargin = insets.left;
                 mlp.rightMargin = insets.right;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppWebView.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppWebView.kt
@@ -30,6 +30,8 @@ internal class CTInAppWebView @SuppressLint("ResourceType") constructor(
     @JvmField
     val dim: Point = Point()
 
+    var isFullscreen = false
+
     @SuppressLint("ResourceType")
     constructor(
         context: Context,
@@ -110,12 +112,14 @@ internal class CTInAppWebView @SuppressLint("ResourceType") constructor(
                 ?: return calculateWidthWithDisplayMetrics()
 
         val metrics = windowManager.currentWindowMetrics
-        val insets = metrics.windowInsets.getInsetsIgnoringVisibility(
-            WindowInsets.Type.systemBars() or
-                    WindowInsets.Type.displayCutout()
-        )
-
-        val availableWidth = metrics.bounds.width() - insets.left - insets.right
+        val availableWidth = if (isFullscreen) {
+            metrics.bounds.width()
+        } else {
+            val insets = metrics.windowInsets.getInsetsIgnoringVisibility(
+                WindowInsets.Type.systemBars() or WindowInsets.Type.displayCutout()
+            )
+            metrics.bounds.width() - insets.left - insets.right
+        }
         return (availableWidth * widthPercentage / 100f).toInt()
     }
 
@@ -127,12 +131,14 @@ internal class CTInAppWebView @SuppressLint("ResourceType") constructor(
                 ?: return calculateHeightWithDisplayMetrics()
 
         val metrics = windowManager.currentWindowMetrics
-        val insets = metrics.windowInsets.getInsetsIgnoringVisibility(
-            WindowInsets.Type.systemBars() or
-                    WindowInsets.Type.displayCutout()
-        )
-
-        val availableHeight = metrics.bounds.height() - insets.top - insets.bottom
+        val availableHeight = if (isFullscreen) {
+            metrics.bounds.height()
+        } else {
+            val insets = metrics.windowInsets.getInsetsIgnoringVisibility(
+                WindowInsets.Type.systemBars() or WindowInsets.Type.displayCutout()
+            )
+            metrics.bounds.height() - insets.top - insets.bottom
+        }
         return (availableHeight * heightPercentage / 100f).toInt()
     }
 


### PR DESCRIPTION
Insets margins are no longer applied for in in-apps fragments that are in fullscreen.
Change InAppNotificationActivity landscape fullscreen mode to be edge-to-edge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved fullscreen support for in-app notifications and web views, ensuring system bars are fully hidden in landscape mode.
- **Bug Fixes**
  - Adjusted margin and inset handling for in-app messages to display correctly in both fullscreen and non-fullscreen modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->