### PR TITLE
task(SDK-5031) - Local Inapp parity with iOS

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/DidClickForHardPermissionListener.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/DidClickForHardPermissionListener.java
@@ -6,4 +6,5 @@ package com.clevertap.android.sdk;
  */
 public interface DidClickForHardPermissionListener {
     void didClickForHardPermissionWithFallbackSettings(boolean fallbackToSettings);
+    void didCancelPermissionRequest();
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -275,7 +275,7 @@ public final class InAppNotificationActivity extends FragmentActivity implements
     @Override
     public void onPushPermissionResult(boolean isGranted) {
         Bundle data = null;
-        if(inAppNotification != null && inAppNotification.isLocalInApp()) {
+        if (inAppNotification != null && inAppNotification.isLocalInApp()) {
             data = new Bundle();
             data.putString(Constants.KEY_C2A, inAppNotification.getButtons().get(0).getText());
             data.putString(Constants.NOTIFICATION_ID_TAG, "");

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -259,6 +259,11 @@ public final class InAppNotificationActivity extends FragmentActivity implements
         showPushPermissionPrompt(fallbackToSettings);
     }
 
+    @Override
+    public void didCancelPermissionRequest() {
+        pushPermissionHandler.notifyPushPermissionExternalListeners(this);
+    }
+
     public void showPushPermissionPrompt(boolean isFallbackSettingsEnabled) {
         pushPermissionHandler.requestPermission(this, isFallbackSettingsEnabled);
     }
@@ -463,7 +468,7 @@ public final class InAppNotificationActivity extends FragmentActivity implements
                 showPushPermissionPrompt(inAppNotification.getFallBackToNotificationSettings());
                 return;
             } else {
-                pushPermissionHandler.notifyPushPermissionListeners(this);
+                didCancelPermissionRequest();
             }
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -274,7 +274,13 @@ public final class InAppNotificationActivity extends FragmentActivity implements
 
     @Override
     public void onPushPermissionResult(boolean isGranted) {
-        didDismiss(null);
+        Bundle data = null;
+        if(inAppNotification != null && inAppNotification.isLocalInApp()) {
+            data = new Bundle();
+            data.putString(Constants.KEY_C2A, inAppNotification.getButtons().get(0).getText());
+            data.putString(Constants.NOTIFICATION_ID_TAG, "");
+        }
+        didDismiss(data);
     }
 
     void didDismiss(Bundle data) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -458,9 +458,13 @@ public final class InAppNotificationActivity extends FragmentActivity implements
     private void onAlertButtonClick(CTInAppNotificationButton button, boolean isPositive) {
         Bundle clickData = didClick(button);
 
-        if (isPositive && inAppNotification.isLocalInApp()) {
-            showPushPermissionPrompt(inAppNotification.getFallBackToNotificationSettings());
-            return;
+        if (inAppNotification.isLocalInApp()) {
+            if(isPositive) {
+                showPushPermissionPrompt(inAppNotification.getFallBackToNotificationSettings());
+                return;
+            } else {
+                pushPermissionHandler.notifyPushPermissionListeners(this);
+            }
         }
 
         CTInAppAction action = button.action;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/PushPermissionHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/PushPermissionHandler.kt
@@ -71,6 +71,10 @@ internal class PushPermissionHandler @JvmOverloads constructor(
         notifyListeners(isPushPermissionGranted(context))
     }
 
+    fun notifyPushPermissionExternalListeners(context: Context) {
+        notifyExternalListeners(isPushPermissionGranted(context))
+    }
+
     /**
      * Attempt to request a push permission. Checks if the permission is already given and does not
      * initiate the flow in this case. When the result of the permission check is known without
@@ -159,7 +163,11 @@ internal class PushPermissionHandler @JvmOverloads constructor(
     }
 
     private fun notifyListeners(isPermissionGranted: Boolean) {
+        notifyExternalListeners(isPermissionGranted)
         pushPermissionCallback.get()?.onPushPermissionResult(isPermissionGranted)
+    }
+
+    private fun notifyExternalListeners(isPermissionGranted: Boolean) {
         if (ctListeners != null) {
             for (listener in ctListeners) {
                 listener?.onPushPermissionResponse(isPermissionGranted)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTLocalInApp.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTLocalInApp.kt
@@ -86,6 +86,9 @@ class CTLocalInApp private constructor() {
                     val negativeButtonObject = JSONObject().apply {
                         put(Constants.KEY_TEXT, negativeBtnText)
                         put(Constants.KEY_RADIUS, "2")
+                        put(Constants.KEY_ACTIONS, JSONObject().apply {
+                            put(Constants.KEY_TYPE, InAppActionType.CLOSE)
+                        })
                     }
                     getJSONArray(Constants.KEY_BUTTONS).put(1, negativeButtonObject)
                     Builder6(this)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -149,7 +149,9 @@ internal class InAppController(
         data.putString(Constants.KEY_C2A, callToAction)
 
         // send clicked event
-        analyticsManager.pushInAppNotificationStateEvent(true, inAppNotification, data)
+        if (!inAppNotification.isLocalInApp) {
+            analyticsManager.pushInAppNotificationStateEvent(true, inAppNotification, data)
+        }
 
         val type = action.type
         if (type == null) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -192,11 +192,18 @@ internal abstract class CTInAppBaseFragment : Fragment() {
             val button = inAppNotification.buttons[index]
             val clickData = didClick(button)
 
-            if (index == 0 && inAppNotification.isLocalInApp && didClickForHardPermissionListener != null) {
-                didClickForHardPermissionListener?.didClickForHardPermissionWithFallbackSettings(
-                    inAppNotification.fallBackToNotificationSettings
-                )
-                return
+            if (inAppNotification.isLocalInApp && didClickForHardPermissionListener != null) {
+                when (index) {
+                    0 -> {
+                        didClickForHardPermissionListener?.didClickForHardPermissionWithFallbackSettings(
+                            inAppNotification.fallBackToNotificationSettings
+                        )
+                        return
+                    }
+                    1 -> {
+                        didClickForHardPermissionListener?.didCancelPermissionRequest()
+                    }
+                }
             }
 
             val action = button.action

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
@@ -206,6 +206,13 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
     }
 
     @Override
+    public void didCancelPermissionRequest() {
+        if (pushPermissionHandler != null) {
+            pushPermissionHandler.notifyPushPermissionExternalListeners(this);
+        }
+    }
+
+    @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
             @NonNull int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);


### PR DESCRIPTION
We are trying to achieve the following change in behaviour
**Half-Inter**
1. For  Allow button clicked Add actionExtras -> {wzrk_c2a = "Allow", wzrk_id = ""}  to onDismissed callback
2. For  Deny button additional onPushPermissionResponse with accepted -> false

**Alert**
1. For  Allow button clicked Add actionExtras -> {wzrk_c2a = "Allow", wzrk_id = ""}  to onDismissed callback
2. For  Deny button clicked Add actionExtras -> {wzrk_c2a = "Deny", wzrk_id = ""}  to onDismissed callback
3. For  Deny button additional onPushPermissionResponse with accepted -> false

Not raise click event for close button

Backlog -> Dismiss local inapp first and then show the OS prompt like system inapp functions