### PR TITLE
Update release date.

### DIFF
--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -1,5 +1,5 @@
 ## CleverTap Android SDK CHANGE LOG
-### Version 7.5.0 (July 10, 2025)
+### Version 7.5.0 (July 11, 2025)
 
 #### New Features
 * Introduces support for linked content within `Native Display` units, enabling richer interactive experiences.

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -1,5 +1,5 @@
 ## CleverTap Android SDK CHANGE LOG
-### Version 7.5.0 (July 10, 2025)
+### Version 7.5.0 (July 11, 2025)
 
 #### New Features
 * Introduces support for linked content within `Native Display` units, enabling richer interactive experiences.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to reflect a new release date for CleverTap Android SDK version 7.5.0 (now July 11, 2025). No other changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->