### PR TITLE
Release Core 7.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## CHANGE LOG.
+### August 28, 2025
+* [CleverTap Android SDK v7.5.1](docs/CTCORECHANGELOG.md)
+
 ### July 11, 2025
 * [CleverTap Android SDK v7.5.0](docs/CTCORECHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We publish the SDK to `mavenCentral` as an `AAR` file. Just declare it as depend
 
 ```groovy
     dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:7.5.0"
+         implementation "com.clevertap.android:clevertap-android-sdk:7.5.1"
     }
 ```
 
@@ -34,7 +34,7 @@ Alternatively, you can download and add the AAR file included in this repo in yo
     
  ```groovy
     dependencies {      
-        implementation (name: "clevertap-android-sdk-7.5.0", ext: 'aar')
+        implementation (name: "clevertap-android-sdk-7.5.1", ext: 'aar')
     }
 ```
 
@@ -46,7 +46,7 @@ Add the Firebase Messaging library and Android Support Library v4 as dependencie
 
 ```groovy
      dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:7.5.0"
+         implementation "com.clevertap.android:clevertap-android-sdk:7.5.1"
          implementation "androidx.core:core:1.13.0"
          implementation "com.google.firebase:firebase-messaging:24.0.0"
          implementation "com.google.android.gms:play-services-ads:23.6.0" // Required only if you enable Google ADID collection in the SDK (turned off by default).

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/cryption/AESCrypt.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/cryption/AESCrypt.kt
@@ -73,6 +73,9 @@ class AESCrypt(accountID: String) : Crypt() {
                 bytes[i] = byteStrings[i].toByte()
             }
             bytes
+        } catch (oom: OutOfMemoryError) {
+            Logger.v("Unable to parse cipher text", oom)
+            null
         } catch (e: Exception) {
             Logger.v("Unable to parse cipher text", e)
             null

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/cryption/AESGCMCrypt.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/cryption/AESGCMCrypt.kt
@@ -67,6 +67,9 @@ internal class AESGCMCrypt(
             val iv = parts[0].fromBase64()
             val encryptedBytes = parts[1].fromBase64()
             AESGCMCryptResult(iv, encryptedBytes)
+        } catch (oom: OutOfMemoryError) {
+            Logger.v("Unable to parse cipher text", oom)
+            null
         } catch (e: Exception) {
             Logger.v("Error parsing cipherText", e)
             null

--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -1,4 +1,9 @@
 ## CleverTap Android SDK CHANGE LOG
+### Version 7.5.1 (August 28, 2025)
+
+#### Bug Fixes
+* Fixes an `OutOfMemoryError` that occurred when parsing large encrypted cipher text in `AESCrypt.parseCipherText()`. The issue was caused by using `Regex.split()` on large byte array string representations, which created excessive memory allocations. The data is recovered through apis eventually.
+
 ### Version 7.5.0 (July 11, 2025)
 
 #### New Features

--- a/docs/CTGEOFENCE.md
+++ b/docs/CTGEOFENCE.md
@@ -17,7 +17,7 @@ Add the following dependencies to the `build.gradle`
 
 ```Groovy
 implementation "com.clevertap.android:clevertap-geofence-sdk:1.4.0"
-implementation "com.clevertap.android:clevertap-android-sdk:7.5.0" // 3.9.0 and above
+implementation "com.clevertap.android:clevertap-android-sdk:7.5.1" // 3.9.0 and above
 implementation "com.google.android.gms:play-services-location:21.3.0"
 implementation "androidx.work:work-runtime:2.10.2" // required for FETCH_LAST_LOCATION_PERIODIC
 implementation "androidx.concurrent:concurrent-futures:1.2.0" // required for FETCH_LAST_LOCATION_PERIODIC

--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -21,7 +21,7 @@ CleverTap Push Templates SDK helps you engage with your users using fancy push n
 
 ```groovy
 implementation "com.clevertap.android:push-templates:2.1.0"
-implementation "com.clevertap.android:clevertap-android-sdk:7.5.0" // 4.4.0 and above
+implementation "com.clevertap.android:clevertap-android-sdk:7.5.1" // 4.4.0 and above
 ```
 
 2. Add the following line to your Application class before the `onCreate()`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,7 @@ hamcrest = "3.0"
 installreferrer = "2.2"
 
 #SDK Versions
-clevertap_android_sdk = "7.5.0"
+clevertap_android_sdk = "7.5.1"
 clevertap_rendermax_sdk = "1.0.3"
 clevertap_geofence_sdk = "1.4.0"
 clevertap_hms_sdk = "1.5.0"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -21,8 +21,8 @@ android {
         applicationId "com.clevertap.demo"
         minSdkVersion 21
         targetSdkVersion 35
-        versionCode 7050000
-        versionName "7.5.0"
+        versionCode 7050100
+        versionName "7.5.1"
         multiDexEnabled true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
@@ -172,12 +172,12 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
     implementation "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.1.1"*/
 
-    remoteImplementation("com.clevertap.android:clevertap-android-sdk:7.5.0")
+    remoteImplementation("com.clevertap.android:clevertap-android-sdk:7.5.1")
     remoteImplementation("com.clevertap.android:clevertap-geofence-sdk:1.4.0")
     remoteImplementation("com.clevertap.android:push-templates:2.1.0")
     remoteImplementation("com.clevertap.android:clevertap-hms-sdk:1.5.0")
 
-    stagingImplementation("com.clevertap.android:clevertap-android-sdk:7.5.0")
+    stagingImplementation("com.clevertap.android:clevertap-android-sdk:7.5.1")
     stagingImplementation("com.clevertap.android:clevertap-geofence-sdk:1.4.0")
     stagingImplementation("com.clevertap.android:push-templates:2.1.0")
     stagingImplementation("com.clevertap.android:clevertap-hms-sdk:1.5.0")

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -1,4 +1,9 @@
 ## CleverTap Android SDK CHANGE LOG
+### Version 7.5.1 (August 28, 2025)
+
+#### Bug Fixes
+* Fixes an `OutOfMemoryError` that occurred when parsing large encrypted cipher text in `AESCrypt.parseCipherText()`. The issue was caused by using `Regex.split()` on large byte array string representations, which created excessive memory allocations. The data is recovered through apis eventually.
+
 ### Version 7.5.0 (July 11, 2025)
 
 #### New Features


### PR DESCRIPTION
Fixes an `OutOfMemoryError` that occurred when parsing large encrypted cipher text in `AESCrypt.parseCipherText()`. The issue was caused by using `Regex.split()` on large byte array string representations, which created excessive memory allocations. The data is recovered through apis eventually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Version
  - Released CleverTap Android SDK 7.5.1.

- Bug Fixes
  - Resolved crashes from OutOfMemoryError when parsing large encrypted messages; errors are now handled gracefully without app termination.

- Documentation
  - Updated installation snippets and references to 7.5.1 across guides.
  - Added changelog entries for the 7.5.1 release.

- Chores
  - Aligned dependency versions to 7.5.1.
  - Updated sample app versionCode/versionName to match the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->