### PR TITLE
task(SDK-5186): Handles evaluation for profile and raised events

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/db/BaseDatabaseManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/db/BaseDatabaseManager.kt
@@ -23,6 +23,12 @@ internal interface BaseDatabaseManager {
         eventGroup: EventGroup
     ): QueueData
 
+    /**
+     * Fetches a combined batch of events from both events and profileEvents tables
+     * Returns QueueData with events data and ids, also if there are more events to fetch
+     */
+    fun getCombinedQueuedEvents(context: Context, batchSize: Int): QueueData
+
     fun queueEventToDB(context: Context, event: JSONObject, type: Int)
 
     fun queuePushNotificationViewedEventToDB(context: Context, event: JSONObject)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/db/DBManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/db/DBManager.kt
@@ -79,10 +79,9 @@ internal class DBManager(
 
     /**
      * Fetches a combined batch of events from both events and profileEvents tables
-     * Always uses fixed batch size of 50
-     * Returns QueueData with cleanup information
+     * Returns QueueData with events data and ids, also if there are more events to fetch
      */
-    private fun getCombinedQueuedEvents(context: Context, batchSize: Int): QueueData {
+    override fun getCombinedQueuedEvents(context: Context, batchSize: Int): QueueData {
         synchronized(ctLockManager.eventLock) {
             val adapter = loadDBAdapter(context)
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/db/QueueData.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/db/QueueData.kt
@@ -6,19 +6,19 @@ import org.json.JSONArray
  * QueueData that holds event data along with cleanup information
  * Used to track which events were fetched for later cleanup
  */
-class QueueData {
-    val data: JSONArray = JSONArray()
-    val eventIds: MutableList<String> = mutableListOf()  // IDs from events table
-    val profileEventIds: MutableList<String> = mutableListOf()  // IDs from profileEvents table
-    var hasMore: Boolean = false
+internal class QueueData {
+    internal val data: JSONArray = JSONArray()
+    internal val eventIds: MutableList<String> = mutableListOf()  // IDs from events table
+    internal val profileEventIds: MutableList<String> = mutableListOf()  // IDs from profileEvents table
+    internal var hasMore: Boolean = false
 
-    val isEmpty: Boolean
+    internal val isEmpty: Boolean
         get() = data.length() <= 0
 
-    val hasEvents: Boolean
+    internal val hasEvents: Boolean
         get() = eventIds.isNotEmpty()
 
-    val hasProfileEvents: Boolean
+    internal val hasProfileEvents: Boolean
         get() = profileEventIds.isNotEmpty()
 
     override fun toString(): String {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManager.kt
@@ -23,24 +23,6 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 /**
- * Enumeration representing different groups of events which are sent in the queue
- *
- * Each enum value corresponds to a specific group which is sent as a batch in the queue
- *
- * @property key The string representation of the event type.
- */
-enum class EventType(val key: String) {
-    PROFILE("profile"),
-    RAISED("raised");
-
-    companion object {
-        fun fromBoolean(isProfile: Boolean): EventType {
-            return if (isProfile) PROFILE else RAISED
-        }
-    }
-}
-
-/**
  * Manages the evaluation of in-app notifications for the client and server sides.
  *
  * This class, `EvaluationManager`, is responsible for coordinating the evaluation of in-app notifications
@@ -250,7 +232,6 @@ internal class EvaluationManager(
                 // Add the campaign ID to the list of evaluated server-side campaign IDs if it's not zero.
                 if (campaignId != 0L) {
                     updated = true
-                    val eventType = EventType.fromBoolean(events[0].isUserAttributeChangeEvent())
                     evaluatedServerSideCampaignIds.add(campaignId)
                 }
             }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManager.kt
@@ -67,11 +67,11 @@ internal class EvaluationManager(
     private val templatesManager: TemplatesManager
 ) : NetworkHeadersListener {
 
-    // Internal map to track server-side evaluated campaign IDs. This map is used to identify the evaluatedIDs for raised and profile events individually
+    // Internal list to track server-side evaluated campaign IDs. This map is used to identify the evaluatedIDs for raised and profile events together.
     @VisibleForTesting
     internal var evaluatedServerSideCampaignIds: MutableList<Long> = ArrayList()
 
-    // Internal map to track client-side suppressed in-app notifications. This map is used to identify the suppressedIDs for raised and profile events individually.
+    // Internal list to track client-side suppressed in-app notifications. This map is used to identify the suppressedIDs for raised and profile events together.
     @VisibleForTesting
     internal var suppressedClientSideInApps: MutableList<Map<String, Any?>> = ArrayList()
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/InAppStore.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/InAppStore.kt
@@ -210,7 +210,7 @@ internal class InAppStore(
     /**
      * Reads suppressed Client-side In-App IDs.
      *
-     * @return A JSoNObject representing the map of EventType - suppressed Client-side In-App IDs.
+     * @return A JSONArray representing suppressed Client-side In-App IDs.
      */
     fun readSuppressedClientSideInAppIds(): JSONArray {
         val suppressedClientSideInAppIds = ctPreference.readString(PREFS_SUPPRESSED_INAPP_KEY_CS, "")
@@ -219,7 +219,7 @@ internal class InAppStore(
         }
 
         return try {
-            // Try to convert the string to a JSONObject which signifies already migrated
+            // Try to convert the string to a JSONArray which signifies already migrated
             JSONArray(suppressedClientSideInAppIds)
         } catch (jsonException: JSONException) {
             migrateInAppHeaderPrefsForEventType(suppressedClientSideInAppIds)
@@ -228,17 +228,15 @@ internal class InAppStore(
 
     /**
      * Migrates suppressed_ss and evaluated_ss after reading from the prefs.
-     * The older format was a JSONArray. This JSoNArray represented the list of all inapps suppressed/evaluated
-     * The migrated format is a JSONObject. This JSoNObject has the key as EvenType and the
-     * value as the corresponding list of inapps suppressed/evaluated
      *
      * @param - inAppIds to be migrated
-     * @return - JSoNObject in the migrated format
+     * @return - JSONArray in the migrated format
      */
     private fun migrateInAppHeaderPrefsForEventType(inAppIds: String): JSONArray {
         try {
             // Old format data from 6.2.1 -> 7.5.1
-            // {"raised":[1733462104],"profile":[]}
+            // {"raised":[123],"profile":[456]}
+            // New format => [123, 456]
             val oldJsonObject = JSONObject(inAppIds)
 
             val raisedArray = oldJsonObject.getJSONArray(Constants.RAISED)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkHeadersListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkHeadersListener.kt
@@ -4,13 +4,12 @@ import com.clevertap.android.sdk.events.EventGroup
 import com.clevertap.android.sdk.events.EventGroup.PUSH_NOTIFICATION_VIEWED
 import com.clevertap.android.sdk.events.EventGroup.REGULAR
 import com.clevertap.android.sdk.events.EventGroup.VARIABLES
-import com.clevertap.android.sdk.inapp.evaluation.EventType
 import org.json.JSONObject
 
 interface NetworkHeadersListener {
 
-    fun onAttachHeaders(endpointId: EndpointId, eventType: EventType): JSONObject?
-    fun onSentHeaders(allHeaders: JSONObject, endpointId: EndpointId, eventType: EventType)
+    fun onAttachHeaders(endpointId: EndpointId): JSONObject?
+    fun onSentHeaders(allHeaders: JSONObject, endpointId: EndpointId)
 }
 
 enum class EndpointId(val identifier: String) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.kt
@@ -334,7 +334,7 @@ internal class NetworkManager constructor(
 
         val endpointId: EndpointId = fromEventGroup(eventGroup)
         val queueHeader: JSONObject? = getQueueHeader(caller)
-        applyQueueHeaderListeners(queueHeader, endpointId, queue.optJSONObject(0).has("profile"))
+        applyQueueHeaderListeners(queueHeader, endpointId)
 
         val requestBody = SendQueueRequestBody(queueHeader, queue)
         logger.debug(config.accountId, "Send queue contains " + queue.length() + " items: " + requestBody)
@@ -398,12 +398,9 @@ internal class NetworkManager constructor(
     ) {
         if (requestBody.queueHeader != null) {
             for (listener: NetworkHeadersListener in mNetworkHeadersListeners) {
-                val isProfile: Boolean =
-                    requestBody.queue.optJSONObject(0).has("profile")
                 listener.onSentHeaders(
                     allHeaders = requestBody.queueHeader,
-                    endpointId = endpointId,
-                    eventType = fromBoolean(isProfile)
+                    endpointId = endpointId
                 )
             }
         }
@@ -434,12 +431,11 @@ internal class NetworkManager constructor(
 
     private fun applyQueueHeaderListeners(
         queueHeader: JSONObject?,
-        endpointId: EndpointId,
-        isProfile: Boolean
+        endpointId: EndpointId
     ) {
         if (queueHeader != null) {
             for (listener in mNetworkHeadersListeners) {
-                val headersToAttach = listener.onAttachHeaders(endpointId, fromBoolean(isProfile))
+                val headersToAttach = listener.onAttachHeaders(endpointId)
                 if (headersToAttach != null) {
                     queueHeader.copyFrom(headersToAttach)
                 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.kt
@@ -20,7 +20,6 @@ import com.clevertap.android.sdk.db.BaseDatabaseManager
 import com.clevertap.android.sdk.db.QueueData
 import com.clevertap.android.sdk.events.EventGroup
 import com.clevertap.android.sdk.inapp.customtemplates.CustomTemplate
-import com.clevertap.android.sdk.inapp.evaluation.EventType.Companion.fromBoolean
 import com.clevertap.android.sdk.network.EndpointId.Companion.fromEventGroup
 import com.clevertap.android.sdk.network.api.CtApi
 import com.clevertap.android.sdk.network.api.CtApiWrapper

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManagerTest.kt
@@ -4,8 +4,6 @@ import android.location.Location
 import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.inapp.TriggerManager
 import com.clevertap.android.sdk.inapp.customtemplates.TemplatesManager
-import com.clevertap.android.sdk.inapp.evaluation.EventType.PROFILE
-import com.clevertap.android.sdk.inapp.evaluation.EventType.RAISED
 import com.clevertap.android.sdk.inapp.evaluation.TriggerAdapter.Companion.INAPP_OPERATOR
 import com.clevertap.android.sdk.inapp.evaluation.TriggerAdapter.Companion.INAPP_PROPERTYNAME
 import com.clevertap.android.sdk.inapp.evaluation.TriggerAdapter.Companion.KEY_PROPERTY_VALUE
@@ -289,7 +287,7 @@ class EvaluationManagerTest : BaseTestCase() {
         every { evaluationManager.generateWzrkId(any(), any()) } returns "campaign1_20231128"
 
         // Act
-        evaluationManager.suppress(inApp, RAISED)
+        evaluationManager.suppress(inApp)
 
         // Assert
         val expectedMap = mapOf(
@@ -297,71 +295,7 @@ class EvaluationManagerTest : BaseTestCase() {
             Constants.INAPP_WZRK_PIVOT to "wzrk_default",
             Constants.INAPP_WZRK_CGID to 0
         )
-        assertEquals(expectedMap, evaluationManager.suppressedClientSideInApps[RAISED.key]?.first())
-    }
-
-    @Test
-    fun `suppress should add entry to suppressedClientSideInApps with default values for profile event`() {
-        // Arrange
-        val inApp = JSONObject().put(Constants.INAPP_ID_IN_PAYLOAD, "campaign1")
-        every { evaluationManager.generateWzrkId(any(), any()) } returns "campaign1_20231128"
-
-        // Act
-        evaluationManager.suppress(inApp, PROFILE)
-
-        // Assert
-        val expectedMap = mapOf(
-            Constants.NOTIFICATION_ID_TAG to "campaign1_20231128",
-            Constants.INAPP_WZRK_PIVOT to "wzrk_default",
-            Constants.INAPP_WZRK_CGID to 0
-        )
-        assertEquals(expectedMap, evaluationManager.suppressedClientSideInApps[PROFILE.key]?.first())
-    }
-
-    @Test
-    fun `suppress should add entry to suppressedClientSideInApps with custom values for raised event`() {
-        // Arrange
-        val inApp = JSONObject().apply {
-            put(Constants.INAPP_ID_IN_PAYLOAD, "campaign2")
-            put(Constants.INAPP_WZRK_PIVOT, "custom_pivot")
-            put(Constants.INAPP_WZRK_CGID, 42)
-        }
-        every { evaluationManager.generateWzrkId(any(), any()) } returns "campaign2_20231128"
-
-        // Act
-        evaluationManager.suppress(inApp, RAISED)
-
-        // Assert
-        val expectedMap = mapOf(
-            Constants.NOTIFICATION_ID_TAG to "campaign2_20231128",
-            Constants.INAPP_WZRK_PIVOT to "custom_pivot",
-            Constants.INAPP_WZRK_CGID to 42
-        )
-        assertEquals(expectedMap, evaluationManager.suppressedClientSideInApps[RAISED.key]?.first())
-        assertEquals(emptyList(), evaluationManager.suppressedClientSideInApps[PROFILE.key]!!)
-    }
-
-    @Test
-    fun `suppress should add entry to suppressedClientSideInApps with custom values for profile event`() {
-        // Arrange
-        val inApp = JSONObject().apply {
-            put(Constants.INAPP_ID_IN_PAYLOAD, "campaign2")
-            put(Constants.INAPP_WZRK_PIVOT, "custom_pivot")
-            put(Constants.INAPP_WZRK_CGID, 42)
-        }
-        every { evaluationManager.generateWzrkId(any(), any()) } returns "campaign2_20231128"
-
-        // Act
-        evaluationManager.suppress(inApp, PROFILE)
-
-        // Assert
-        val expectedMap = mapOf(
-            Constants.NOTIFICATION_ID_TAG to "campaign2_20231128",
-            Constants.INAPP_WZRK_PIVOT to "custom_pivot",
-            Constants.INAPP_WZRK_CGID to 42
-        )
-        assertEquals(expectedMap, evaluationManager.suppressedClientSideInApps[PROFILE.key]?.first())
-        assertEquals(emptyList(), evaluationManager.suppressedClientSideInApps[RAISED.key]!!)
+        assertTrue(evaluationManager.suppressedClientSideInApps.contains(expectedMap))
     }
 
     @Test
@@ -489,7 +423,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateClientSide(listOf(EventAdapter("", mapOf())))
 
         assertEquals(0, evaluateClientSide.length())
-        assertEquals(1, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(1, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -508,7 +442,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateClientSide(listOf(EventAdapter("", mapOf())))
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(1, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(1, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -527,7 +461,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateClientSide(listOf(EventAdapter("", mapOf())))
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(0, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(0, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -543,7 +477,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateClientSide(listOf(EventAdapter("", mapOf())))
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(0, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(0, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -561,7 +495,7 @@ class EvaluationManagerTest : BaseTestCase() {
             evaluationManager.evaluateClientSide(listOf(EventAdapter("", mapOf()), EventAdapter("", mapOf())))
 
         assertEquals(0, evaluateClientSide.length())
-        assertEquals(2, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(2, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -581,7 +515,7 @@ class EvaluationManagerTest : BaseTestCase() {
             evaluationManager.evaluateClientSide(listOf(EventAdapter("", mapOf()), EventAdapter("", mapOf())))
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(1, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(1, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -601,7 +535,7 @@ class EvaluationManagerTest : BaseTestCase() {
             evaluationManager.evaluateClientSide(listOf(EventAdapter("", mapOf()), EventAdapter("", mapOf())))
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(0, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(0, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -614,7 +548,7 @@ class EvaluationManagerTest : BaseTestCase() {
             evaluationManager.evaluateClientSide(listOf(EventAdapter("", mapOf()), EventAdapter("", mapOf())))
 
         assertEquals(0, evaluateClientSide.length())
-        assertEquals(0, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(0, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -633,7 +567,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateClientSide(listOf(event1, event2))
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(0, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(0, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -656,7 +590,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateClientSide(listOf(event1, event2))
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(1, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(1, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -680,7 +614,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateClientSide(listOf(event1, event2))
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(0, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(0, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -693,7 +627,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateClientSide(listOf(event1))
 
         assertEquals(0, evaluateClientSide.length())
-        assertEquals(0, evaluationManager.suppressedClientSideInApps[PROFILE.key]!!.size)
+        assertEquals(0, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -763,7 +697,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateClientSide(listOf(event1))
 
         assertEquals(0, evaluateClientSide.length())
-        assertEquals(1, evaluationManager.suppressedClientSideInApps[PROFILE.key]!!.size)
+        assertEquals(1, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -785,7 +719,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateClientSide(listOf(event1))
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(1, evaluationManager.suppressedClientSideInApps[PROFILE.key]!!.size)
+        assertEquals(1, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -807,7 +741,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateClientSide(listOf(event1))
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(1, evaluationManager.suppressedClientSideInApps[PROFILE.key]!!.size)
+        assertEquals(1, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -821,7 +755,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateOnAppLaunchedServerSide(inApps, emptyMap(), null)
 
         assertEquals(0, evaluateClientSide.length())
-        assertEquals(1, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(1, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -836,7 +770,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateOnAppLaunchedServerSide(inApps, emptyMap(), null)
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(1, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(1, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -851,7 +785,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateOnAppLaunchedServerSide(inApps, emptyMap(), null)
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(0, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(0, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -864,7 +798,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val evaluateClientSide = evaluationManager.evaluateOnAppLaunchedServerSide(inApps, emptyMap(), null)
 
         assertEquals(1, evaluateClientSide.length())
-        assertEquals(0, evaluationManager.suppressedClientSideInApps[RAISED.key]!!.size)
+        assertEquals(0, evaluationManager.suppressedClientSideInApps.size)
     }
 
     @Test
@@ -878,7 +812,7 @@ class EvaluationManagerTest : BaseTestCase() {
 
         evaluationManager.evaluateServerSide(listOf(EventAdapter("", mapOf())))
 
-        assertEquals(0, evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]!!.size)
+        assertEquals(0, evaluationManager.evaluatedServerSideCampaignIds.size)
     }
 
     @Test
@@ -892,7 +826,7 @@ class EvaluationManagerTest : BaseTestCase() {
 
         evaluationManager.evaluateServerSide(listOf(EventAdapter("", mapOf())))
 
-        assertEquals(1, evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]!!.size)
+        assertEquals(1, evaluationManager.evaluatedServerSideCampaignIds.size)
     }
 
     @Test
@@ -906,8 +840,8 @@ class EvaluationManagerTest : BaseTestCase() {
 
         evaluationManager.evaluateServerSide(listOf(EventAdapter("", mapOf()), EventAdapter("", mapOf())))
 
-        assertEquals(0, evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]!!.size)
-        assertEquals(0, evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]!!.size)
+        assertEquals(0, evaluationManager.evaluatedServerSideCampaignIds.size)
+        assertEquals(0, evaluationManager.evaluatedServerSideCampaignIds.size)
     }
 
     @Test
@@ -938,8 +872,7 @@ class EvaluationManagerTest : BaseTestCase() {
 
         evaluationManager.evaluateServerSide(listOf(event1, event2))
 
-        assertEquals(1, evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]!!.size)
-        assertEquals(0, evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]!!.size)
+        assertEquals(1, evaluationManager.evaluatedServerSideCampaignIds.size)
     }
 
     @Test
@@ -1173,10 +1106,10 @@ class EvaluationManagerTest : BaseTestCase() {
         // Arrange
         val endpointId = EndpointId.ENDPOINT_A1
         // Populate evaluatedServerSideCampaignIds with some values
-        evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]?.add(1)
+        evaluationManager.evaluatedServerSideCampaignIds.add(1)
 
         // Act
-        val result = evaluationManager.onAttachHeaders(endpointId, RAISED)
+        val result = evaluationManager.onAttachHeaders(endpointId)
 
         // Assert
         assertNotNull(result)
@@ -1193,10 +1126,10 @@ class EvaluationManagerTest : BaseTestCase() {
         // Arrange
         val endpointId = EndpointId.ENDPOINT_A1
         // Populate evaluatedServerSideCampaignIds with some values
-        evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]?.add(1)
+        evaluationManager.evaluatedServerSideCampaignIds.add(1)
 
         // Act
-        val result = evaluationManager.onAttachHeaders(endpointId, PROFILE)
+        val result = evaluationManager.onAttachHeaders(endpointId)
 
         // Assert
         assertNotNull(result)
@@ -1212,10 +1145,10 @@ class EvaluationManagerTest : BaseTestCase() {
     fun `onAttachHeaders returns JSONObject when suppressedClientSideInApps is not empty for RASIED event`() {
         // Arrange
         val endpointId = EndpointId.ENDPOINT_A1
-        evaluationManager.suppressedClientSideInApps[RAISED.key]?.add(mapOf("key" to "value"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf("key" to "value"))
 
         // Act
-        val result = evaluationManager.onAttachHeaders(endpointId, RAISED)
+        val result = evaluationManager.onAttachHeaders(endpointId)
 
         // Assert
         assertNotNull(result)
@@ -1233,10 +1166,10 @@ class EvaluationManagerTest : BaseTestCase() {
     fun `onAttachHeaders returns JSONObject when suppressedClientSideInApps is not empty for PROFILE event`() {
         // Arrange
         val endpointId = EndpointId.ENDPOINT_A1
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf("key" to "value"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf("key" to "value"))
 
         // Act
-        val result = evaluationManager.onAttachHeaders(endpointId, PROFILE)
+        val result = evaluationManager.onAttachHeaders(endpointId)
 
         // Assert
         assertNotNull(result)
@@ -1254,11 +1187,11 @@ class EvaluationManagerTest : BaseTestCase() {
     fun `onAttachHeaders returns JSONObject when both lists are not empty for PROFILE event`() {
         // Arrange
         val endpointId = EndpointId.ENDPOINT_A1
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf("key" to "value"))
-        evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]?.add(1)
+        evaluationManager.suppressedClientSideInApps.add(mapOf("key" to "value"))
+        evaluationManager.evaluatedServerSideCampaignIds.add(1)
 
         // Act
-        val result = evaluationManager.onAttachHeaders(endpointId, PROFILE)
+        val result = evaluationManager.onAttachHeaders(endpointId)
 
         // Assert
         assertNotNull(result)
@@ -1280,11 +1213,11 @@ class EvaluationManagerTest : BaseTestCase() {
     fun `onAttachHeaders returns JSONObject when both lists are not empty for RAISED event`() {
         // Arrange
         val endpointId = EndpointId.ENDPOINT_A1
-        evaluationManager.suppressedClientSideInApps[RAISED.key]?.add(mapOf("key" to "value"))
-        evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]?.add(1)
+        evaluationManager.suppressedClientSideInApps.add(mapOf("key" to "value"))
+        evaluationManager.evaluatedServerSideCampaignIds.add(1)
 
         // Act
-        val result = evaluationManager.onAttachHeaders(endpointId, RAISED)
+        val result = evaluationManager.onAttachHeaders(endpointId)
 
         // Assert
         assertNotNull(result)
@@ -1308,7 +1241,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val endpointId = EndpointId.ENDPOINT_A1
 
         // Act
-        val result = evaluationManager.onAttachHeaders(endpointId, RAISED)
+        val result = evaluationManager.onAttachHeaders(endpointId)
 
         // Assert
         assertNull(result)
@@ -1320,7 +1253,7 @@ class EvaluationManagerTest : BaseTestCase() {
         val endpointId = EndpointId.ENDPOINT_A1
 
         // Act
-        val result = evaluationManager.onAttachHeaders(endpointId, PROFILE)
+        val result = evaluationManager.onAttachHeaders(endpointId)
 
         // Assert
         assertNull(result)
@@ -1331,11 +1264,11 @@ class EvaluationManagerTest : BaseTestCase() {
         // Arrange
         val endpointId = EndpointId.ENDPOINT_HELLO
 
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf("key" to "value"))
-        evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]?.add(1)
+        evaluationManager.suppressedClientSideInApps.add(mapOf("key" to "value"))
+        evaluationManager.evaluatedServerSideCampaignIds.add(1)
 
         // Act
-        val result = evaluationManager.onAttachHeaders(endpointId, RAISED)
+        val result = evaluationManager.onAttachHeaders(endpointId)
 
         // Assert
         assertNull(result)
@@ -1357,24 +1290,24 @@ class EvaluationManagerTest : BaseTestCase() {
         }
 
         // Manually manipulate the evaluatedServerSideCampaignIds and suppressedClientSideInApps lists
-        evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]?.add(1L)
-        evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]?.add(2L)
-        evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]?.add(3L)
+        evaluationManager.evaluatedServerSideCampaignIds.add(1L)
+        evaluationManager.evaluatedServerSideCampaignIds.add(2L)
+        evaluationManager.evaluatedServerSideCampaignIds.add(3L)
 
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id1"))
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id2"))
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id3"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id1"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id2"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id3"))
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, PROFILE)
+        evaluationManager.onSentHeaders(header, endpointId)
 
         // Assert
         // Manually assert the state after the method call
-        assertTrue(evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]!!.isEmpty())
+        assertTrue(evaluationManager.evaluatedServerSideCampaignIds.isEmpty())
 
         val resultList = evaluationManager.suppressedClientSideInApps
-        assertEquals(1, resultList[PROFILE.key]!!.size)
-        assertEquals("id3", resultList[PROFILE.key]!![0][Constants.NOTIFICATION_ID_TAG])
+        assertEquals(1, resultList.size)
+        assertEquals("id3", resultList[0][Constants.NOTIFICATION_ID_TAG])
     }
 
     @Test
@@ -1393,24 +1326,24 @@ class EvaluationManagerTest : BaseTestCase() {
         }
 
         // Manually manipulate the evaluatedServerSideCampaignIds and suppressedClientSideInApps lists
-        evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]?.add(1L)
-        evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]?.add(2L)
-        evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]?.add(3L)
+        evaluationManager.evaluatedServerSideCampaignIds.add(1L)
+        evaluationManager.evaluatedServerSideCampaignIds.add(2L)
+        evaluationManager.evaluatedServerSideCampaignIds.add(3L)
 
-        evaluationManager.suppressedClientSideInApps[RAISED.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id1"))
-        evaluationManager.suppressedClientSideInApps[RAISED.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id2"))
-        evaluationManager.suppressedClientSideInApps[RAISED.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id3"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id1"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id2"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "id3"))
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, RAISED)
+        evaluationManager.onSentHeaders(header, endpointId)
 
         // Assert
         // Manually assert the state after the method call
-        assertTrue(evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]!!.isEmpty())
+        assertTrue(evaluationManager.evaluatedServerSideCampaignIds.isEmpty())
 
         val resultList = evaluationManager.suppressedClientSideInApps
-        assertEquals(1, resultList[RAISED.key]!!.size)
-        assertEquals("id3", resultList[RAISED.key]!![0][Constants.NOTIFICATION_ID_TAG])
+        assertEquals(1, resultList.size)
+        assertEquals("id3", resultList[0][Constants.NOTIFICATION_ID_TAG])
     }
 
     @Test
@@ -1426,16 +1359,16 @@ class EvaluationManagerTest : BaseTestCase() {
             )
         }
 
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, PROFILE)
+        evaluationManager.onSentHeaders(header, endpointId)
 
         // Assert
 
         val resultList = evaluationManager.suppressedClientSideInApps
-        assertEquals(1, resultList[PROFILE.key]!!.size)
-        assertEquals("112322222_646464646", resultList[PROFILE.key]!![0][Constants.NOTIFICATION_ID_TAG])
+        assertEquals(1, resultList.size)
+        assertEquals("112322222_646464646", resultList[0][Constants.NOTIFICATION_ID_TAG])
     }
 
     @Test
@@ -1451,16 +1384,16 @@ class EvaluationManagerTest : BaseTestCase() {
             )
         }
 
-        evaluationManager.suppressedClientSideInApps[RAISED.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, RAISED)
+        evaluationManager.onSentHeaders(header, endpointId)
 
         // Assert
 
         val resultList = evaluationManager.suppressedClientSideInApps
-        assertEquals(1, resultList[RAISED.key]!!.size)
-        assertEquals("112322222_646464646", resultList[RAISED.key]!![0][Constants.NOTIFICATION_ID_TAG])
+        assertEquals(1, resultList.size)
+        assertEquals("112322222_646464646", resultList[0][Constants.NOTIFICATION_ID_TAG])
     }
 
     @Test
@@ -1476,14 +1409,14 @@ class EvaluationManagerTest : BaseTestCase() {
             )
         }
 
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, PROFILE)
+        evaluationManager.onSentHeaders(header, endpointId)
         // Assert
 
         val resultList = evaluationManager.suppressedClientSideInApps
-        assertEquals(0, resultList[PROFILE.key]!!.size)
+        assertEquals(0, resultList.size)
     }
 
     @Test
@@ -1499,14 +1432,14 @@ class EvaluationManagerTest : BaseTestCase() {
             )
         }
 
-        evaluationManager.suppressedClientSideInApps[RAISED.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, RAISED)
+        evaluationManager.onSentHeaders(header, endpointId)
         // Assert
 
         val resultList = evaluationManager.suppressedClientSideInApps
-        assertEquals(0, resultList[RAISED.key]!!.size)
+        assertEquals(0, resultList.size)
     }
 
     @Test
@@ -1522,16 +1455,16 @@ class EvaluationManagerTest : BaseTestCase() {
             )
         }
 
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, PROFILE)
+        evaluationManager.onSentHeaders(header, endpointId)
 
         // Assert
 
         val resultList = evaluationManager.suppressedClientSideInApps
-        assertEquals(1, resultList[PROFILE.key]!!.size)
-        assertEquals("112322222_646464646", resultList[PROFILE.key]!![0][Constants.NOTIFICATION_ID_TAG])
+        assertEquals(1, resultList.size)
+        assertEquals("112322222_646464646", resultList[0][Constants.NOTIFICATION_ID_TAG])
     }
 
     @Test
@@ -1543,15 +1476,15 @@ class EvaluationManagerTest : BaseTestCase() {
             put(Constants.INAPP_SS_EVAL_META, JSONArray().put(1))
         }
 
-        evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]?.add(1L)
+        evaluationManager.evaluatedServerSideCampaignIds.add(1L)
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, PROFILE)
+        evaluationManager.onSentHeaders(header, endpointId)
 
         // Assert
 
         val resultList = evaluationManager.evaluatedServerSideCampaignIds
-        assertEquals(1, resultList[PROFILE.key]!!.size)
+        assertEquals(1, resultList.size)
     }
 
     @Test
@@ -1562,16 +1495,16 @@ class EvaluationManagerTest : BaseTestCase() {
         // Create a JSONObject with the desired structure
         val header = JSONObject()
 
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, PROFILE)
+        evaluationManager.onSentHeaders(header, endpointId)
 
         // Assert
 
         val resultList = evaluationManager.suppressedClientSideInApps
-        assertEquals(1, resultList[PROFILE.key]!!.size)
-        assertEquals("112322222_646464646", resultList[PROFILE.key]!![0][Constants.NOTIFICATION_ID_TAG])
+        assertEquals(1, resultList.size)
+        assertEquals("112322222_646464646", resultList[0][Constants.NOTIFICATION_ID_TAG])
     }
 
     @Test
@@ -1582,16 +1515,16 @@ class EvaluationManagerTest : BaseTestCase() {
         // Create a JSONObject with the desired structure
         val header = JSONObject().put(Constants.INAPP_SUPPRESSED_META, JSONArray())
 
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to "112322222_646464646"))
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, PROFILE)
+        evaluationManager.onSentHeaders(header, endpointId)
 
         // Assert
 
         val resultList = evaluationManager.suppressedClientSideInApps
-        assertEquals(1, resultList[PROFILE.key]!!.size)
-        assertEquals("112322222_646464646", resultList[PROFILE.key]!![0][Constants.NOTIFICATION_ID_TAG])
+        assertEquals(1, resultList.size)
+        assertEquals("112322222_646464646", resultList[0][Constants.NOTIFICATION_ID_TAG])
     }
 
     @Test
@@ -1607,16 +1540,16 @@ class EvaluationManagerTest : BaseTestCase() {
             )
         }
 
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf("key" to "112322222_646464646"))
+        evaluationManager.suppressedClientSideInApps.add(mapOf("key" to "112322222_646464646"))
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, PROFILE)
+        evaluationManager.onSentHeaders(header, endpointId)
 
         // Assert
 
         val resultList = evaluationManager.suppressedClientSideInApps
-        assertEquals(1, resultList[PROFILE.key]!!.size)
-        assertEquals("112322222_646464646", resultList[PROFILE.key]!![0]["key"])
+        assertEquals(1, resultList.size)
+        assertEquals("112322222_646464646", resultList[0]["key"])
     }
 
     @Test
@@ -1632,15 +1565,15 @@ class EvaluationManagerTest : BaseTestCase() {
             )
         }
 
-        evaluationManager.suppressedClientSideInApps[PROFILE.key]?.add(mapOf(Constants.NOTIFICATION_ID_TAG to JSONObject()))
+        evaluationManager.suppressedClientSideInApps.add(mapOf(Constants.NOTIFICATION_ID_TAG to JSONObject()))
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, PROFILE)
+        evaluationManager.onSentHeaders(header, endpointId)
 
         // Assert
 
         val resultList = evaluationManager.suppressedClientSideInApps
-        assertEquals(1, resultList[PROFILE.key]!!.size)
+        assertEquals(1, resultList.size)
     }
 
     @Test
@@ -1653,40 +1586,17 @@ class EvaluationManagerTest : BaseTestCase() {
             put(Constants.INAPP_SS_EVAL_META, JSONArray().put(0))
         }
 
-        evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]?.add(1L)
-        evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]?.add(2L)
-        evaluationManager.evaluatedServerSideCampaignIds[PROFILE.key]?.add(3L)
+        evaluationManager.evaluatedServerSideCampaignIds.add(1L)
+        evaluationManager.evaluatedServerSideCampaignIds.add(2L)
+        evaluationManager.evaluatedServerSideCampaignIds.add(3L)
 
         // Act
-        evaluationManager.onSentHeaders(header, endpointId, PROFILE)
+        evaluationManager.onSentHeaders(header, endpointId)
 
         // Assert
 
         val resultList = evaluationManager.evaluatedServerSideCampaignIds
-        assertEquals(3, resultList[PROFILE.key]!!.size)
-    }
-
-    @Test
-    fun `onSentHeaders should not remove when evaluatedServerSideCampaignIds have id as 0 for RAISED event`() {
-        // Arrange
-        val endpointId = EndpointId.ENDPOINT_A1
-
-        // Create a JSONObject with the desired structure
-        val header = JSONObject().apply {
-            put(Constants.INAPP_SS_EVAL_META, JSONArray().put(0))
-        }
-
-        evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]?.add(1L)
-        evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]?.add(2L)
-        evaluationManager.evaluatedServerSideCampaignIds[RAISED.key]?.add(3L)
-
-        // Act
-        evaluationManager.onSentHeaders(header, endpointId, RAISED)
-
-        // Assert
-
-        val resultList = evaluationManager.evaluatedServerSideCampaignIds
-        assertEquals(3, resultList[RAISED.key]!!.size)
+        assertEquals(3, resultList.size)
     }
 
     @Test

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/store/preference/InAppStoreTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/store/preference/InAppStoreTest.kt
@@ -2,14 +2,11 @@ package com.clevertap.android.sdk.inapp.store.preference
 
 import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.cryption.CryptHandler
-import com.clevertap.android.sdk.inapp.evaluation.EventType
 import com.clevertap.android.sdk.store.preference.ICTPreference
 import io.mockk.*
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.*
-import org.skyscreamer.jsonassert.JSONAssert
-import org.skyscreamer.jsonassert.JSONCompareMode.STRICT
 import kotlin.test.assertEquals
 
 class InAppStoreTest {

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/store/preference/InAppStoreTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/store/preference/InAppStoreTest.kt
@@ -112,138 +112,42 @@ class InAppStoreTest {
     @Test
     fun `storeEvaluatedServerSideInAppIds writes JSONObject to ctPreference`() {
         // Arrange
-        val evaluatedServerSideInAppIds = JSONObject()
-            .put(EventType.PROFILE.key, listOf(100000,1000002,100000001))
-            .put(EventType.RAISED.key, listOf(200000,2000002,200000001))
+        val evaluatedServerSideInAppIds = JSONArray().apply {
+            put(100000)
+            put(1000002)
+            put(100000001)
+        }
         every { ctPreference.writeString(any(), any()) } just Runs
 
         // Act
         inAppStore.storeEvaluatedServerSideInAppIds(evaluatedServerSideInAppIds)
 
         // Assert
-        verify { ctPreference.writeString(Constants.PREFS_EVALUATED_INAPP_KEY_SS, """{"profile":"[100000, 1000002, 100000001]","raised":"[200000, 2000002, 200000001]"}""") }
+        verify { ctPreference.writeString(Constants.PREFS_EVALUATED_INAPP_KEY_SS, "[100000,1000002,100000001]") }
     }
 
     @Test
     fun `storeSuppressedClientSideInAppIds writes JSONObject to ctPreference`() {
-        // Arrange
-        val evaluatedServerSideInAppIds = JSONObject()
-            .put(EventType.PROFILE.key, listOf(mapOf(Constants.NOTIFICATION_ID_TAG to "id1"), mapOf(Constants.NOTIFICATION_ID_TAG to "id2")))
-            .put(EventType.RAISED.key, listOf(mapOf(Constants.NOTIFICATION_ID_TAG to "id2")))
+
+        val evaluatedServerSideInAppIds = JSONArray().apply {
+            put(
+                JSONObject().apply {
+                    put(Constants.NOTIFICATION_ID_TAG, "id1")
+                }
+            )
+            put(
+                JSONObject().apply {
+                    put(Constants.NOTIFICATION_ID_TAG, "id2")
+                }
+            )
+        }
         every { ctPreference.writeString(any(), any()) } just Runs
 
         // Act
         inAppStore.storeSuppressedClientSideInAppIds(evaluatedServerSideInAppIds)
 
         // Assert
-        verify { ctPreference.writeString(Constants.PREFS_SUPPRESSED_INAPP_KEY_CS, """{"profile":"[{wzrk_id=id1}, {wzrk_id=id2}]","raised":"[{wzrk_id=id2}]"}""") }
-    }
-
-    @Test
-    fun `readEvaluatedServerSideInAppIds returns JSONObject from ctPreference when saved value`() {
-        // Arrange
-        val evaluatedServerSideInAppIdsString = """{"profile":"[100000, 1000002, 100000001]","raised":"[200000, 2000002, 200000001]"}"""
-        every { ctPreference.readString(Constants.PREFS_EVALUATED_INAPP_KEY_SS, any()) } returns evaluatedServerSideInAppIdsString
-
-        // Act
-        val result = inAppStore.readEvaluatedServerSideInAppIds()
-
-        // Assert
-        assertEquals(evaluatedServerSideInAppIdsString, result.toString())
-    }
-
-    @Test
-    fun `readEvaluatedServerSideInAppIds returns empty JSONObject from ctPreference when saved value is null`()
-    {
-        // Arrange
-        val evaluatedServerSideInAppIdsString = null
-        every { ctPreference.readString(Constants.PREFS_EVALUATED_INAPP_KEY_SS, any()) } returns evaluatedServerSideInAppIdsString
-
-        // Act
-        val result = inAppStore.readEvaluatedServerSideInAppIds()
-
-        // Assert
-        JSONAssert.assertEquals(JSONObject(), result, STRICT)
-    }
-
-    @Test
-    fun `readEvaluatedServerSideInAppIds returns empty JSONObject from ctPreference when saved value is empty`() {
-        // Arrange
-        val evaluatedServerSideInAppIdsString = ""
-        every { ctPreference.readString(Constants.PREFS_EVALUATED_INAPP_KEY_SS, any()) } returns evaluatedServerSideInAppIdsString
-
-        // Act
-        val result = inAppStore.readEvaluatedServerSideInAppIds()
-
-        // Assert
-        JSONAssert.assertEquals(JSONObject(), result, STRICT)
-    }
-
-    @Test
-    fun `readEvaluatedServerSideInAppIds returns populated JSONObject from ctPreference when saved value is legacy JSoNArray`() {
-        // Arrange
-        val evaluatedServerSideInAppIdsString = "[100000, 1000002, 100000001]"
-        every { ctPreference.readString(Constants.PREFS_EVALUATED_INAPP_KEY_SS, any()) } returns evaluatedServerSideInAppIdsString
-
-        // Act
-        val result = inAppStore.readEvaluatedServerSideInAppIds()
-
-        // Assert
-        JSONAssert.assertEquals(JSONObject().put(EventType.RAISED.key, JSONArray("[100000, 1000002, 100000001]")), result, STRICT)
-    }
-
-
-    @Test
-    fun `readSuppressedClientSideInAppIds() returns JSONObject from ctPreference when saved value`() {
-        // Arrange
-        val evaluatedServerSideInAppIdsString = """{"profile":"[{wzrk_id=id1}, {wzrk_id=id2}]","raised":"[{wzrk_id=id2}]"}"""
-        every { ctPreference.readString(Constants.PREFS_SUPPRESSED_INAPP_KEY_CS, any()) } returns evaluatedServerSideInAppIdsString
-
-        // Act
-        val result = inAppStore.readSuppressedClientSideInAppIds()
-
-        // Assert
-        assertEquals(evaluatedServerSideInAppIdsString, result.toString())
-    }
-
-    @Test
-    fun `readSuppressedClientSideInAppIds() returns empty JSONObject from ctPreference when saved value is null`()
-    {
-        // Arrange
-        val evaluatedServerSideInAppIdsString = null
-        every { ctPreference.readString(Constants.PREFS_SUPPRESSED_INAPP_KEY_CS, any()) } returns evaluatedServerSideInAppIdsString
-
-        // Act
-        val result = inAppStore.readSuppressedClientSideInAppIds()
-
-        // Assert
-        JSONAssert.assertEquals(JSONObject(), result, STRICT)
-    }
-
-    @Test
-    fun `readSuppressedClientSideInAppIds() returns empty JSONObject from ctPreference when saved value is empty`() {
-        // Arrange
-        val evaluatedServerSideInAppIdsString = ""
-        every { ctPreference.readString(Constants.PREFS_SUPPRESSED_INAPP_KEY_CS, any()) } returns evaluatedServerSideInAppIdsString
-
-        // Act
-        val result = inAppStore.readSuppressedClientSideInAppIds()
-
-        // Assert
-        JSONAssert.assertEquals(JSONObject(), result, STRICT)
-    }
-
-    @Test
-    fun `readSuppressedClientSideInAppIds() returns populated JSONObject from ctPreference when saved value is legacy JSoNArray`() {
-        // Arrange
-        val evaluatedServerSideInAppIdsString = "[{wzrk_id=id1}, {wzrk_id=id2}]"
-        every { ctPreference.readString(Constants.PREFS_SUPPRESSED_INAPP_KEY_CS, any()) } returns evaluatedServerSideInAppIdsString
-
-        // Act
-        val result = inAppStore.readSuppressedClientSideInAppIds()
-
-        // Assert
-        JSONAssert.assertEquals(JSONObject().put(EventType.RAISED.key, JSONArray("[{wzrk_id=id1}, {wzrk_id=id2}]")), result, STRICT)
+        verify { ctPreference.writeString(Constants.PREFS_SUPPRESSED_INAPP_KEY_CS, evaluatedServerSideInAppIds.toString()) }
     }
 
     @Test


### PR DESCRIPTION
- removes separate handling as it is not needed
- reverts back to original way of saving data for suppressed and eval modes.