### PR TITLE
task(SDK-5134) - Fix to support custom init of agconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## CHANGE LOG.
+### September 26, 2025
+* [CleverTap Huawei Push SDK v1.5.1](docs/CTHUAWEIPUSHCHANGELOG.md)
+
 ### September 11, 2025
 * [CleverTap Android SDK v7.5.2](docs/CTCORECHANGELOG.md)
 

--- a/clevertap-hms/src/main/java/com/clevertap/android/hms/HmsSdkHandler.java
+++ b/clevertap-hms/src/main/java/com/clevertap/android/hms/HmsSdkHandler.java
@@ -7,6 +7,7 @@ import static com.clevertap.android.sdk.pushnotification.PushConstants.LOG_TAG;
 
 import android.content.Context;
 import android.text.TextUtils;
+
 import com.clevertap.android.sdk.CleverTapInstanceConfig;
 import com.huawei.agconnect.AGConnectInstance;
 import com.huawei.agconnect.AGConnectOptions;
@@ -23,7 +24,7 @@ class HmsSdkHandler implements IHmsSdkHandler {
 
     private final Context context;
     private final CleverTapInstanceConfig mConfig;
-    private AGConnectOptions options;
+    private volatile AGConnectOptions options;
 
     HmsSdkHandler(final Context context, final CleverTapInstanceConfig config) {
         this.context = context.getApplicationContext();
@@ -31,13 +32,16 @@ class HmsSdkHandler implements IHmsSdkHandler {
     }
 
     @TestOnly
-    HmsSdkHandler(final Context context, final CleverTapInstanceConfig config,final AGConnectOptions op) {
+    HmsSdkHandler(final Context context, final CleverTapInstanceConfig config, final AGConnectOptions op) {
         this.context = context.getApplicationContext();
         mConfig = config;
         options = op;
     }
 
-    private void initializeOptions() {
+    private synchronized void initializeOptions() {
+        if (options != null) {
+            return;
+        }
         try {
             // Try existing AGConnect instance first
             AGConnectInstance instance = AGConnectInstance.getInstance();

--- a/docs/CTHUAWEIPUSH.md
+++ b/docs/CTHUAWEIPUSH.md
@@ -52,7 +52,7 @@ allprojects {
 * Add the following to your app’s `build.gradle` file
 
 ```groovy
-implementation "com.clevertap.android:clevertap-hms-sdk:1.5.0"
+implementation "com.clevertap.android:clevertap-hms-sdk:1.5.1"
 implementation "com.huawei.hms:push:6.11.0.300"
 
 //At the bottom of the file add this

--- a/docs/CTHUAWEIPUSHCHANGELOG.md
+++ b/docs/CTHUAWEIPUSHCHANGELOG.md
@@ -1,5 +1,8 @@
 ## CleverTap Huawei Push SDK CHANGE LOG
 
+### Version 1.5.1 (September 26, 2025)
+* Adds support for custom initialization of `AGConnect` using `agconnect-services.json` from the assets folder.
+
 ### Version 1.5.0 (March 11, 2025)
 
 #### Breaking API Changes

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ installreferrer = "2.2"
 clevertap_android_sdk = "7.5.2"
 clevertap_rendermax_sdk = "1.0.3"
 clevertap_geofence_sdk = "1.4.0"
-clevertap_hms_sdk = "1.5.0"
+clevertap_hms_sdk = "1.5.1"
 clevertap_push_templates_sdk = "2.1.0"
 
 # Glide

--- a/templates/CTHUAWEIPUSHCHANGELOG.md
+++ b/templates/CTHUAWEIPUSHCHANGELOG.md
@@ -1,5 +1,8 @@
 ## CleverTap Huawei Push SDK CHANGE LOG
 
+### Version 1.5.1 (September 26, 2025)
+* Adds support for custom initialization of `AGConnect` using `agconnect-services.json` from the assets folder.
+
 ### Version 1.5.0 (March 11, 2025)
 
 #### Breaking API Changes


### PR DESCRIPTION
1. Gets the agconnect options from the initialized object rather than creating a new one each time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Safer handling when HMS configuration isn’t available, reducing failures when fetching the HMS app ID.
  - Clearer error logging for initialization and ID retrieval.

- Performance
  - Lazy initialization and reuse of existing HMS configuration to avoid unnecessary setup.

- Documentation
  - Added changelog and docs noting v1.5.1 and support for custom AGConnect initialization via agconnect-services.json.

- Chores
  - Updated internal HMS SDK dependency version to 1.5.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->