### PR TITLE
task(SDK-5045) - Avoids duplicate redownloads of images and gifs

### DIFF
--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
@@ -184,6 +184,7 @@ class TemplateRenderer(context: Context, extras: Bundle, internal val config: Cl
                 PTLog.verbose("operation not defined!")
             }
         }
+        templateMediaManager.clearCaches()
         return null
     }
 


### PR DESCRIPTION
- Uses a simple cache
- Effective for templates where same images were required in different views