### PR TITLE
task(SDK-5365) - Removes the setTheme from the InAppNotificationActivity

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -252,11 +252,6 @@ public final class InAppNotificationActivity extends FragmentActivity implements
     }
 
     @Override
-    public void setTheme(int resid) {
-        super.setTheme(android.R.style.Theme_Translucent_NoTitleBar);
-    }
-
-    @Override
     public void didClickForHardPermissionWithFallbackSettings(boolean fallbackToSettings) {
         showPushPermissionPrompt(fallbackToSettings);
     }


### PR DESCRIPTION
Theme is already set in AndroidManifest.xml of clevertap-core

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * In-app notifications now use the app's default theme instead of enforcing a fixed translucent style, ensuring visual consistency with the rest of the app.
  * Notification screens now respect custom themes and title bar settings for improved appearance and compatibility.
  * No other functional behavior of in-app notifications was changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->