### PR TITLE
task(SDK-5528) - Fixes an NPE due to a possible race condition

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -826,7 +826,6 @@ internal class InAppController(
 
     @MainThread
     private fun showInApp(inAppNotification: CTInAppNotification) {
-        val activity = CoreMetaData.getCurrentActivity()
         val goFromListener = checkBeforeShowApprovalBeforeDisplay(inAppNotification)
         if (!goFromListener) {
             logger.verbose(
@@ -857,6 +856,7 @@ internal class InAppController(
             return
         }
 
+        val activity = CoreMetaData.getCurrentActivity()
         if (!canShowInAppOnActivity(activity)) {
             pendingNotifications.add(inAppNotification)
             logger.verbose(
@@ -956,18 +956,21 @@ internal class InAppController(
             }
         }
 
-        if (inAppFragment != null) {
-            logger.debug("Displaying In-App: ${inAppNotification.jsonDescription}")
-            val showFragmentSuccess = CTInAppBaseFragment.showOnActivity(
-                inAppFragment,
-                activity,
-                inAppNotification,
-                config,
-                defaultLogTag
-            )
-            if (!showFragmentSuccess) {
-                currentlyDisplayingInApp = null
-            }
+        if (inAppFragment == null || activity == null) {
+            logger.debug("Unable to display In-App: Activity/Fragment is null")
+            return
+        }
+
+        logger.debug("Displaying In-App: ${inAppNotification.jsonDescription}")
+        val showFragmentSuccess = CTInAppBaseFragment.showOnActivity(
+            inAppFragment,
+            activity,
+            inAppNotification,
+            config,
+            defaultLogTag
+        )
+        if (!showFragmentSuccess) {
+            currentlyDisplayingInApp = null
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -924,8 +924,8 @@ internal class InAppController(
                         t
                     )
                     currentlyDisplayingInApp = null
-                    return
                 }
+                return
             }
 
             CTInAppTypeFooterHTML -> {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -958,6 +958,7 @@ internal class InAppController(
 
         if (inAppFragment == null || activity == null) {
             logger.debug("Unable to display In-App: Activity/Fragment is null")
+            currentlyDisplayingInApp = null
             return
         }
 


### PR DESCRIPTION
- Valid for Fragment Based InApps
- Adds a simple null check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of in-app message presentation by adding null-safe guards and early exits to avoid displaying when UI or activity is unavailable.
  * Consolidated visibility checks to ensure messages are only shown when both fragment and activity are present.
  * Ensures consistent logging and clears any pending in-app state when a message cannot be shown, reducing unexpected behavior and potential crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->