### PR TITLE
fix(SDK-5461): Replace printStackTrace() with Logger methods

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
@@ -50,8 +50,7 @@ fun Context.isNotificationChannelEnabled(channelId: String): Boolean =
 fun Context.areAppNotificationsEnabled() = try {
     NotificationManagerCompat.from(this).areNotificationsEnabled()
 } catch (e: Exception) {
-    Logger.d("Unable to query notifications enabled flag, returning true!")
-    e.printStackTrace()
+    Logger.d("Unable to query notifications enabled flag, returning true!",e)
     true
 }
 
@@ -226,11 +225,10 @@ fun CleverTapAPI.flushPushImpressionsOnPostAsyncSafely(logTag: String, caller: S
         }
         null
     }
-
     try {
         flushFutureResult.get()
     } catch (e: Exception) {
-        e.printStackTrace()
+        Logger.d(logTag, "Error getting flush result for push impressions", e)
     }
 }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
@@ -42,7 +42,7 @@ fun Context.isNotificationChannelEnabled(channelId: String): Boolean =
         } catch (e: Exception) {
             Logger.d(
                 Constants.CLEVERTAP_LOG_TAG,
-                "Unable to find notification channel with id = $channelId"
+                "Unable to find notification channel with id = $channelId", e
             )
             false
         }
@@ -55,7 +55,7 @@ fun Context.areAppNotificationsEnabled() = try {
 } catch (e: Exception) {
     Logger.d(
         Constants.CLEVERTAP_LOG_TAG,
-        "Unable to query notifications enabled flag, returning true!"
+        "Unable to query notifications enabled flag, returning true!", e
     )
     true
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
@@ -40,7 +40,10 @@ fun Context.isNotificationChannelEnabled(channelId: String): Boolean =
             val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
             nm.getNotificationChannel(channelId).importance != NotificationManager.IMPORTANCE_NONE
         } catch (e: Exception) {
-            Logger.d(Constants.CLEVERTAP_LOG_TAG, "Unable to find notification channel with id = $channelId")
+            Logger.d(
+                Constants.CLEVERTAP_LOG_TAG,
+                "Unable to find notification channel with id = $channelId"
+            )
             false
         }
     } else {
@@ -50,7 +53,10 @@ fun Context.isNotificationChannelEnabled(channelId: String): Boolean =
 fun Context.areAppNotificationsEnabled() = try {
     NotificationManagerCompat.from(this).areNotificationsEnabled()
 } catch (e: Exception) {
-    Logger.d(Constants.CLEVERTAP_LOG_TAG, "Unable to query notifications enabled flag, returning true!")
+    Logger.d(
+        Constants.CLEVERTAP_LOG_TAG,
+        "Unable to query notifications enabled flag, returning true!"
+    )
     true
 }
 
@@ -94,7 +100,7 @@ fun NotificationManager.getOrCreateChannel(
         // Create appropriate fallback channel
         createFallbackChannel(context, hideHeadsUp)
     } catch (e: Exception) {
-        Logger.v(Constants.CLEVERTAP_LOG_TAG, "Error getting or creating notification channel", e)
+        Logger.d(Constants.CLEVERTAP_LOG_TAG, "Error getting or creating notification channel", e)
         null
     }
 }
@@ -123,7 +129,10 @@ private fun NotificationManager.tryGetChannel(
     val shouldSkip = hideHeadsUp && channel.importance != NotificationManager.IMPORTANCE_LOW
 
     if (shouldSkip) {
-        Logger.d(Constants.CLEVERTAP_LOG_TAG, "Skipping channel $channelId because heads-up should be hidden in FG but importance is ${channel.importance}")
+        Logger.d(
+            Constants.CLEVERTAP_LOG_TAG,
+            "Skipping channel $channelId because heads-up should be hidden in FG but importance is ${channel.importance}"
+        )
         return null
     }
     return channelId
@@ -185,6 +194,11 @@ private fun NotificationManager.createDefaultFallbackChannel(context: Context): 
         val channelName = try {
             context.getString(R.string.ct_fcm_fallback_notification_channel_label)
         } catch (e: Exception) {
+            Logger.d(
+                Constants.CLEVERTAP_LOG_TAG,
+                "Failed to fetch fallback channel name from resources",
+                e
+            )
             Constants.FCM_FALLBACK_NOTIFICATION_CHANNEL_NAME
         }
 
@@ -211,14 +225,26 @@ private fun NotificationManager.createDefaultFallbackChannel(context: Context): 
  * @param context The application context.
  */
 @MainThread
-fun CleverTapAPI.flushPushImpressionsOnPostAsyncSafely(logTag: String, caller: String, context: Context) {
+fun CleverTapAPI.flushPushImpressionsOnPostAsyncSafely(
+    logTag: String,
+    caller: String,
+    context: Context
+) {
     val flushTask = CTExecutorFactory.executors(coreState.config).postAsyncSafelyTask<Void?>()
 
     val flushFutureResult = flushTask.submit(logTag) {
         try {
-            coreState.baseEventQueueManager.flushQueueSync(context, PUSH_NOTIFICATION_VIEWED, caller)
+            coreState.baseEventQueueManager.flushQueueSync(
+                context,
+                PUSH_NOTIFICATION_VIEWED,
+                caller
+            )
         } catch (e: Exception) {
-            Logger.d(logTag, "Failed to flush push impressions on CT instance = ${coreState.config.accountId}", e)
+            Logger.d(
+                logTag,
+                "Failed to flush push impressions on CT instance = ${coreState.config.accountId}",
+                e
+            )
         }
         null
     }
@@ -427,13 +453,13 @@ fun String?.isNotNullAndBlank(): Boolean {
  * }
  * ```
  */
-fun View.applyInsetsWithMarginAdjustment(marginAdjuster : (insets:Insets, mlp:MarginLayoutParams) -> Unit) {
+fun View.applyInsetsWithMarginAdjustment(marginAdjuster: (insets: Insets, mlp: MarginLayoutParams) -> Unit) {
     ViewCompat.setOnApplyWindowInsetsListener(this) { v, insets ->
         val bars: Insets = insets.getInsets(
             WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
         )
         v.updateLayoutParams<MarginLayoutParams> {
-            marginAdjuster(bars,this)
+            marginAdjuster(bars, this)
         }
         WindowInsetsCompat.CONSUMED
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTXtensions.kt
@@ -40,7 +40,7 @@ fun Context.isNotificationChannelEnabled(channelId: String): Boolean =
             val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
             nm.getNotificationChannel(channelId).importance != NotificationManager.IMPORTANCE_NONE
         } catch (e: Exception) {
-            Logger.d("Unable to find notification channel with id = $channelId")
+            Logger.d(Constants.CLEVERTAP_LOG_TAG, "Unable to find notification channel with id = $channelId")
             false
         }
     } else {
@@ -50,7 +50,7 @@ fun Context.isNotificationChannelEnabled(channelId: String): Boolean =
 fun Context.areAppNotificationsEnabled() = try {
     NotificationManagerCompat.from(this).areNotificationsEnabled()
 } catch (e: Exception) {
-    Logger.d("Unable to query notifications enabled flag, returning true!",e)
+    Logger.d(Constants.CLEVERTAP_LOG_TAG, "Unable to query notifications enabled flag, returning true!")
     true
 }
 
@@ -123,10 +123,7 @@ private fun NotificationManager.tryGetChannel(
     val shouldSkip = hideHeadsUp && channel.importance != NotificationManager.IMPORTANCE_LOW
 
     if (shouldSkip) {
-        Logger.d(
-            Constants.CLEVERTAP_LOG_TAG,
-            "Skipping channel $channelId because heads-up should be hidden in FG but importance is ${channel.importance}"
-        )
+        Logger.d(Constants.CLEVERTAP_LOG_TAG, "Skipping channel $channelId because heads-up should be hidden in FG but importance is ${channel.importance}")
         return null
     }
     return channelId
@@ -221,7 +218,7 @@ fun CleverTapAPI.flushPushImpressionsOnPostAsyncSafely(logTag: String, caller: S
         try {
             coreState.baseEventQueueManager.flushQueueSync(context, PUSH_NOTIFICATION_VIEWED, caller)
         } catch (e: Exception) {
-            Logger.d(logTag, "failed to flush push impressions on ct instance = " + coreState.config.accountId)
+            Logger.d(logTag, "Failed to flush push impressions on CT instance = ${coreState.config.accountId}", e)
         }
         null
     }
@@ -402,7 +399,7 @@ fun String?.toJsonOrNull(): JSONObject? {
 }
 
 @OptIn(ExperimentalContracts::class)
-fun String?.isNotNullAndBlank() : Boolean {
+fun String?.isNotNullAndBlank(): Boolean {
     contract { returns(true) implies (this@isNotNullAndBlank != null) }
     return isNullOrBlank().not()
 }
@@ -431,8 +428,7 @@ fun String?.isNotNullAndBlank() : Boolean {
  * ```
  */
 fun View.applyInsetsWithMarginAdjustment(marginAdjuster : (insets:Insets, mlp:MarginLayoutParams) -> Unit) {
-    ViewCompat.setOnApplyWindowInsetsListener(this
-    ) { v, insets ->
+    ViewCompat.setOnApplyWindowInsetsListener(this) { v, insets ->
         val bars: Insets = insets.getInsets(
             WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
         )

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
@@ -462,14 +462,14 @@ public class DeviceInfo {
                 }
             } catch (Exception e) {
                 //uiModeManager or context is null
-                Logger.v(TAG, "Failed to decide whether device is a TV!", e);
+                Logger.d(TAG, "Failed to decide whether device is a TV!", e);
             }
 
             try {
                 sDeviceType = context.getResources().getBoolean(R.bool.ctIsTablet) ? TABLET : SMART_PHONE;
             } catch (Exception e) {
                 // resource not found or context is null
-                Logger.v(TAG, "Failed to decide whether device is a smart phone or tablet!", e);
+                Logger.d(TAG, "Failed to decide whether device is a smart phone or tablet!", e);
                 sDeviceType = UNKNOWN;
             }
         }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
@@ -26,6 +26,7 @@ import android.view.Display;
 import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.view.WindowMetrics;
+
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
@@ -41,6 +42,8 @@ import com.clevertap.android.sdk.validation.ValidationError;
 import com.clevertap.android.sdk.validation.ValidationResult;
 import com.clevertap.android.sdk.validation.ValidationResultFactory;
 
+import org.json.JSONObject;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.reflect.Method;
@@ -48,12 +51,12 @@ import java.util.ArrayList;
 import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.Callable;
-import org.json.JSONObject;
 
 @RestrictTo(Scope.LIBRARY)
 public class DeviceInfo {
 
     private static final String TAG = "DeviceInfo";
+
     private class DeviceCachedInfo {
 
 
@@ -196,7 +199,7 @@ public class DeviceInfo {
                 packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
                 return packageInfo.versionCode;
             } catch (PackageManager.NameNotFoundException e) {
-                getConfigLogger().debug(config.getAccountId(), "Unable to get app build");
+                getConfigLogger().debug(config.getAccountId(), "Unable to get app build", e);
             }
             return 0;
         }
@@ -232,20 +235,20 @@ public class DeviceInfo {
         }
 
         /**
-         *  This method is used for devices above API 28
-            This method gets the standby values for app.Standby buckets are divided into the following:-
-            STANDBY_BUCKET_ACTIVE - The app was used very recently, currently in use or likely to be used very soon.
-            STANDBY_BUCKET_FREQUENT - The app was used in the last few days and/or likely to be used in the next few days.
-            STANDBY_BUCKET_RARE - The app has not be used for several days and/or is unlikely to be used for several days.
-            STANDBY_BUCKET_RESTRICTED - The app has not be used for several days, is unlikely to be used for several days, and has
-                                        been misbehaving in some manner.
-            STANDBY_BUCKET_WORKING_SET - The app was used recently and/or likely to be used in the next few hours.
-
-            @return one of the possible String value of AppStandbyBucket(). If no AppBucket info is found,
-                    returns empty String
-        */
+         * This method is used for devices above API 28
+         * This method gets the standby values for app.Standby buckets are divided into the following:-
+         * STANDBY_BUCKET_ACTIVE - The app was used very recently, currently in use or likely to be used very soon.
+         * STANDBY_BUCKET_FREQUENT - The app was used in the last few days and/or likely to be used in the next few days.
+         * STANDBY_BUCKET_RARE - The app has not be used for several days and/or is unlikely to be used for several days.
+         * STANDBY_BUCKET_RESTRICTED - The app has not be used for several days, is unlikely to be used for several days, and has
+         * been misbehaving in some manner.
+         * STANDBY_BUCKET_WORKING_SET - The app was used recently and/or likely to be used in the next few hours.
+         *
+         * @return one of the possible String value of AppStandbyBucket(). If no AppBucket info is found,
+         * returns empty String
+         */
         @RequiresApi(api = Build.VERSION_CODES.P)
-        private String getAppBucket(){
+        private String getAppBucket() {
             UsageStatsManager usm = (UsageStatsManager) context.getSystemService(USAGE_STATS_SERVICE);
             switch (usm.getAppStandbyBucket()) {
                 case UsageStatsManager.STANDBY_BUCKET_ACTIVE:
@@ -292,7 +295,7 @@ public class DeviceInfo {
                 packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
                 return packageInfo.versionName;
             } catch (PackageManager.NameNotFoundException e) {
-                getConfigLogger().debug(config.getAccountId(), "Unable to get app version");
+                getConfigLogger().debug(config.getAccountId(), "Unable to get app version", e);
             }
             return null;
         }
@@ -474,7 +477,7 @@ public class DeviceInfo {
     }
 
     DeviceInfo(Context context, CleverTapInstanceConfig config, String cleverTapID,
-            CoreMetaData coreMetaData) {
+               CoreMetaData coreMetaData) {
         this.context = context;
         this.config = config;
         this.library = null;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
@@ -455,19 +455,16 @@ public class DeviceInfo {
                 }
             } catch (Exception e) {
                 //uiModeManager or context is null
-                Logger.d("Failed to decide whether device is a TV!");
-                e.printStackTrace();
+                Logger.d("Failed to decide whether device is a TV!",e);
             }
 
             try {
                 sDeviceType = context.getResources().getBoolean(R.bool.ctIsTablet) ? TABLET : SMART_PHONE;
             } catch (Exception e) {
                 // resource not found or context is null
-                Logger.d("Failed to decide whether device is a smart phone or tablet!");
-                e.printStackTrace();
+                Logger.d("Failed to decide whether device is a smart phone or tablet!",e);
                 sDeviceType = UNKNOWN;
             }
-
         }
         return sDeviceType;
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/DeviceInfo.java
@@ -53,7 +53,9 @@ import org.json.JSONObject;
 @RestrictTo(Scope.LIBRARY)
 public class DeviceInfo {
 
+    private static final String TAG = "DeviceInfo";
     private class DeviceCachedInfo {
+
 
         private final static String STANDBY_BUCKET_ACTIVE = "active";
         private final static String STANDBY_BUCKET_FREQUENT = "frequent";
@@ -130,7 +132,8 @@ public class DeviceInfo {
             WindowManager wm = getWindowManager();
 
             if (wm == null) {
-                Logger.v("WindowManager is null, returning zero dimension for width/height");
+                getConfigLogger().verbose(config.getAccountId(),
+                        "WindowManager is null, returning zero dimension for width/height");
                 return new WindowSize(0, 0, 0);
             }
 
@@ -193,7 +196,7 @@ public class DeviceInfo {
                 packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
                 return packageInfo.versionCode;
             } catch (PackageManager.NameNotFoundException e) {
-                Logger.d("Unable to get app build");
+                getConfigLogger().debug(config.getAccountId(), "Unable to get app build");
             }
             return 0;
         }
@@ -255,7 +258,8 @@ public class DeviceInfo {
                     return STANDBY_BUCKET_RESTRICTED;
                 case UsageStatsManager.STANDBY_BUCKET_WORKING_SET:
                     return STANDBY_BUCKET_WORKING_SET;
-                default: return "";
+                default:
+                    return "";
             }
         }
 
@@ -288,7 +292,7 @@ public class DeviceInfo {
                 packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
                 return packageInfo.versionName;
             } catch (PackageManager.NameNotFoundException e) {
-                Logger.d("Unable to get app version");
+                getConfigLogger().debug(config.getAccountId(), "Unable to get app version");
             }
             return null;
         }
@@ -346,7 +350,7 @@ public class DeviceInfo {
                     }
                 }
             } catch (Exception e) {
-                Logger.v("Window context creation failed: " + e.getMessage());
+                getConfigLogger().verbose(config.getAccountId(), "Window context creation failed", e);
             }
         }
 
@@ -455,14 +459,14 @@ public class DeviceInfo {
                 }
             } catch (Exception e) {
                 //uiModeManager or context is null
-                Logger.d("Failed to decide whether device is a TV!",e);
+                Logger.v(TAG, "Failed to decide whether device is a TV!", e);
             }
 
             try {
                 sDeviceType = context.getResources().getBoolean(R.bool.ctIsTablet) ? TABLET : SMART_PHONE;
             } catch (Exception e) {
                 // resource not found or context is null
-                Logger.d("Failed to decide whether device is a smart phone or tablet!",e);
+                Logger.v(TAG, "Failed to decide whether device is a smart phone or tablet!", e);
                 sDeviceType = UNKNOWN;
             }
         }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Utils.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Utils.java
@@ -586,7 +586,7 @@ public final class Utils {
             }
             return DownloadedBitmapFactory.INSTANCE.successBitmap(drawableToBitmap(logo), 0, null);
         } catch (Exception e) {
-            e.printStackTrace();
+            Logger.v("Utils", "Failed to get app logo, falling back to app icon", e);
             // Try to get the app icon now
             // No error handling here - handle upstream
             return DownloadedBitmapFactory.INSTANCE.successBitmap(
@@ -640,7 +640,7 @@ public final class Utils {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            Logger.v("Utils", "Error checking if main process", e);
         }
         return false;
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Utils.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Utils.java
@@ -56,12 +56,12 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Scanner;
 import java.util.regex.Pattern;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 public final class Utils {
+    private static final String TAG = "Utils";
 
     private static final Pattern normalizedNameExcludePattern = Pattern.compile("\\s+");
 
@@ -99,8 +99,7 @@ public final class Utils {
                 try {
                     hashMapArrayList.add(convertJSONObjectToHashMap(jsonArray.getJSONObject(i)));
                 } catch (JSONException e) {
-                    Logger.v("Could not convert JSONArray of JSONObjects to ArrayList of HashMaps - " + e
-                            .getMessage());
+                    Logger.v(TAG, "Could not convert JSONArray of JSONObjects to ArrayList of HashMaps" ,e);
                 }
             }
         }
@@ -114,7 +113,7 @@ public final class Utils {
                 try {
                     listdata.add(array.getString(i));
                 } catch (JSONException e) {
-                    Logger.v("Could not convert JSONArray to ArrayList - " + e.getMessage());
+                    Logger.v(TAG, "Could not convert JSONArray to ArrayList",e);
                 }
             }
         }
@@ -213,10 +212,10 @@ public final class Utils {
                 try {
                     networkType = teleMan.getDataNetworkType();
                 } catch (SecurityException se) {
-                    Logger.d("Security Exception caught while fetch network type" + se.getMessage());
+                    Logger.d(TAG, "Security Exception caught while fetch network type",se);
                 }
             } else {
-                Logger.d("READ_PHONE_STATE permission not asked by the app or not granted by the user");
+                Logger.d(TAG , "READ_PHONE_STATE permission not asked by the app or not granted by the user");
             }
         } else {
             networkType = teleMan.getNetworkType();
@@ -314,7 +313,7 @@ public final class Utils {
             }
         } catch (Exception e) {
             config.getLogger().debug(config.getAccountId(),
-                    "Couldn't download gif for notification: " + e.getMessage());
+                    "Couldn't download gif for notification: " ,e);
             return null;
         }
     }
@@ -417,7 +416,7 @@ public final class Utils {
             }
         } catch (Exception e) {
             config.getLogger().debug(config.getAccountId(),
-                    "Error during animated image cleanup: " + e.getMessage());
+                    "Error during animated image cleanup: ",e);
         }
     }
 
@@ -466,12 +465,12 @@ public final class Utils {
             ServiceInfo[] services = packageInfo.services;
             for (ServiceInfo serviceInfo : services) {
                 if (serviceInfo.name.equals(clazz.getName())) {
-                    Logger.v("Service " + serviceInfo.name + " found");
+                    Logger.v(TAG, "Service " + serviceInfo.name + " found");
                     return true;
                 }
             }
         } catch (PackageManager.NameNotFoundException e) {
-            Logger.d("Intent Service name not found exception - " + e.getLocalizedMessage());
+            Logger.d(TAG, "Intent Service name not found exception - " ,e);
         }
         return false;
     }
@@ -542,21 +541,21 @@ public final class Utils {
     public static boolean validateCTID(String cleverTapID) {
         if (cleverTapID == null) {
             Logger.i(
-                    "CLEVERTAP_USE_CUSTOM_ID has been set as 1 in AndroidManifest.xml but custom CleverTap ID passed is NULL.");
+                    TAG, "CLEVERTAP_USE_CUSTOM_ID has been set as 1 in AndroidManifest.xml but custom CleverTap ID passed is NULL.");
             return false;
         }
         if (cleverTapID.isEmpty()) {
             Logger.i(
-                    "CLEVERTAP_USE_CUSTOM_ID has been set as 1 in AndroidManifest.xml but custom CleverTap ID passed is empty.");
+                   TAG,  "CLEVERTAP_USE_CUSTOM_ID has been set as 1 in AndroidManifest.xml but custom CleverTap ID passed is empty.");
             return false;
         }
         if (cleverTapID.length() > 64) {
-            Logger.i("Custom CleverTap ID passed is greater than 64 characters. ");
+            Logger.i(TAG, "Custom CleverTap ID passed is greater than 64 characters. ");
             return false;
         }
         if (!cleverTapID.matches("[=|<>;+.A-Za-z0-9()!:$@_-]*")) {
             Logger.i(
-                    "Custom CleverTap ID cannot contain special characters apart from : =,(,),_,!,@,$,|<,>,;,+,. and - ");
+                   TAG, "Custom CleverTap ID cannot contain special characters apart from : =,(,),_,!,@,$,|<,>,;,+,. and - ");
             return false;
         }
         return true;
@@ -586,7 +585,7 @@ public final class Utils {
             }
             return DownloadedBitmapFactory.INSTANCE.successBitmap(drawableToBitmap(logo), 0, null);
         } catch (Exception e) {
-            Logger.v("Utils", "Failed to get app logo, falling back to app icon", e);
+            Logger.v(TAG, "Failed to get app logo, falling back to app icon", e);
             // Try to get the app icon now
             // No error handling here - handle upstream
             return DownloadedBitmapFactory.INSTANCE.successBitmap(
@@ -640,7 +639,7 @@ public final class Utils {
                 }
             }
         } catch (Exception e) {
-            Logger.v("Utils", "Error checking if main process", e);
+            Logger.v(TAG, "Error checking if main process", e);
         }
         return false;
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/BitmapDownloader.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/BitmapDownloader.kt
@@ -17,6 +17,7 @@ class BitmapDownloader(
 ) {
     companion object {
         const val NETWORK_TAG_DOWNLOAD_REQUESTS = 21
+        private const val TAG = "BitmapDownloader"
     }
 
     private var downloadStartTimeInMilliseconds: Long = 0
@@ -24,7 +25,7 @@ class BitmapDownloader(
     private lateinit var srcUrl: String
 
     fun downloadBitmap(srcUrl: String): DownloadedBitmap {
-        Logger.v("initiating bitmap download in BitmapDownloader....")
+        Logger.v(TAG, "Initiating bitmap download in BitmapDownloader...")
 
         this.srcUrl = srcUrl
         downloadStartTimeInMilliseconds = Utils.getNowInMillis()
@@ -36,11 +37,11 @@ class BitmapDownloader(
 
                 // expect HTTP 200 OK, so we don't mistakenly save error report instead of the file
                 if (responseCode != HttpURLConnection.HTTP_OK) {
-                    Logger.d("File not loaded completely not going forward. URL was: $srcUrl")
+                    Logger.d(TAG, "File not loaded completely. URL was: $srcUrl")
                     return DownloadedBitmapFactory.nullBitmapWithStatus(DOWNLOAD_FAILED)
                 }
 
-                Logger.v("Downloading $srcUrl....")
+                Logger.v(TAG, "Downloading $srcUrl....")
 
                 // might be -1: server did not report the length
                 val fileLength = contentLength
@@ -48,7 +49,7 @@ class BitmapDownloader(
 
                 // Check if the size limit is exceeded
                 if (isSizeConstrained && fileLength > size) {
-                    Logger.v("Image size is larger than $size bytes. Cancelling download!")
+                    Logger.v(TAG, "Image size is larger than $size bytes. Cancelling download!")
                     return DownloadedBitmapFactory.nullBitmapWithStatus(SIZE_LIMIT_EXCEEDED)
                 }
 
@@ -59,14 +60,14 @@ class BitmapDownloader(
                 )
             }
         } catch (e: Throwable) {
-            Logger.v("BitmapDownloader", "Couldn't download the notification media. URL was: $srcUrl", e)
+            Logger.v(TAG, "Couldn't download the notification media. URL was: $srcUrl", e)
             return DownloadedBitmapFactory.nullBitmapWithStatus(DOWNLOAD_FAILED)
         } finally {
             try {
                 connection.disconnect()
                 TrafficStats.clearThreadStatsTag()
             } catch (t: Throwable) {
-                Logger.v("Couldn't close connection!", t)
+                Logger.v(TAG, "Couldn't close connection!", t)
             }
         }
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/BitmapDownloader.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/BitmapDownloader.kt
@@ -1,6 +1,7 @@
 package com.clevertap.android.sdk.bitmap
 
 import android.net.TrafficStats
+import android.util.Log
 import com.clevertap.android.sdk.Logger
 import com.clevertap.android.sdk.Utils
 import com.clevertap.android.sdk.network.DownloadedBitmap
@@ -59,8 +60,7 @@ class BitmapDownloader(
                 )
             }
         } catch (e: Throwable) {
-            Logger.v("Couldn't download the notification media. URL was: $srcUrl")
-            e.printStackTrace()
+            Logger.v("BitmapDownloader", "Couldn't download the notification media. URL was: $srcUrl", e)
             return DownloadedBitmapFactory.nullBitmapWithStatus(DOWNLOAD_FAILED)
         } finally {
             try {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/BitmapDownloader.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/bitmap/BitmapDownloader.kt
@@ -1,7 +1,6 @@
 package com.clevertap.android.sdk.bitmap
 
 import android.net.TrafficStats
-import android.util.Log
 import com.clevertap.android.sdk.Logger
 import com.clevertap.android.sdk.Utils
 import com.clevertap.android.sdk.network.DownloadedBitmap

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/featureFlags/CTFeatureFlagsController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/featureFlags/CTFeatureFlagsController.java
@@ -256,9 +256,7 @@ public class CTFeatureFlagsController {
                             getConfigLogger().verbose(getLogTag(), "Feature flags file is empty-" + fileName);
                         }
                     } catch (Exception e) {
-                        e.printStackTrace();
-                        getConfigLogger().verbose(getLogTag(),
-                                "UnArchiveData failed file- " + fileName + " " + e.getLocalizedMessage());
+                        getConfigLogger().verbose(getLogTag(), "UnArchiveData failed file- " + fileName, e);
                         return false;
                     }
                     return true;
@@ -276,8 +274,7 @@ public class CTFeatureFlagsController {
                 getConfigLogger()
                         .verbose(getLogTag(), "Feature flags saved into file-[" + getCachedFullPath() + "]" + store);
             } catch (Exception e) {
-                e.printStackTrace();
-                getConfigLogger().verbose(getLogTag(), "ArchiveData failed - " + e.getLocalizedMessage());
+                getConfigLogger().verbose(getLogTag(), "ArchiveData failed", e);
             }
         }
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.kt
@@ -347,8 +347,7 @@ internal class NetworkManager constructor(
             responseFailureCount++
             logger.debug(
                 config.accountId,
-                "An exception occurred while sending the queue, will retry: "
-            )
+                "An exception occurred while sending the queue, will retry: ", e)
             if (callbackManager.failureFlushListener != null) {
                 callbackManager.failureFlushListener.failureFlush(context)
             }
@@ -419,7 +418,7 @@ internal class NetworkManager constructor(
                 }
             }
         } catch (e: Exception) {
-            logger.debug(config.accountId, "An exception occurred while defining templates.")
+            logger.debug(config.accountId, "An exception occurred while defining templates.", e)
             return false
         }
     }
@@ -457,8 +456,7 @@ internal class NetworkManager constructor(
         } catch (e: Exception) {
             logger.debug(
                 config.accountId,
-                "An exception occurred while fetching the inapp payload from URL"
-            )
+                "An exception occurred while fetching the inapp payload from URL" , e)
             return null
         }
     }
@@ -722,13 +720,11 @@ internal class NetworkManager constructor(
             } catch (e: JSONException) {
                 logger.verbose(
                     config.accountId,
-                    "Encountered an exception while parsing the push notification viewed event queue"
-                )
+                    "Encountered an exception while parsing the push notification viewed event queue", e)
             } catch (e: Exception) {
                 logger.verbose(
                     config.accountId,
-                    "Exception occurred while notifying push impression listeners"
-                )
+                    "Exception occurred while notifying push impression listeners" , e)
             }
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.kt
@@ -707,10 +707,10 @@ internal class NetworkManager constructor(
             } catch (e: JSONException) {
                 logger.verbose(
                     config.accountId,
-                    "Encountered an exception while parsing the push notification viewed event queue"
+                    "Encountered an exception while parsing the push notification viewed event queue",e
                 )
             } catch (e: Exception) {
-                e.printStackTrace()
+                logger.verbose(config.accountId, "Exception occurred while notifying push impression listeners", e)
             }
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/product_config/CTProductConfigController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/product_config/CTProductConfigController.java
@@ -9,7 +9,9 @@ import static com.clevertap.android.sdk.product_config.CTProductConfigConstants.
 
 import android.content.Context;
 import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
+
 import com.clevertap.android.sdk.BaseAnalyticsManager;
 import com.clevertap.android.sdk.BaseCallbackManager;
 import com.clevertap.android.sdk.CleverTapInstanceConfig;
@@ -19,6 +21,11 @@ import com.clevertap.android.sdk.task.CTExecutorFactory;
 import com.clevertap.android.sdk.task.OnSuccessListener;
 import com.clevertap.android.sdk.task.Task;
 import com.clevertap.android.sdk.utils.FileUtils;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -27,13 +34,10 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
- *      Note: This class has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+ * Note: This class has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
  * </p>
  */
 @Deprecated
@@ -71,7 +75,7 @@ public class CTProductConfigController {
 
     /**
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This variable has been deprecated and will be removed in the future versions of this SDK.
+     * Note: This variable has been deprecated and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -83,14 +87,14 @@ public class CTProductConfigController {
 
     /**
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
     CTProductConfigController(Context context, CleverTapInstanceConfig config,
-            final BaseAnalyticsManager analyticsManager, final CoreMetaData coreMetaData,
-            final BaseCallbackManager callbackManager, ProductConfigSettings productConfigSettings,
-            FileUtils fileUtils) {
+                              final BaseAnalyticsManager analyticsManager, final CoreMetaData coreMetaData,
+                              final BaseCallbackManager callbackManager, ProductConfigSettings productConfigSettings,
+                              FileUtils fileUtils) {
         this.context = context;
         this.config = config;
         this.coreMetaData = coreMetaData;
@@ -104,7 +108,7 @@ public class CTProductConfigController {
     /**
      * Asynchronously activates the most recently fetched configs, so that the fetched key value pairs take effect.
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -155,7 +159,7 @@ public class CTProductConfigController {
     /**
      * Starts fetching configs, adhering to the default minimum fetch interval.
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -167,10 +171,10 @@ public class CTProductConfigController {
      * Starts fetching configs, adhering to the specified minimum fetch interval in seconds.
      *
      * @param minimumFetchIntervalInSeconds - long value of seconds
-
-     * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
-     * </p>
+     *
+     *                                      <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
+     *                                      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     *                                      </p>
      */
     @Deprecated
     public void fetch(long minimumFetchIntervalInSeconds) {
@@ -182,7 +186,7 @@ public class CTProductConfigController {
     /**
      * Asynchronously fetches and then activates the fetched configs.
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -195,7 +199,7 @@ public class CTProductConfigController {
      * This method is internal to CleverTap SDK.
      * Developers should not use this method manually.
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -223,7 +227,7 @@ public class CTProductConfigController {
      * @return Boolean - value of the product config,if key is not present return {@link
      * CTProductConfigConstants#DEFAULT_VALUE_FOR_BOOLEAN}
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -245,7 +249,7 @@ public class CTProductConfigController {
      * @return Double - value of the product config,if key is not present return {@link
      * CTProductConfigConstants#DEFAULT_VALUE_FOR_DOUBLE}
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -270,7 +274,7 @@ public class CTProductConfigController {
      *
      * @return - long value of timestamp in millis.
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -285,7 +289,7 @@ public class CTProductConfigController {
      * @return Long - value of the product config,if key is not present return {@link
      * CTProductConfigConstants#DEFAULT_VALUE_FOR_LONG}
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -316,7 +320,7 @@ public class CTProductConfigController {
      * @return String - value of the product config,if key is not present return {@link
      * CTProductConfigConstants#DEFAULT_VALUE_FOR_STRING}
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -333,7 +337,7 @@ public class CTProductConfigController {
 
     /**
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -346,7 +350,7 @@ public class CTProductConfigController {
      * Developers should not use this method manually.
      *
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -360,7 +364,7 @@ public class CTProductConfigController {
      * Developers should not use this method manually.
      *
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -405,7 +409,7 @@ public class CTProductConfigController {
      * Deletes all activated, fetched and defaults configs as well as all Product Config settings.
      *
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -418,7 +422,7 @@ public class CTProductConfigController {
 
     /**
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -431,7 +435,7 @@ public class CTProductConfigController {
      * Developers should not use this method manually.
      *
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -445,9 +449,9 @@ public class CTProductConfigController {
      * @param resourceID - resource Id of the XML.
      *
      *
-     * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
-     * </p>
+     *                   <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
+     *                   Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     *                   </p>
      */
     @Deprecated
     public void setDefaults(final int resourceID) {
@@ -460,9 +464,9 @@ public class CTProductConfigController {
      * @param map - HashMap of the default configs
      *
      *
-     * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
-     * </p>
+     *            <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
+     *            Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     *            </p>
      */
     @Deprecated
     public void setDefaults(final HashMap<String, Object> map) {
@@ -506,7 +510,7 @@ public class CTProductConfigController {
      * Developers should not use this method manually.
      *
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -533,7 +537,7 @@ public class CTProductConfigController {
 
     /**
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -589,7 +593,7 @@ public class CTProductConfigController {
 
     /**
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
-     *      Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
+     * Note: This method has been deprecated since v5.0.0 and will be removed in the future versions of this SDK.
      * </p>
      */
     @Deprecated
@@ -745,8 +749,7 @@ public class CTProductConfigController {
                     try {
                         value = String.valueOf(jsonObject.get(key));
                     } catch (Exception e) {
-                        config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                                "GetStoredValues for key " + key + " while parsing json", e);
+                        config.getLogger().verbose(ProductConfigUtil.getLogTag(config), "GetStoredValues failed for key " + key + " while parsing json", e);
                         continue;
                     }
                     if (!TextUtils.isEmpty(value)) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/product_config/CTProductConfigController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/product_config/CTProductConfigController.java
@@ -142,9 +142,8 @@ public class CTProductConfigController {
                         config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
                                 "Activated successfully with configs: " + activatedConfigs);
                     } catch (Exception e) {
-                        e.printStackTrace();
                         config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                                "Activate failed: " + e.getLocalizedMessage());
+                                "Activate failed", e);
                     }
                     return null;
                 }
@@ -208,7 +207,8 @@ public class CTProductConfigController {
             event.put("evtName", Constants.WZRK_FETCH);
             event.put("evtData", notif);
         } catch (JSONException e) {
-            e.printStackTrace();
+            config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
+                    "Error creating fetch event JSON", e);
         }
         analyticsManager.sendFetchEvent(event);
         coreMetaData.setProductConfigRequested(true);
@@ -258,9 +258,8 @@ public class CTProductConfigController {
                     return Double.parseDouble(value);
                 }
             } catch (Exception e) {
-                e.printStackTrace();
                 config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                        "Error getting Double for Key-" + Key + " " + e.getLocalizedMessage());
+                        "Error getting Double for Key-" + Key, e);
             }
         }
         return DEFAULT_VALUE_FOR_DOUBLE;
@@ -299,9 +298,8 @@ public class CTProductConfigController {
                     return Long.parseLong(value);
                 }
             } catch (Exception e) {
-                e.printStackTrace();
                 config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                        "Error getting Long for Key-" + Key + " " + e.getLocalizedMessage());
+                        "Error getting Long for Key-" + Key, e);
             }
         }
         return DEFAULT_VALUE_FOR_LONG;
@@ -394,8 +392,7 @@ public class CTProductConfigController {
                         activate();
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
-                    config.getLogger().verbose(ProductConfigUtil.getLogTag(config), "Product Config: fetch Failed");
+                    config.getLogger().verbose(ProductConfigUtil.getLogTag(config), "Product Config: fetch Failed", e);
                     sendCallback(PROCESSING_STATE.FETCHED);
                     // set fetchAndActivating flag to false if fetch fails.
                     isFetchAndActivating.compareAndSet(true, false);
@@ -491,8 +488,7 @@ public class CTProductConfigController {
                                     }
                                 } catch (Exception e) {
                                     config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                                            "Product Config: setDefaults Failed for Key: " + key + " with Error: " + e
-                                                    .getLocalizedMessage());
+                                            "Product Config: setDefaults Failed for Key: " + key, e);
                                 }
                             }
                         }
@@ -553,9 +549,8 @@ public class CTProductConfigController {
                         config.getLogger()
                                 .verbose(ProductConfigUtil.getLogTag(config), "Reset Deleted Dir: " + dirName);
                     } catch (Exception e) {
-                        e.printStackTrace();
                         config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                                "Reset failed: " + e.getLocalizedMessage());
+                                "Reset failed", e);
                     }
 
                     return null;
@@ -631,9 +626,8 @@ public class CTProductConfigController {
                         isInitialized.set(true);
 
                     } catch (Exception e) {
-                        e.printStackTrace();
                         config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                                "InitAsync failed - " + e.getLocalizedMessage());
+                                "InitAsync failed", e);
                         return false;
                     }
                     return true;
@@ -696,9 +690,8 @@ public class CTProductConfigController {
         try {
             kvArray = jsonObject.getJSONArray(Constants.KEY_KV);
         } catch (JSONException e) {
-            e.printStackTrace();
             config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                    "ConvertServerJsonToMap failed - " + e.getLocalizedMessage());
+                    "ConvertServerJsonToMap failed", e);
             return map;
         }
 
@@ -715,9 +708,8 @@ public class CTProductConfigController {
                         }
                     }
                 } catch (Exception e) {
-                    e.printStackTrace();
                     config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                            "ConvertServerJsonToMap failed: " + e.getLocalizedMessage());
+                            "ConvertServerJsonToMap failed", e);
                 }
             }
         }
@@ -732,9 +724,8 @@ public class CTProductConfigController {
             config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
                     "GetStoredValues reading file success:[ " + fullFilePath + "]--[Content]" + content);
         } catch (Exception e) {
-            e.printStackTrace();
             config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                    "GetStoredValues reading file failed: " + e.getLocalizedMessage());
+                    "GetStoredValues reading file failed", e);
             return map;
         }
         if (!TextUtils.isEmpty(content)) {
@@ -742,9 +733,8 @@ public class CTProductConfigController {
             try {
                 jsonObject = new JSONObject(content);
             } catch (Exception e) {
-                e.printStackTrace();
                 config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                        "GetStoredValues failed due to malformed json: " + e.getLocalizedMessage());
+                        "GetStoredValues failed due to malformed json", e);
                 return map;
             }
             Iterator<String> iterator = jsonObject.keys();
@@ -755,9 +745,8 @@ public class CTProductConfigController {
                     try {
                         value = String.valueOf(jsonObject.get(key));
                     } catch (Exception e) {
-                        e.printStackTrace();
                         config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                                "GetStoredValues for key " + key + " while parsing json: " + e.getLocalizedMessage());
+                                "GetStoredValues for key " + key + " while parsing json", e);
                         continue;
                     }
                     if (!TextUtils.isEmpty(value)) {
@@ -800,9 +789,8 @@ public class CTProductConfigController {
         try {
             timestamp = (Integer) jsonObject.get(CTProductConfigConstants.KEY_LAST_FETCHED_TIMESTAMP);
         } catch (Exception e) {
-            e.printStackTrace();
             config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                    "ParseFetchedResponse failed: " + e.getLocalizedMessage());
+                    "ParseFetchedResponse failed", e);
         }
         if (timestamp != null) {
             settings.setLastFetchTimeStampInMillis(timestamp * 1000L);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/product_config/ProductConfigSettings.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/product_config/ProductConfigSettings.java
@@ -67,9 +67,8 @@ public class ProductConfigSettings {
                         config.getLogger()
                                 .verbose(ProductConfigUtil.getLogTag(config), "Deleted settings file" + fileName);
                     } catch (Exception e) {
-                        e.printStackTrace();
                         config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                                "Error while resetting settings" + e.getLocalizedMessage());
+                                "Error while resetting settings", e);
                     }
                     return null;
                 }
@@ -104,9 +103,8 @@ public class ProductConfigSettings {
             try {
                 return new JSONObject(content);
             } catch (JSONException e) {
-                e.printStackTrace();
                 config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                        "LoadSettings failed: " + e.getLocalizedMessage());
+                        "LoadSettings failed", e);
             }
         }
         return null;
@@ -120,9 +118,8 @@ public class ProductConfigSettings {
                 lastFetchedTimeStamp = (long) Double.parseDouble(value);
             }
         } catch (Exception e) {
-            e.printStackTrace();
             config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                    "GetLastFetchTimeStampInMillis failed: " + e.getLocalizedMessage());
+                    "GetLastFetchTimeStampInMillis failed", e);
         }
         return lastFetchedTimeStamp;
     }
@@ -165,9 +162,8 @@ public class ProductConfigSettings {
             JSONObject jsonObject = getJsonObject(content);
             populateMapWithJson(jsonObject);
         } catch (Exception e) {
-            e.printStackTrace();
             config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                    "LoadSettings failed while reading file: " + e.getLocalizedMessage());
+                    "LoadSettings failed while reading file", e);
         }
     }
 
@@ -184,9 +180,8 @@ public class ProductConfigSettings {
                     Object obj = jsonObject.get(key);
                     value = String.valueOf(obj);
                 } catch (Exception e) {
-                    e.printStackTrace();
                     config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                            "Failed loading setting for key " + key + " Error: " + e.getLocalizedMessage());
+                            "Failed loading setting for key " + key, e);
                     continue;
                 }
                 if (!TextUtils.isEmpty(value)) {
@@ -222,9 +217,8 @@ public class ProductConfigSettings {
                     }
 
                 } catch (Exception e) {
-                    e.printStackTrace();
                     config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                            "Product Config setARPValue failed " + e.getLocalizedMessage());
+                            "Product Config setARPValue failed", e);
                 }
             }
         }
@@ -245,9 +239,8 @@ public class ProductConfigSettings {
                 minInterVal = (long) Double.parseDouble(value);
             }
         } catch (Exception e) {
-            e.printStackTrace();
             config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                    "GetMinFetchIntervalInSeconds failed: " + e.getLocalizedMessage());
+                    "GetMinFetchIntervalInSeconds failed", e);
         }
         return minInterVal;
     }
@@ -260,9 +253,8 @@ public class ProductConfigSettings {
                 noCallsAllowedInWindow = (int) Double.parseDouble(value);
             }
         } catch (Exception e) {
-            e.printStackTrace();
             config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                    "GetNoOfCallsInAllowedWindow failed: " + e.getLocalizedMessage());
+                    "GetNoOfCallsInAllowedWindow failed", e);
         }
         return noCallsAllowedInWindow;
     }
@@ -283,9 +275,8 @@ public class ProductConfigSettings {
                 windowIntervalInMinutes = (int) Double.parseDouble(value);
             }
         } catch (Exception e) {
-            e.printStackTrace();
             config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                    "GetWindowIntervalInMinutes failed: " + e.getLocalizedMessage());
+                    "GetWindowIntervalInMinutes failed", e);
         }
         return windowIntervalInMinutes;
     }
@@ -334,9 +325,8 @@ public class ProductConfigSettings {
                     fileUtils.writeJsonToFile(getDirName(),
                             CTProductConfigConstants.FILE_NAME_CONFIG_SETTINGS, new JSONObject(toWriteMap));
                 } catch (Exception e) {
-                    e.printStackTrace();
                     config.getLogger().verbose(ProductConfigUtil.getLogTag(config),
-                            "UpdateConfigToFile failed: " + e.getLocalizedMessage());
+                            "UpdateConfigToFile failed", e);
                     return false;
                 }
                 return true;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/fcm/CTFirebaseMessagingReceiver.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/fcm/CTFirebaseMessagingReceiver.java
@@ -92,7 +92,7 @@ public class CTFirebaseMessagingReceiver extends BroadcastReceiver implements No
                         "have already informed OS to kill receiver, can not inform again else OS will get angry :-O");
             }
         } catch (Exception e) {
-            Logger.v(TAG, "Error finishing receiver and canceling timer", e);
+            Logger.d(TAG, "Error finishing receiver and canceling timer", e);
         }
     }
 
@@ -164,7 +164,7 @@ public class CTFirebaseMessagingReceiver extends BroadcastReceiver implements No
                         }
                         //We are done flushing events
                     } catch (Exception e) {
-                        Logger.v(TAG, "Failed executing CTRM flushQueueSync thread.", e);
+                        Logger.d(TAG, "Failed executing CTRM flushQueueSync thread.", e);
                     } finally {
                         finishReceiverAndCancelTimer("flush from receiver is done!");
                     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/fcm/CTFirebaseMessagingReceiver.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/fcm/CTFirebaseMessagingReceiver.java
@@ -92,7 +92,7 @@ public class CTFirebaseMessagingReceiver extends BroadcastReceiver implements No
                         "have already informed OS to kill receiver, can not inform again else OS will get angry :-O");
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            Logger.v(TAG, "Error finishing receiver and canceling timer", e);
         }
     }
 
@@ -164,7 +164,6 @@ public class CTFirebaseMessagingReceiver extends BroadcastReceiver implements No
                         }
                         //We are done flushing events
                     } catch (Exception e) {
-                        e.printStackTrace();
                         Logger.v(TAG, "Failed executing CTRM flushQueueSync thread.", e);
                     } finally {
                         finishReceiverAndCancelTimer("flush from receiver is done!");

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/fcm/FcmNotificationParser.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/fcm/FcmNotificationParser.java
@@ -25,7 +25,6 @@ class FcmNotificationParser implements INotificationParser<RemoteMessage> {
             Logger.d(LOG_TAG, FCM_LOG_TAG + "Found Valid Notification Message ");
             return extras;
         } catch (Throwable e) {
-            e.printStackTrace();
             Logger.d(LOG_TAG, FCM_LOG_TAG + "Invalid Notification Message ", e);
         }
         return null;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/work/CTWorkManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/work/CTWorkManager.kt
@@ -43,7 +43,6 @@ class CTWorkManager(private val context: Context, config: CleverTapInstanceConfi
             logger.verbose(accountId, "Finished scheduling one time work request to flush push impressions...")
         } catch (t: Throwable) {
             logger.verbose(accountId, "Failed to schedule one time work request to flush push impressions.", t)
-            t.printStackTrace()
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/task/PostAsyncSafelyExecutor.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/task/PostAsyncSafelyExecutor.java
@@ -1,6 +1,7 @@
 package com.clevertap.android.sdk.task;
 
 import com.clevertap.android.sdk.Logger;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -57,7 +58,7 @@ class PostAsyncSafelyExecutor implements ExecutorService {
 
     @Override
     public <T> List<Future<T>> invokeAll(final Collection<? extends Callable<T>> tasks, final long timeout,
-            final TimeUnit unit)
+                                         final TimeUnit unit)
             throws UnsupportedOperationException {
         throw new UnsupportedOperationException("PostAsyncSafelyExecutor#invokeAll: This method is not supported");
     }
@@ -105,7 +106,7 @@ class PostAsyncSafelyExecutor implements ExecutorService {
             try {
                 task.call();
             } catch (Exception e) {
-                Logger.v(TAG, "Error executing task synchronously", e);
+                Logger.d(TAG, "Error executing task synchronously", e);
             }
         } else {
             future = executor.submit(new Callable<T>() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/task/PostAsyncSafelyExecutor.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/task/PostAsyncSafelyExecutor.java
@@ -1,7 +1,6 @@
 package com.clevertap.android.sdk.task;
 
 import com.clevertap.android.sdk.Logger;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -19,6 +18,7 @@ import java.util.concurrent.TimeUnit;
 class PostAsyncSafelyExecutor implements ExecutorService {
 
     private long EXECUTOR_THREAD_ID = 0;
+    private static final String TAG = "PostAsyncSafelyExecutor";
 
     void setExecutor(final ExecutorService executor) {
         this.executor = executor;
@@ -105,7 +105,7 @@ class PostAsyncSafelyExecutor implements ExecutorService {
             try {
                 task.call();
             } catch (Exception e) {
-                Logger.v("PostAsyncSafelyExecutor", "Error executing task synchronously", e);
+                Logger.v(TAG, "Error executing task synchronously", e);
             }
         } else {
             future = executor.submit(new Callable<T>() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/task/PostAsyncSafelyExecutor.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/task/PostAsyncSafelyExecutor.java
@@ -1,5 +1,7 @@
 package com.clevertap.android.sdk.task;
 
+import com.clevertap.android.sdk.Logger;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -103,7 +105,7 @@ class PostAsyncSafelyExecutor implements ExecutorService {
             try {
                 task.call();
             } catch (Exception e) {
-                e.printStackTrace();
+                Logger.v("PostAsyncSafelyExecutor", "Error executing task synchronously", e);
             }
         } else {
             future = executor.submit(new Callable<T>() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/task/Task.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/task/Task.java
@@ -185,12 +185,12 @@ public class Task<TResult> {
             tResultFuture = ((ExecutorService) executor).submit(callable);
             return tResultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
-            Logger.v("submitAndGetResult :: " + logTag + " task failed", e);
+            logProperly("submitAndGetResult :: " + logTag + " task failed", e);
             if (tResultFuture != null && !tResultFuture.isCancelled()) {
                 tResultFuture.cancel(true);
             }
         }
-        Logger.v("submitAndGetResult :: " + logTag + " task timed out");
+        logProperly("submitAndGetResult :: " + logTag + " task timed out",null);
         return null;
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/task/Task.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/task/Task.java
@@ -185,7 +185,7 @@ public class Task<TResult> {
             tResultFuture = ((ExecutorService) executor).submit(callable);
             return tResultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
         } catch (Exception e) {
-            e.printStackTrace();
+            Logger.v("submitAndGetResult :: " + logTag + " task failed", e);
             if (tResultFuture != null && !tResultFuture.isCancelled()) {
                 tResultFuture.cancel(true);
             }
@@ -237,7 +237,6 @@ public class Task<TResult> {
                 } catch (Exception e) {
                     onFailure(e);
                     logProperly(taskName + " Task: " + logTag + " failed to execute on..." + Thread.currentThread().getName(), e);
-                    e.printStackTrace();
                 }
             }
         };

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/task/Task.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/task/Task.java
@@ -189,6 +189,9 @@ public class Task<TResult> {
             return tResultFuture.get(timeoutMillis, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
             logProperly("submitAndGetResult :: " + logTag + " task timed out", e);
+            if (tResultFuture != null && !tResultFuture.isCancelled()) {
+                tResultFuture.cancel(true);
+            }
         } catch (Exception e) {
             logProperly("submitAndGetResult :: " + logTag + " task failed", e);
             if (tResultFuture != null && !tResultFuture.isCancelled()) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/utils/CTJsonConverter.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/utils/CTJsonConverter.java
@@ -31,7 +31,7 @@ import java.util.Map.Entry;
 
 @RestrictTo(Scope.LIBRARY)
 public class CTJsonConverter {
-
+    private static final String TAG = "CTJsonConverter";
     @NonNull
     public static JSONObject toJsonObject(String json, ILogger logger, String logtag) {
         JSONObject cache = null;
@@ -51,7 +51,7 @@ public class CTJsonConverter {
         JSONObject r = new JSONObject();
 
         String pushJsonPayload = extras.getString(Constants.DISPLAY_UNIT_PREVIEW_PUSH_PAYLOAD_KEY);
-        Logger.v("Received Display Unit via push payload: " + pushJsonPayload);
+        Logger.v(TAG, "Received Display Unit via push payload: " + pushJsonPayload);
         JSONArray displayUnits = new JSONArray();
         r.put(Constants.DISPLAY_UNIT_JSON_RESPONSE_KEY, displayUnits);
         JSONObject testPushObject = new JSONObject(pushJsonPayload);
@@ -181,7 +181,7 @@ public class CTJsonConverter {
     public static JSONArray pushIdsToJSONArray(String[] pushIds) {
         JSONArray renderedTargets = new JSONArray();
         for (String pushId : pushIds) {
-            Logger.v("RTL IDs -" + pushId);
+            Logger.v(TAG, "RTL IDs -" + pushId);
             renderedTargets.put(pushId);
         }
         return renderedTargets;
@@ -213,7 +213,7 @@ public class CTJsonConverter {
                 array[i] = jsonArray.get(i);
             }
         } catch (JSONException e) {
-            Logger.v("CTJsonConverter", "Error converting JSONArray to array", e);
+            Logger.v(TAG,  "Error converting JSONArray to array");
         }
         return array;
     }
@@ -246,7 +246,7 @@ public class CTJsonConverter {
             try {
                 list.add(array.get(i));
             } catch (JSONException e) {
-                Logger.v("CTJsonConverter", "Error converting JSONArray to list", e);
+                Logger.v(TAG, "Error converting JSONArray to list");
             }
         }
         return list;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/utils/CTJsonConverter.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/utils/CTJsonConverter.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 @RestrictTo(Scope.LIBRARY)
 public class CTJsonConverter {
     private static final String TAG = "CTJsonConverter";
+
     @NonNull
     public static JSONObject toJsonObject(String json, ILogger logger, String logtag) {
         JSONObject cache = null;
@@ -40,7 +41,7 @@ public class CTJsonConverter {
                 cache = new JSONObject(json);
             } catch (Throwable t) {
                 // no-op
-                logger.verbose(logtag, "Error reading guid cache: " + t.toString());
+                logger.verbose(logtag, "Error reading guid cache: ", t);
             }
         }
 
@@ -115,7 +116,7 @@ public class CTJsonConverter {
             }
 
             boolean sslPinning = ManifestInfo.getInstance(deviceInfo.getContext()).isSSLPinningEnabled();
-            if(sslPinning){
+            if (sslPinning) {
                 evtData.put("sslpin", true);
             }
 
@@ -151,7 +152,7 @@ public class CTJsonConverter {
                 }
             }
             //Adds an extra field to send local inApp count in queueData.
-            evtData.put("LIAMC",deviceInfo.getLocalInAppCount());
+            evtData.put("LIAMC", deviceInfo.getLocalInAppCount());
 
             // add custom sdk versions in "af" key of header.
             HashMap<String, Integer> allCustomSdkVersions = coreMetaData.getAllCustomSdkVersions();
@@ -213,7 +214,7 @@ public class CTJsonConverter {
                 array[i] = jsonArray.get(i);
             }
         } catch (JSONException e) {
-            Logger.v(TAG,  "Error converting JSONArray to array");
+            Logger.v(TAG, "Error converting JSONArray to array", e);
         }
         return array;
     }
@@ -246,7 +247,7 @@ public class CTJsonConverter {
             try {
                 list.add(array.get(i));
             } catch (JSONException e) {
-                Logger.v(TAG, "Error converting JSONArray to list");
+                Logger.v(TAG, "Error converting JSONArray to list", e);
             }
         }
         return list;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/utils/CTJsonConverter.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/utils/CTJsonConverter.java
@@ -213,7 +213,7 @@ public class CTJsonConverter {
                 array[i] = jsonArray.get(i);
             }
         } catch (JSONException e) {
-            e.printStackTrace();
+            Logger.v("CTJsonConverter", "Error converting JSONArray to array", e);
         }
         return array;
     }
@@ -246,7 +246,7 @@ public class CTJsonConverter {
             try {
                 list.add(array.get(i));
             } catch (JSONException e) {
-                e.printStackTrace();
+                Logger.v("CTJsonConverter", "Error converting JSONArray to list", e);
             }
         }
         return list;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/utils/FileUtils.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/utils/FileUtils.java
@@ -47,9 +47,8 @@ public class FileUtils {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
             config.getLogger().verbose(config.getAccountId(),
-                    "writeFileOnInternalStorage: failed" + dirName + " Error:" + e.getLocalizedMessage());
+                    "writeFileOnInternalStorage: failed" + dirName, e);
         }
     }
 
@@ -69,9 +68,8 @@ public class FileUtils {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
             config.getLogger().verbose(config.getAccountId(),
-                    "writeFileOnInternalStorage: failed" + fileName + " Error:" + e.getLocalizedMessage());
+                    "writeFileOnInternalStorage: failed" + fileName, e);
         }
     }
 
@@ -142,9 +140,8 @@ public class FileUtils {
                 writer.flush();
             }
         } catch (Exception e) {
-            e.printStackTrace();
             config.getLogger().verbose(config.getAccountId(),
-                    "writeFileOnInternalStorage: failed" + e.getLocalizedMessage());
+                    "writeFileOnInternalStorage: failed", e);
         }finally {
             if(writer != null){
                 writer.close();

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/utils/FileUtils.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/utils/FileUtils.java
@@ -48,7 +48,7 @@ public class FileUtils {
             }
         } catch (Exception e) {
             config.getLogger().verbose(config.getAccountId(),
-                    "writeFileOnInternalStorage: failed" + dirName, e);
+                    "deleteDirectory: failed: "  + dirName, e);
         }
     }
 
@@ -69,7 +69,7 @@ public class FileUtils {
             }
         } catch (Exception e) {
             config.getLogger().verbose(config.getAccountId(),
-                    "writeFileOnInternalStorage: failed" + fileName, e);
+                    "deleteFile: failed: "  + fileName, e);
         }
     }
 
@@ -103,7 +103,7 @@ public class FileUtils {
             content = stringBuilder.toString();
         } catch (Exception e) {
             config.getLogger()
-                    .verbose(config.getAccountId(), "[Exception While Reading: " + e.getLocalizedMessage());
+                    .verbose(config.getAccountId(), "readFromFile: failed for " + fileNameWithPath, e);
             //Log your error with Log.e
         }finally {
             if (inputStream != null) {
@@ -141,7 +141,7 @@ public class FileUtils {
             }
         } catch (Exception e) {
             config.getLogger().verbose(config.getAccountId(),
-                    "writeFileOnInternalStorage: failed", e);
+                    "writeJsonToFile: failed for dir=" + dirName + ", file=" + fileName, e);
         }finally {
             if(writer != null){
                 writer.close();

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/CTVariableUtils.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/CTVariableUtils.java
@@ -15,6 +15,8 @@ import java.util.Map;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public final class CTVariableUtils {
+
+    private static final String TAG = "CTVariableUtils";
     public static final String VARS = "vars";
     public static final String STRING = "string";
     public static final String BOOLEAN = "boolean";
@@ -23,7 +25,7 @@ public final class CTVariableUtils {
     public static final String FILE = "file";
 
     private static void log(String msg){
-        Logger.d("variables", msg);
+        Logger.d(TAG, msg);
     }
 
     public static void updateValuesAndKinds(String name, String[] nameComponents, Object value, String kind, Map<String, Object> values, Map<String, String> kinds) {
@@ -214,7 +216,7 @@ public final class CTVariableUtils {
             return name.split("\\.");
         }
         catch (Throwable t){
-            Logger.v("CTVariableUtils", "Error splitting variable name: " + name, t);
+            Logger.v(TAG, "Error splitting variable name: " + name, t);
             return new String[]{};
         }
     }
@@ -303,7 +305,7 @@ public final class CTVariableUtils {
            return resultJson;
        }
        catch (Throwable t){
-           Logger.v("CTVariableUtils", "Error creating flat vars JSON", t);
+           Logger.v(TAG, "Error creating flat vars JSON", t);
            return new JSONObject();
        }
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/CTVariableUtils.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/CTVariableUtils.java
@@ -214,7 +214,7 @@ public final class CTVariableUtils {
             return name.split("\\.");
         }
         catch (Throwable t){
-            t.printStackTrace();
+            Logger.v("CTVariableUtils", "Error splitting variable name: " + name, t);
             return new String[]{};
         }
     }
@@ -303,7 +303,7 @@ public final class CTVariableUtils {
            return resultJson;
        }
        catch (Throwable t){
-           t.printStackTrace();
+           Logger.v("CTVariableUtils", "Error creating flat vars JSON", t);
            return new JSONObject();
        }
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/CTVariableUtils.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/CTVariableUtils.java
@@ -216,7 +216,7 @@ public final class CTVariableUtils {
             return name.split("\\.");
         }
         catch (Throwable t){
-            Logger.v(TAG, "Error splitting variable name: " + name, t);
+            Logger.d(TAG, "Error splitting variable name: " + name, t);
             return new String[]{};
         }
     }
@@ -305,7 +305,7 @@ public final class CTVariableUtils {
            return resultJson;
        }
        catch (Throwable t){
-           Logger.v(TAG, "Error creating flat vars JSON", t);
+           Logger.d(TAG, "Error creating flat vars JSON", t);
            return new JSONObject();
        }
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Parser.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Parser.java
@@ -138,7 +138,6 @@ public class Parser {
       }
     } catch (Throwable t) {
       log( "Error parsing variables:", t);
-      t.printStackTrace();
     }
   }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
@@ -1,12 +1,14 @@
 package com.clevertap.android.sdk.variables;
 
 import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.clevertap.android.sdk.Logger;
 import com.clevertap.android.sdk.Utils;
 import com.clevertap.android.sdk.variables.callbacks.VariableCallback;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +51,7 @@ public class Var<T> {
         this.ctVariables = ctVariables;
     }
 
-    private static void log(String msg){
+    private static void log(String msg) {
         Logger.v(TAG, msg);
     }
 
@@ -70,6 +72,7 @@ public class Var<T> {
     public static <T> Var<T> define(String name, T defaultValue, String kind, CTVariables ctVariables) {
         if (TextUtils.isEmpty(name)) {
             log("Empty name parameter provided.");
+            return null;
 
         }
         if (name.startsWith(".") || name.endsWith(".")) {
@@ -97,7 +100,7 @@ public class Var<T> {
             ctVariables.getVarCache().registerVariable(var);
             var.update();
         } catch (Throwable t) {
-            Logger.v(TAG, "Error defining variable: " + name,t);
+            Logger.v(TAG, "Error defining variable: " + name, t);
         }
         return var;
     }
@@ -210,7 +213,7 @@ public class Var<T> {
     void warnIfNotStarted() {
         if (!ctVariables.hasVarsRequestCompleted() && !printedCallbackWarning) {
             log("CleverTap hasn't finished retrieving values from the server. You should use a callback to make sure the value for "
-                + name + " is ready. Otherwise, your app may not use the most up-to-date value.");
+                    + name + " is ready. Otherwise, your app may not use the most up-to-date value.");
             printedCallbackWarning = true;
         }
     }
@@ -246,7 +249,7 @@ public class Var<T> {
         if (CTVariableUtils.FILE.equals(kind)) {
             return stringValue;
         } else {
-           return null;
+            return null;
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
@@ -22,7 +22,7 @@ import java.util.Map;
  */
 public class Var<T> {
 
-    private static final String TAG = "Var";
+    private static final String TAG = "variable";
     private final CTVariables ctVariables;
 
     private String name;
@@ -80,7 +80,7 @@ public class Var<T> {
             return null;
         }
         if (!CTVariableUtils.FILE.equals(kind) && defaultValue == null) {
-            Logger.v(TAG, "Invalid Operation! Null values are not allowed as default values when defining the variable '" + name + "'.");
+            Logger.d("Invalid Operation! Null values are not allowed as default values when defining the variable '" + name + "'.");
             return null;
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
@@ -19,6 +19,8 @@ import java.util.Map;
  * @author Ansh Sachdeva
  */
 public class Var<T> {
+
+    private static final String TAG = "Var";
     private final CTVariables ctVariables;
 
     private String name;
@@ -48,7 +50,7 @@ public class Var<T> {
     }
 
     private static void log(String msg){
-        Logger.v("variable", msg);
+        Logger.v(TAG, msg);
     }
 
     public static <T> Var<T> define(String name, T defaultValue, CTVariables ctVariables) {
@@ -75,8 +77,7 @@ public class Var<T> {
             return null;
         }
         if (!CTVariableUtils.FILE.equals(kind) && defaultValue == null) {
-            Logger.d("Invalid Operation! Null values are not allowed as default values when defining the variable '"
-                    + name + "'.");
+            Logger.d(TAG, "Invalid Operation! Null values are not allowed as default values when defining the variable '" + name + "'.");
             return null;
         }
 
@@ -96,7 +97,7 @@ public class Var<T> {
             ctVariables.getVarCache().registerVariable(var);
             var.update();
         } catch (Throwable t) {
-            Logger.v("variable", "Error defining variable: " + name, t);
+            Logger.v(TAG, "Error defining variable: " + name,t);
         }
         return var;
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
@@ -96,7 +96,7 @@ public class Var<T> {
             ctVariables.getVarCache().registerVariable(var);
             var.update();
         } catch (Throwable t) {
-            t.printStackTrace();
+            Logger.v("variable", "Error defining variable: " + name, t);
         }
         return var;
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
@@ -70,14 +70,14 @@ public class Var<T> {
     public static <T> Var<T> define(String name, T defaultValue, String kind, CTVariables ctVariables) {
         if (TextUtils.isEmpty(name)) {
             log("Empty name parameter provided.");
-            return null;
+
         }
         if (name.startsWith(".") || name.endsWith(".")) {
             log("Variable name starts or ends with a `.` which is not allowed: " + name);
             return null;
         }
         if (!CTVariableUtils.FILE.equals(kind) && defaultValue == null) {
-            Logger.d(TAG, "Invalid Operation! Null values are not allowed as default values when defining the variable '" + name + "'.");
+            Logger.v(TAG, "Invalid Operation! Null values are not allowed as default values when defining the variable '" + name + "'.");
             return null;
         }
 

--- a/clevertap-geofence/src/main/java/com/clevertap/android/geofence/FileUtils.java
+++ b/clevertap-geofence/src/main/java/com/clevertap/android/geofence/FileUtils.java
@@ -2,16 +2,19 @@ package com.clevertap.android.geofence;
 
 import android.content.Context;
 import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
+
+import org.json.JSONObject;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import org.json.JSONObject;
 
 @SuppressWarnings("WeakerAccess")
 public class FileUtils {
@@ -36,9 +39,7 @@ public class FileUtils {
                 }
             }
         } catch (Exception e) {
-            e.printStackTrace();
-            CTGeofenceAPI.getLogger().verbose(CTGeofenceAPI.GEOFENCE_LOG_TAG,
-                    "deleteFileOnInternalStorage: failed" + dirName + " Error:" + e.getLocalizedMessage());
+            CTGeofenceAPI.getLogger().debug(CTGeofenceAPI.GEOFENCE_LOG_TAG, "deleteDirectory failed for dirName: " + dirName, e);
         }
     }
 
@@ -84,15 +85,14 @@ public class FileUtils {
             inputStream.close();
             content = stringBuilder.toString();
         } catch (Exception e) {
-            CTGeofenceAPI.getLogger()
-                    .verbose(CTGeofenceAPI.GEOFENCE_LOG_TAG, "[Exception While Reading: " + e.getLocalizedMessage());
+            CTGeofenceAPI.getLogger().debug(CTGeofenceAPI.GEOFENCE_LOG_TAG, "Exception while reading file: " + fileNameWithPath, e);
         }
         return content;
     }
 
     @WorkerThread
     static boolean writeJsonToFile(Context context, String dirName, String fileName,
-            @Nullable JSONObject jsonObject) {
+                                   @Nullable JSONObject jsonObject) {
         boolean isWriteSuccessful = false;
         try {
             if (jsonObject == null || TextUtils.isEmpty(dirName) || TextUtils.isEmpty(fileName)) {
@@ -110,16 +110,11 @@ public class FileUtils {
             writer.append(jsonObject.toString());
             writer.flush();
             writer.close();
-
             isWriteSuccessful = true;
-            CTGeofenceAPI.getLogger().verbose(CTGeofenceAPI.GEOFENCE_LOG_TAG, fileName
-                    + ": writeFileOnInternalStorage: successful");
+            CTGeofenceAPI.getLogger().verbose(CTGeofenceAPI.GEOFENCE_LOG_TAG, fileName + ": writeFileOnInternalStorage: successful");
         } catch (Exception e) {
-            e.printStackTrace();
-            CTGeofenceAPI.getLogger().verbose(CTGeofenceAPI.GEOFENCE_LOG_TAG,
-                    "writeFileOnInternalStorage: failed" + e.getLocalizedMessage());
+            CTGeofenceAPI.getLogger().debug(CTGeofenceAPI.GEOFENCE_LOG_TAG, "writeJsonToFile failed for fileName: " + fileName, e);
         }
-
         return isWriteSuccessful;
     }
 }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
@@ -37,7 +37,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.util.*
-
+private const val TAG = "TemplateRenderer"
 class TemplateRenderer(context: Context, private val extras: Bundle, internal val config: CleverTapInstanceConfig? = null) : INotificationRenderer, AudibleNotification {
     internal val templateMediaManager: TemplateMediaManager by lazy {
         TemplateMediaManager(templateRepository = TemplateRepository(context, config))
@@ -67,7 +67,7 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
                 newExtras = Utils.fromJson(JSONObject(pt_json))
             }
         } catch (e: JSONException) {
-            e.printStackTrace()
+            PTLog.verbose("Failed to parse push template JSON", e)
         }
         if (newExtras != null) extras.putAll(newExtras)
     }
@@ -280,7 +280,7 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
                     val id = action.optString("id")
 
                     if (label.isEmpty() || id.isEmpty()) {
-                        Logger.d("not adding push notification action: action label or id missing")
+                        Logger.d(TAG , "not adding push notification action: action label or id missing")
                         continue
                     }
                     var icon = 0
@@ -288,7 +288,7 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
                         try {
                             icon = context.resources.getIdentifier(ico, "drawable", context.packageName)
                         } catch (t: Throwable) {
-                            Logger.d("unable to add notification action icon: " + t.localizedMessage)
+                            Logger.d(TAG, "unable to add notification action icon: " ,t)
                         }
                     }
 
@@ -302,7 +302,7 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
                         actionButtonPendingIntents[id] = pendingIntent
                     }
                 } catch (t: Throwable) {
-                    Logger.d("error adding notification action : " + t.localizedMessage)
+                    Logger.d(TAG, "error adding notification action : " ,t)
                 }
             }
         }
@@ -331,14 +331,14 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
                     try {
                         clazz = Class.forName("com.clevertap.android.sdk.pushnotification.CTNotificationIntentService")
                     } catch (_: ClassNotFoundException) {
-                        Logger.d("No Intent Service found")
+                        Logger.d(TAG, "No Intent Service found")
                     }
                 }
             } else {
                 try {
                     clazz = Class.forName("com.clevertap.android.sdk.pushnotification.CTNotificationIntentService")
                 } catch (_: ClassNotFoundException) {
-                    Logger.d("No Intent Service found")
+                    Logger.d(TAG, "No Intent Service found")
                 }
             }
             val isCTIntentServiceAvailable = com.clevertap.android.sdk.Utils.isServiceAvailable(context, clazz)
@@ -425,7 +425,7 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
                 )
             }
         } catch (t: Throwable) {
-            Logger.d("error creating pending intent for action button: " + t.localizedMessage)
+            Logger.d(TAG, "error creating pending intent for action button: ",t)
             return null
         }
     }


### PR DESCRIPTION
## Summary
Replaced all `printStackTrace()` calls in main source files with appropriate `Logger` methods to improve logging consistency and production safety.

## Changes
- Replaced 50 `printStackTrace()` occurrences across 18 files
- Pattern: `e.printStackTrace()` → `Logger.d(message, e)`
- Exceptions now logged with consistent CleverTap tag
- Test files unchanged (not production code)

## Testing
- All unit tests passing
- Manual testing verified exception logging behavior
- Build successful

## Benefits
- Consistent logging with single tag (easy filtering)
- Production safety (can be disabled)
- Improved security (controllable stack traces)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a JSONArray.partition API to split JSON arrays by a predicate.

* **Chores**
  * Standardized internal logging across the SDK: removed raw stack-trace prints and replaced them with tagged/structured logs that include exception objects and context for clearer diagnostics.

* **Style**
  * Minor public-facing signature spacing/formatting tweaks only; no behavioral or API changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->