### PR TITLE
 SampleApp - fix geofence command index mismatch

### DIFF
--- a/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenFragment.kt
+++ b/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenFragment.kt
@@ -83,8 +83,8 @@ class HomeScreenFragment : Fragment() {
 
         viewModel.clickCommand.observe(viewLifecycleOwner) { commandPosition ->
             when (commandPosition) {
-                "6-0" -> startActivity(Intent(activity, WebViewActivity::class.java))
-                "7-0" -> { // init Geofence API
+                "7-0" -> startActivity(Intent(activity, WebViewActivity::class.java))
+                "8-0" -> { // init Geofence API
                     when {
                         // proceed only if cleverTap instance is not null
                         cleverTapInstance == null -> println("cleverTapInstance is null")
@@ -93,7 +93,7 @@ class HomeScreenFragment : Fragment() {
                     }
                 }
 
-                "7-1" -> { // trigger location
+                "8-1" -> { // trigger location
                     try {
                         CTGeofenceAPI.getInstance(context).triggerLocation()
                     } catch (e: IllegalStateException) {
@@ -104,8 +104,8 @@ class HomeScreenFragment : Fragment() {
                     }
                 }
 
-                "7-2" -> CTGeofenceAPI.getInstance(context).deactivate() // deactivate geofence
-                "2-16" -> startActivity(Intent(activity, CustomInboxComposeActivity::class.java)) // Launch Compose Inbox
+                "8-2" -> CTGeofenceAPI.getInstance(context).deactivate() // deactivate geofence
+                "3-16" -> startActivity(Intent(activity, CustomInboxComposeActivity::class.java)) // Launch Compose Inbox
             }
         }
     }


### PR DESCRIPTION
## Problem
GEOFENCE section in HomeScreenModel is at index 8, but 
HomeScreenFragment was handling commands "7-0", "7-1", "7-2".
This caused Init Geofence, Trigger Location and Deactivate 
buttons to do nothing when clicked.

## Fix
Updated command handlers from "7-x" to "8-x" to match 
the correct section index of GEOFENCE in HomeScreenModel.

## Changes
- HomeScreenFragment.kt: "7-0" → "8-0" (Init Geofence)
- HomeScreenFragment.kt: "7-1" → "8-1" (Trigger Location)
- HomeScreenFragment.kt: "7-2" → "8-2" (Deactivate Geofence)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal command routing was reorganized; underlying mappings updated.
  * No user-facing behavior changed — web view launch, geofence behavior (initialization, trigger, deactivation), and inbox launch continue to work as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->