### PR TITLE
chore: bump minSdk to 23 and remove redundant API level checks

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -407,7 +407,7 @@ public final class InAppNotificationActivity extends FragmentActivity implements
         AlertDialog alertDialog;
         CTInAppNotificationButton positiveButton = buttons.get(0);
 
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+
             alertDialog = new AlertDialog.Builder(InAppNotificationActivity.this,
                     android.R.style.Theme_Material_Light_Dialog_Alert)
                     .setCancelable(false)
@@ -423,22 +423,7 @@ public final class InAppNotificationActivity extends FragmentActivity implements
                         negativeButton.getText(),
                         (dialog, which) -> onAlertButtonClick(negativeButton, false));
             }
-        } else {
-            alertDialog = new AlertDialog.Builder(InAppNotificationActivity.this)
-                    .setCancelable(false)
-                    .setTitle(inAppNotification.getTitle())
-                    .setMessage(inAppNotification.getMessage())
-                    .setPositiveButton(positiveButton.getText(),
-                            (dialogInterface, i) -> onAlertButtonClickLegacy(positiveButton))
-                    .create();
 
-            if (inAppNotification.getButtons().size() == 2) {
-                CTInAppNotificationButton negativeButton = buttons.get(1);
-                alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE,
-                        negativeButton.getText(),
-                        (dialog, which) -> onAlertButtonClickLegacy(negativeButton));
-            }
-        }
         //By default, we will allow 2 button alerts and set a third button if it is configured
         if (buttons.size() > 2) {
             CTInAppNotificationButton button = buttons.get(2);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/cryption/CTKeyGenerator.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/cryption/CTKeyGenerator.kt
@@ -12,12 +12,12 @@ internal class CTKeyGenerator(val cryptRepository: CryptRepository) {
     /**
      * Generates or retrieves a secret key for encryption/decryption.
      *
-     * This method uses the Android Keystore system on devices running API 23 (Marshmallow) or higher
-     * to securely store the key. If the Android Keystore is not available (on older API levels),
-     * it falls back to generating a key and storing it in SharedPreferences, encoded in Base64.
+     * This method uses Android Keystore to securely retrieve or create the key.
+     * With minSdk 23+, no SharedPreferences fallback path is used.
      *
-     * @return The secret key for encryption/decryption, or null if an error occurs during key generation/retrieval.
+     * @return The secret key for encryption/decryption, or null if an error occurs.
      */
+
     fun generateOrGetKey(): SecretKey? {
         return fromAndroidKeystore()
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/cryption/CTKeyGenerator.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/cryption/CTKeyGenerator.kt
@@ -1,14 +1,11 @@
 package com.clevertap.android.sdk.cryption
 
-import android.os.Build
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
-import androidx.annotation.RequiresApi
 import com.clevertap.android.sdk.Logger
 import java.security.KeyStore
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
-import javax.crypto.spec.SecretKeySpec
 
 internal class CTKeyGenerator(val cryptRepository: CryptRepository) {
 
@@ -22,25 +19,7 @@ internal class CTKeyGenerator(val cryptRepository: CryptRepository) {
      * @return The secret key for encryption/decryption, or null if an error occurs during key generation/retrieval.
      */
     fun generateOrGetKey(): SecretKey? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            fromAndroidKeystore()
-        } else {
-            Logger.v("KeyStore is not supported on API levels below 23")
-
-            val encodedKey = cryptRepository.localEncryptionKey()
-            if (encodedKey != null) {
-                // If the key exists, decode it and return as SecretKey
-                val decodedKey = encodedKey.fromBase64()
-                SecretKeySpec(decodedKey, "AES")
-            } else {
-                val secretKey = generateSecretKey()
-
-                // Store the key in SharedPreferences
-                val encodedNewKey = secretKey.encoded.toBase64()
-                cryptRepository.updateLocalEncryptionKey(encodedNewKey)
-                secretKey
-            }
-        }
+        return fromAndroidKeystore()
     }
 
     fun generateSecretKey(): SecretKey {
@@ -51,7 +30,6 @@ internal class CTKeyGenerator(val cryptRepository: CryptRepository) {
         return secretKey
     }
 
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun fromAndroidKeystore() = try {
         val keyStore = KeyStore.getInstance("AndroidKeyStore")
         keyStore.load(null)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/cryption/CryptRepository.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/cryption/CryptRepository.kt
@@ -16,8 +16,6 @@ interface ICryptRepository {
     fun isSSInAppDataMigrated(): Boolean
     fun updateIsSSInAppDataMigrated(migrated: Boolean)
     fun migrationFailureCount(): Int
-    fun localEncryptionKey(): String?
-    fun updateLocalEncryptionKey(key: String)
     fun updateEncryptionLevel(configEncryptionLevel: Int)
     fun updateMigrationFailureCount(migrationSuccessful: Boolean)
 }
@@ -57,15 +55,6 @@ class CryptRepository(
         MIGRATION_FAILURE_COUNT_KEY,
         MIGRATION_FIRST_UPGRADE
     )
-
-    override fun localEncryptionKey(): String? {
-        val encodedKey = StorageHelper.getString(context, ENCRYPTION_KEY, null)
-        return encodedKey
-    }
-
-    override fun updateLocalEncryptionKey(key: String) {
-        StorageHelper.putString(context, ENCRYPTION_KEY, key)
-    }
 
     override fun updateEncryptionLevel(configEncryptionLevel: Int) {
         StorageHelper.putInt(

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/INotificationRenderer.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/INotificationRenderer.java
@@ -1,6 +1,5 @@
 package com.clevertap.android.sdk.pushnotification;
 
-import android.app.ActivityOptions;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -139,12 +138,10 @@ public interface INotificationRenderer {
                         actionLaunchIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
                     }
 
+                    int flagsActionLaunchPendingIntent = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
+
                     PendingIntent actionIntent;
                     int requestCode = new Random().nextInt();
-                    int flagsActionLaunchPendingIntent = PendingIntent.FLAG_UPDATE_CURRENT;
-                    if (VERSION.SDK_INT >= VERSION_CODES.M) {
-                        flagsActionLaunchPendingIntent |= PendingIntent.FLAG_IMMUTABLE;
-                    }
                     if (sendToCTIntentService) {
                         actionIntent = PendingIntent.getService(context, requestCode,
                                 actionLaunchIntent, flagsActionLaunchPendingIntent);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/LaunchPendingIntentFactory.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/LaunchPendingIntentFactory.java
@@ -1,6 +1,5 @@
 package com.clevertap.android.sdk.pushnotification;
 
-import android.app.ActivityOptions;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -16,6 +15,7 @@ import java.util.Random;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 public class LaunchPendingIntentFactory {
+    private static final int flagsLaunchPendingIntent = PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE;
 
     public static PendingIntent getLaunchPendingIntent(@NonNull Bundle extras, @NonNull Context context) {
         Intent launchIntent;
@@ -28,10 +28,6 @@ public class LaunchPendingIntentFactory {
             launchIntent.putExtras(extras);
             launchIntent.removeExtra(Constants.WZRK_ACTIONS);
 
-            int flagsLaunchPendingIntent = PendingIntent.FLAG_UPDATE_CURRENT;
-            if (VERSION.SDK_INT >= VERSION_CODES.M) {
-                flagsLaunchPendingIntent |= PendingIntent.FLAG_IMMUTABLE;
-            }
             pIntent = PendingIntent.getBroadcast(context, new Random().nextInt(),
                     launchIntent, flagsLaunchPendingIntent);
         }
@@ -58,11 +54,6 @@ public class LaunchPendingIntentFactory {
         // Take all the properties from the notif and add it to the intent
         launchIntent.putExtras(extras);
         launchIntent.removeExtra(Constants.WZRK_ACTIONS);
-
-        int flagsLaunchPendingIntent = PendingIntent.FLAG_UPDATE_CURRENT;
-        if (VERSION.SDK_INT >= VERSION_CODES.M) {
-            flagsLaunchPendingIntent |= PendingIntent.FLAG_IMMUTABLE;
-        }
 
         return PendingIntent.getActivity(context, new Random().nextInt(), launchIntent,
                 flagsLaunchPendingIntent, null);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushProviders.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/PushProviders.java
@@ -15,7 +15,6 @@ import android.os.Bundle;
 import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
 import androidx.core.app.NotificationCompat;
@@ -471,7 +470,6 @@ public class PushProviders implements CTPushProviderListener {
     }
 
     @SuppressLint("MissingPermission")
-    @RequiresApi(api = VERSION_CODES.LOLLIPOP)
     private void stopJobScheduler(Context context) {
         int existingJobId = StorageHelper.getInt(context, PF_JOB_ID, -1);
         if (existingJobId != -1) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/work/CTFlushPushImpressionsWork.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/pushnotification/work/CTFlushPushImpressionsWork.kt
@@ -1,23 +1,17 @@
 package com.clevertap.android.sdk.pushnotification.work
 
 import android.content.Context
-import android.content.Context.BATTERY_SERVICE
-import android.os.BatteryManager
-import android.os.Build.VERSION_CODES
-import androidx.annotation.RequiresApi
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.Logger
-import com.clevertap.android.sdk.Utils
 import com.clevertap.android.sdk.flushPushImpressionsOnPostAsyncSafely
 
 class CTFlushPushImpressionsWork(context: Context, workerParams: WorkerParameters) : Worker(context, workerParams) {
 
     val tag = "CTFlushPushImpressionsWork"
 
-    @RequiresApi(api = VERSION_CODES.LOLLIPOP)
     override fun doWork(): Result {
         Logger.d(
             tag,

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/UtilsTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/UtilsTest.kt
@@ -16,8 +16,6 @@ import android.graphics.drawable.Drawable
 import android.net.ConnectivityManager
 import android.net.NetworkInfo
 import android.os.Build
-import android.os.Build.VERSION_CODES.KITKAT
-import android.os.Build.VERSION_CODES.LOLLIPOP
 import android.os.Build.VERSION_CODES.M
 import android.os.Build.VERSION_CODES.N
 import android.os.Build.VERSION_CODES.O
@@ -325,7 +323,7 @@ class UtilsTest : BaseTestCase() {
         //if telephone service is available and SDK version is <R,
         // it will give the network type accordingly no matter weather we have read phone state permission or not
         var receivedType = ""
-        arrayOf(KITKAT, LOLLIPOP, M, N, O, P, Q).forEach {
+        arrayOf(M, N, O, P, Q).forEach {
             prepareForTeleConnectTest(sdk = it, hasRPSPermission = false)
             receivedType = Utils.getDeviceNetworkType(application)
             printIfDebug("receivedType = $receivedType")

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/UtilsTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/UtilsTest.kt
@@ -2942,19 +2942,6 @@ class UtilsTest {
 
 
     @Test
-    @Config(sdk = [Build.VERSION_CODES.LOLLIPOP])
-    fun `getNotificationIds should return empty list when API level is 21`() {
-        // Given
-        val mockContext = mockk<Context>()
-
-        // When
-        val result = Utils.getNotificationIds(mockContext)
-
-        // Then
-        assertTrue(result.isEmpty())
-    }
-
-    @Test
     @Config(sdk = [Build.VERSION_CODES.M])
     fun `getNotificationIds should return empty list when no notifications match package`() {
         // Given

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Project
 android_compileSdk = "36"
 android_gradle_plugin = "8.9.3"
-android_minSdk = "21"
+android_minSdk = "23"
 kotlin_plugin = "2.0.10"
 rules = "1.7.0"
 sonarqube_plugin = "3.3"

--- a/instantapp/build.gradle.kts
+++ b/instantapp/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId = "com.clevertap.demo"
-        minSdk = 21
+        minSdk = 23
         targetSdk = 36
         versionCode = 556
         versionName = "1.7.0-instant"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -20,7 +20,7 @@ android {
     compileSdk 36
     defaultConfig {
         applicationId "com.clevertap.demo"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 36
         versionCode 8000000
         versionName "8.0.0"


### PR DESCRIPTION
## Context
-As part of migrating the SDK to minSdk 23 (Marshmallow), all `Build.VERSION.SDK_INT` checks guarding features that are       already available at API 23 are now redundant and have been removed from the `clevertap-core` module.

## Type of Change
- Refactor (no behaviour change, dead code removal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised minimum Android API level from 21 to 23.
  * Removed legacy API-level branches and conditional code paths.

* **Security**
  * Unified encryption key handling to always use the Android Keystore.

* **Refactor**
  * Standardized notification intent flags and removed outdated API annotations.
  * Simplified alert dialog flow by removing legacy two-button handling.

* **Tests**
  * Removed an API-level-specific unit test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->