### PR TITLE
feat: Add default ImageView for App Inbox when media orientation is missing

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPagerAdapter.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPagerAdapter.java
@@ -76,6 +76,10 @@ public class CTCarouselViewPagerAdapter extends PagerAdapter {
             } else if (inboxMessage.getOrientation().equalsIgnoreCase("p")) {
                 ImageView imageView = view.findViewById(R.id.squareImageView);
                 addImageAndSetClick(imageView, view, position, container);
+            } else {
+                ImageView imageView = view.findViewById(R.id.defaultImageView);
+                imageView.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                addImageAndSetClick(imageView, view, position, container);
             }
         } catch (NoClassDefFoundError error) {
             Logger.d("CleverTap SDK requires Glide dependency. Please refer CleverTap Documentation for more info");

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
@@ -62,6 +62,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
         cta3 = itemView.findViewById(R.id.cta_button_3);
         frameLayout = itemView.findViewById(R.id.icon_message_frame_layout);
         squareImage = itemView.findViewById(R.id.square_media_image);
+        defaultImage = itemView.findViewById(R.id.default_media_image);
         clickLayout = itemView.findViewById(R.id.click_relative_layout);
         ctaLinearLayout = itemView.findViewById(R.id.cta_linear_layout);
         progressBarFrameLayout = itemView.findViewById(R.id.icon_progress_frame_layout);
@@ -165,6 +166,8 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
         this.mediaImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.squareImage.setVisibility(View.GONE);
         this.squareImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.defaultImage.setVisibility(View.GONE);
+        this.defaultImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.mediaLayout.setVisibility(View.GONE);
         this.progressBarFrameLayout.setVisibility(View.GONE);
         try {
@@ -360,6 +363,95 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         }
                     }
                     break;
+                default:
+                    if (!TextUtils.isEmpty(content.getMedia())) {
+                        if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
+                            this.defaultImage.setContentDescription(content.getMediaContentDescription());
+                        }
+                        if (content.mediaIsImage()) {
+                            this.mediaLayout.setVisibility(View.VISIBLE);
+                            this.defaultImage.setVisibility(View.VISIBLE);
+                            this.defaultImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                            try {
+                                Glide.with(this.defaultImage.getContext())
+                                        .load(content.getMedia())
+                                        .apply(new RequestOptions()
+                                                .placeholder(
+                                                        Utils.getThumbnailImage(context, Constants.IMAGE_PLACEHOLDER))
+                                                .error(Utils.getThumbnailImage(context, Constants.IMAGE_PLACEHOLDER)))
+                                        .into(this.defaultImage);
+                            } catch (NoSuchMethodError error) {
+                                Logger.d(
+                                        "CleverTap SDK requires Glide v4.9.0 or above. Please refer CleverTap Documentation for more info");
+                                Glide.with(this.defaultImage.getContext())
+                                        .load(content.getMedia())
+                                        .into(this.defaultImage);
+                            }
+                        } else if (content.mediaIsGIF()) {
+                            this.mediaLayout.setVisibility(View.VISIBLE);
+                            this.defaultImage.setVisibility(View.VISIBLE);
+                            this.defaultImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                            try {
+                                Glide.with(this.defaultImage.getContext())
+                                        .asGif()
+                                        .load(content.getMedia())
+                                        .apply(new RequestOptions()
+                                                .placeholder(
+                                                        Utils.getThumbnailImage(context, Constants.IMAGE_PLACEHOLDER))
+                                                .error(Utils.getThumbnailImage(context, Constants.IMAGE_PLACEHOLDER)))
+                                        .into(this.defaultImage);
+                            } catch (NoSuchMethodError error) {
+                                Logger.d(
+                                        "CleverTap SDK requires Glide v4.9.0 or above. Please refer CleverTap Documentation for more info");
+                                Glide.with(this.defaultImage.getContext())
+                                        .asGif()
+                                        .load(content.getMedia())
+                                        .into(this.defaultImage);
+                            }
+                        } else if (content.mediaIsVideo()) {
+                            this.mediaLayout.setVisibility(View.VISIBLE);
+                            if (!content.getPosterUrl().isEmpty()) {
+                                this.defaultImage.setVisibility(View.VISIBLE);
+                                this.defaultImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                                try {
+                                    Glide.with(this.defaultImage.getContext())
+                                            .load(content.getPosterUrl())
+                                            .apply(new RequestOptions()
+                                                    .placeholder(
+                                                            Utils.getThumbnailImage(context, Constants.VIDEO_THUMBNAIL))
+                                                    .error(Utils.getThumbnailImage(context, Constants.VIDEO_THUMBNAIL)))
+                                            .into(this.defaultImage);
+                                } catch (NoSuchMethodError error) {
+                                    Logger.d(
+                                            "CleverTap SDK requires Glide v4.9.0 or above. Please refer CleverTap Documentation for more info");
+                                    Glide.with(this.defaultImage.getContext())
+                                            .load(content.getPosterUrl())
+                                            .into(this.defaultImage);
+                                }
+                            } else {
+                                this.defaultImage.setVisibility(View.VISIBLE);
+                                this.defaultImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                                int drawableId = Utils.getThumbnailImage(context, Constants.VIDEO_THUMBNAIL);
+                                if (drawableId != -1) {
+                                    Glide.with(this.defaultImage.getContext())
+                                            .load(drawableId)
+                                            .into(this.defaultImage);
+                                }
+                            }
+                        } else if (content.mediaIsAudio()) {
+                            this.mediaLayout.setVisibility(View.VISIBLE);
+                            this.defaultImage.setVisibility(View.VISIBLE);
+                            this.defaultImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                            this.defaultImage.setBackgroundColor(getImageBackgroundColor());
+                            int drawableId = Utils.getThumbnailImage(context, Constants.AUDIO_THUMBNAIL);
+                            if (drawableId != -1) {
+                                Glide.with(this.defaultImage.getContext())
+                                        .load(drawableId)
+                                        .into(this.defaultImage);
+                            }
+                        }
+                    }
+                    break;
             }
         } catch (NoClassDefFoundError error) {
             Logger.d("CleverTap SDK requires Glide dependency. Please refer CleverTap Documentation for more info");
@@ -374,7 +466,13 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
             width = resources.getDisplayMetrics().widthPixels / 2;
         } else {
             width = resources.getDisplayMetrics().widthPixels;
-            height = inboxMessage.getOrientation().equalsIgnoreCase("l") ? Math.round(width * 0.5625f) : width;
+            if (inboxMessage.getOrientation().equalsIgnoreCase("l")) {
+                height = Math.round(width * 0.5625f);
+            } else if (inboxMessage.getOrientation().equalsIgnoreCase("p")) {
+                height = width;
+            } else {
+                height = RelativeLayout.LayoutParams.WRAP_CONTENT;
+            }
         }
         this.progressBarFrameLayout.setLayoutParams(new RelativeLayout.LayoutParams(width, height));
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
@@ -168,6 +168,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
         this.squareImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.defaultImage.setVisibility(View.GONE);
         this.defaultImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.defaultImage.setContentDescription(null);
         this.mediaLayout.setVisibility(View.GONE);
         this.progressBarFrameLayout.setVisibility(View.GONE);
         try {
@@ -471,7 +472,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
             } else if (inboxMessage.getOrientation().equalsIgnoreCase("p")) {
                 height = width;
             } else {
-                height = RelativeLayout.LayoutParams.WRAP_CONTENT;
+                height = Math.round(width * 0.5625f);
             }
         }
         this.progressBarFrameLayout.setLayoutParams(new RelativeLayout.LayoutParams(width, height));

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
@@ -39,7 +39,7 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
 
     FrameLayout frameLayout;
 
-    ImageView mediaImage, squareImage;
+    ImageView mediaImage, squareImage, defaultImage;
 
     RelativeLayout mediaLayout;
 
@@ -89,14 +89,30 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
             if (message.getOrientation().equalsIgnoreCase("l")) {
                 width = Math.round(this.mediaImage.getMeasuredHeight() * 1.76f);
                 height = this.mediaImage.getMeasuredHeight();
-            } else {
+            } else if (message.getOrientation().equalsIgnoreCase("p")) {
                 height = this.squareImage.getMeasuredHeight();
                 //noinspection all
                 width = height;
+            } else {
+                width = this.defaultImage.getMeasuredWidth();
+                height = this.defaultImage.getMeasuredHeight();
+                if (width == 0 || height == 0) {
+                    width = resources.getDisplayMetrics().widthPixels / 2;
+                    height = Math.round(width * 0.5625f);
+                }
             }
         } else {
             width = resources.getDisplayMetrics().widthPixels;
-            height = message.getOrientation().equalsIgnoreCase("l") ? Math.round(width * 0.5625f) : width;
+            if (message.getOrientation().equalsIgnoreCase("l")) {
+                height = Math.round(width * 0.5625f);
+            } else if (message.getOrientation().equalsIgnoreCase("p")) {
+                height = width;
+            } else {
+                height = this.defaultImage.getMeasuredHeight();
+                if (height == 0) {
+                    height = Math.round(width * 0.5625f);
+                }
+            }
         }
 
         videoSurfaceView.setLayoutParams(new FrameLayout.LayoutParams(width, height));

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
@@ -83,8 +83,8 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
         final Resources resources = context.getResources();
         final DisplayMetrics displayMetrics = resources.getDisplayMetrics();
 
-        int width;
-        int height;
+        int width = 0;
+        int height = 0;
         if (CTInboxActivity.orientation == Configuration.ORIENTATION_LANDSCAPE) {
             if (message.getOrientation().equalsIgnoreCase("l")) {
                 width = Math.round(this.mediaImage.getMeasuredHeight() * 1.76f);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
@@ -94,9 +94,11 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
                 //noinspection all
                 width = height;
             } else {
-                width = this.defaultImage.getMeasuredWidth();
-                height = this.defaultImage.getMeasuredHeight();
-                if (width == 0 || height == 0) {
+                if (this.defaultImage != null) {
+                    width = this.defaultImage.getMeasuredWidth();
+                    height = this.defaultImage.getMeasuredHeight();
+                }
+                if (this.defaultImage == null || width == 0 || height == 0) {
                     width = resources.getDisplayMetrics().widthPixels / 2;
                     height = Math.round(width * 0.5625f);
                 }
@@ -108,8 +110,10 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
             } else if (message.getOrientation().equalsIgnoreCase("p")) {
                 height = width;
             } else {
-                height = this.defaultImage.getMeasuredHeight();
-                if (height == 0) {
+                if (this.defaultImage != null) {
+                    height = this.defaultImage.getMeasuredHeight();
+                }
+                if (this.defaultImage == null || height == 0) {
                     height = Math.round(width * 0.5625f);
                 }
             }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
@@ -163,6 +163,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
         this.squareImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.defaultImage.setVisibility(View.GONE);
         this.defaultImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.defaultImage.setContentDescription(null);
         this.mediaLayout.setVisibility(View.GONE);
         this.progressBarFrameLayout.setVisibility(View.GONE);
         try {
@@ -461,7 +462,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
             } else if (inboxMessage.getOrientation().equalsIgnoreCase("p")) {
                 height = width;
             } else {
-                height = RelativeLayout.LayoutParams.WRAP_CONTENT;
+                height = Math.round(width * 0.5625f);
             }
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
@@ -56,6 +56,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
         relativeLayout = itemView.findViewById(R.id.simple_message_relative_layout);
         frameLayout = itemView.findViewById(R.id.simple_message_frame_layout);
         squareImage = itemView.findViewById(R.id.square_media_image);
+        defaultImage = itemView.findViewById(R.id.default_media_image);
         clickLayout = itemView.findViewById(R.id.click_relative_layout);
         ctaLinearLayout = itemView.findViewById(R.id.cta_linear_layout);
         bodyRelativeLayout = itemView.findViewById(R.id.body_linear_layout);
@@ -160,6 +161,8 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
         this.mediaImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.squareImage.setVisibility(View.GONE);
         this.squareImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.defaultImage.setVisibility(View.GONE);
+        this.defaultImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.mediaLayout.setVisibility(View.GONE);
         this.progressBarFrameLayout.setVisibility(View.GONE);
         try {
@@ -351,6 +354,95 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         }
                     }
                     break;
+                default:
+                    if (!TextUtils.isEmpty(content.getMedia())) {
+                        if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
+                            this.defaultImage.setContentDescription(content.getMediaContentDescription());
+                        }
+                        if (content.mediaIsImage()) {
+                            this.mediaLayout.setVisibility(View.VISIBLE);
+                            this.defaultImage.setVisibility(View.VISIBLE);
+                            this.defaultImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                            try {
+                                Glide.with(this.defaultImage.getContext())
+                                        .load(content.getMedia())
+                                        .apply(new RequestOptions()
+                                                .placeholder(
+                                                        Utils.getThumbnailImage(context, Constants.IMAGE_PLACEHOLDER))
+                                                .error(Utils.getThumbnailImage(context, Constants.IMAGE_PLACEHOLDER)))
+                                        .into(this.defaultImage);
+                            } catch (NoSuchMethodError error) {
+                                Logger.d(
+                                        "CleverTap SDK requires Glide v4.9.0 or above. Please refer CleverTap Documentation for more info");
+                                Glide.with(this.defaultImage.getContext())
+                                        .load(content.getMedia())
+                                        .into(this.defaultImage);
+                            }
+                        } else if (content.mediaIsGIF()) {
+                            this.mediaLayout.setVisibility(View.VISIBLE);
+                            this.defaultImage.setVisibility(View.VISIBLE);
+                            this.defaultImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                            try {
+                                Glide.with(this.defaultImage.getContext())
+                                        .asGif()
+                                        .load(content.getMedia())
+                                        .apply(new RequestOptions()
+                                                .placeholder(
+                                                        Utils.getThumbnailImage(context, Constants.IMAGE_PLACEHOLDER))
+                                                .error(Utils.getThumbnailImage(context, Constants.IMAGE_PLACEHOLDER)))
+                                        .into(this.defaultImage);
+                            } catch (NoSuchMethodError error) {
+                                Logger.d(
+                                        "CleverTap SDK requires Glide v4.9.0 or above. Please refer CleverTap Documentation for more info");
+                                Glide.with(this.defaultImage.getContext())
+                                        .asGif()
+                                        .load(content.getMedia())
+                                        .into(this.defaultImage);
+                            }
+                        } else if (content.mediaIsVideo()) {
+                            this.mediaLayout.setVisibility(View.VISIBLE);
+                            if (!content.getPosterUrl().isEmpty()) {
+                                this.defaultImage.setVisibility(View.VISIBLE);
+                                this.defaultImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                                try {
+                                    Glide.with(this.defaultImage.getContext())
+                                            .load(content.getPosterUrl())
+                                            .apply(new RequestOptions()
+                                                    .placeholder(
+                                                            Utils.getThumbnailImage(context, Constants.VIDEO_THUMBNAIL))
+                                                    .error(Utils.getThumbnailImage(context, Constants.VIDEO_THUMBNAIL)))
+                                            .into(this.defaultImage);
+                                } catch (NoSuchMethodError error) {
+                                    Logger.d(
+                                            "CleverTap SDK requires Glide v4.9.0 or above. Please refer CleverTap Documentation for more info");
+                                    Glide.with(this.defaultImage.getContext())
+                                            .load(content.getPosterUrl())
+                                            .into(this.defaultImage);
+                                }
+                            } else {
+                                this.defaultImage.setVisibility(View.VISIBLE);
+                                this.defaultImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                                int drawableId = Utils.getThumbnailImage(context, Constants.VIDEO_THUMBNAIL);
+                                if (drawableId != -1) {
+                                    Glide.with(this.defaultImage.getContext())
+                                            .load(drawableId)
+                                            .into(this.defaultImage);
+                                }
+                            }
+                        } else if (content.mediaIsAudio()) {
+                            this.mediaLayout.setVisibility(View.VISIBLE);
+                            this.defaultImage.setVisibility(View.VISIBLE);
+                            this.defaultImage.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                            this.defaultImage.setBackgroundColor(getImageBackgroundColor());
+                            int drawableId = Utils.getThumbnailImage(context, Constants.AUDIO_THUMBNAIL);
+                            if (drawableId != -1) {
+                                Glide.with(this.defaultImage.getContext())
+                                        .load(drawableId)
+                                        .into(this.defaultImage);
+                            }
+                        }
+                    }
+                    break;
             }
         } catch (NoClassDefFoundError error) {
             Logger.d("CleverTap SDK requires Glide dependency. Please refer CleverTap Documentation for more info");
@@ -364,7 +456,13 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
             width = resources.getDisplayMetrics().widthPixels / 2;
         } else {
             width = resources.getDisplayMetrics().widthPixels;
-            height = inboxMessage.getOrientation().equalsIgnoreCase("l") ? Math.round(width * 0.5625f) : width;
+            if (inboxMessage.getOrientation().equalsIgnoreCase("l")) {
+                height = Math.round(width * 0.5625f);
+            } else if (inboxMessage.getOrientation().equalsIgnoreCase("p")) {
+                height = width;
+            } else {
+                height = RelativeLayout.LayoutParams.WRAP_CONTENT;
+            }
         }
 
         this.progressBarFrameLayout.setLayoutParams(new RelativeLayout.LayoutParams(width, height));

--- a/clevertap-core/src/main/res/layout-land/inbox_carousel_image_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_carousel_image_layout.xml
@@ -22,4 +22,14 @@
         android:scaleType="centerCrop"
         android:src="@drawable/ct_audio"
         android:visibility="gone" />
+
+    <ImageView
+        android:id="@+id/defaultImageView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:adjustViewBounds="true"
+        android:scaleType="fitCenter"
+        android:src="@drawable/ct_audio"
+        android:visibility="gone" />
 </LinearLayout>

--- a/clevertap-core/src/main/res/layout-land/inbox_carousel_image_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_carousel_image_layout.xml
@@ -30,6 +30,5 @@
         android:layout_gravity="center"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
-        android:src="@drawable/ct_audio"
         android:visibility="gone" />
 </LinearLayout>

--- a/clevertap-core/src/main/res/layout-land/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_icon_message_layout.xml
@@ -40,6 +40,16 @@
                     android:focusable="true"
                     android:visibility="gone" />
 
+                <ImageView
+                    android:id="@+id/default_media_image"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:adjustViewBounds="true"
+                    android:scaleType="fitCenter"
+                    android:contentDescription="@string/ct_inbox_media_content_description"
+                    android:focusable="true"
+                    android:visibility="gone" />
+
                 <FrameLayout
                     android:id="@+id/icon_message_frame_layout"
                     android:layout_width="wrap_content"

--- a/clevertap-core/src/main/res/layout-land/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_simple_message_layout.xml
@@ -41,6 +41,16 @@
                     android:focusable="true"
                     android:visibility="gone" />
 
+                <ImageView
+                    android:id="@+id/default_media_image"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:adjustViewBounds="true"
+                    android:scaleType="fitCenter"
+                    android:contentDescription="@string/ct_inbox_media_content_description"
+                    android:focusable="true"
+                    android:visibility="gone" />
+
                 <FrameLayout
                     android:id="@+id/simple_message_frame_layout"
                     android:layout_width="wrap_content"

--- a/clevertap-core/src/main/res/layout/inbox_carousel_image_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_carousel_image_layout.xml
@@ -22,4 +22,14 @@
         android:scaleType="centerCrop"
         android:src="@drawable/ct_audio"
         android:visibility="gone" />
+
+    <ImageView
+        android:id="@+id/defaultImageView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:adjustViewBounds="true"
+        android:scaleType="fitCenter"
+        android:src="@drawable/ct_audio"
+        android:visibility="gone" />
 </LinearLayout>

--- a/clevertap-core/src/main/res/layout/inbox_carousel_image_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_carousel_image_layout.xml
@@ -30,6 +30,5 @@
         android:layout_gravity="center"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
-        android:src="@drawable/ct_audio"
         android:visibility="gone" />
 </LinearLayout>

--- a/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
@@ -86,6 +86,16 @@
                 android:focusable="true"
                 android:visibility="gone" />
 
+            <ImageView
+                android:id="@+id/default_media_image"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:adjustViewBounds="true"
+                android:scaleType="fitCenter"
+                android:contentDescription="@string/ct_inbox_media_content_description"
+                android:focusable="true"
+                android:visibility="gone" />
+
             <FrameLayout
                 android:id="@+id/icon_message_frame_layout"
                 android:layout_width="match_parent"

--- a/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
@@ -34,6 +34,16 @@
                 android:focusable="true"
                 android:visibility="gone" />
 
+            <ImageView
+                android:id="@+id/default_media_image"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:adjustViewBounds="true"
+                android:scaleType="fitCenter"
+                android:contentDescription="@string/ct_inbox_media_content_description"
+                android:focusable="true"
+                android:visibility="gone" />
+
             <FrameLayout
                 android:id="@+id/simple_message_frame_layout"
                 android:layout_width="match_parent"

--- a/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenFragment.kt
+++ b/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenFragment.kt
@@ -115,7 +115,7 @@ class HomeScreenFragment : Fragment() {
         viewModel.showCustomEventDialog.observe(viewLifecycleOwner) { show ->
             if (show == true) {
                 showCustomEventDialog()
-                viewModel.showCustomEventDialog.value = false
+                viewModel.resetShowCustomEventDialog()
             }
         }
     }

--- a/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenFragment.kt
+++ b/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenFragment.kt
@@ -14,7 +14,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ExpandableListView
+import android.widget.EditText
+import android.widget.LinearLayout
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -108,6 +111,70 @@ class HomeScreenFragment : Fragment() {
                 "3-16" -> startActivity(Intent(activity, CustomInboxComposeActivity::class.java)) // Launch Compose Inbox
             }
         }
+
+        viewModel.showCustomEventDialog.observe(viewLifecycleOwner) { show ->
+            if (show == true) {
+                showCustomEventDialog()
+                viewModel.showCustomEventDialog.value = false
+            }
+        }
+    }
+
+    private fun showCustomEventDialog() {
+        val ctx = requireContext()
+        val padding = (16 * resources.displayMetrics.density).toInt()
+
+        val layout = LinearLayout(ctx).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(padding, padding, padding, 0)
+        }
+
+        val eventNameInput = EditText(ctx).apply {
+            hint = "Event Name"
+            setSingleLine()
+        }
+
+        val propertiesInput = EditText(ctx).apply {
+            hint = "Properties (key1:value1, key2:value2)"
+            setSingleLine()
+        }
+
+        layout.addView(eventNameInput)
+        layout.addView(propertiesInput)
+
+        AlertDialog.Builder(ctx)
+            .setTitle("Push Custom Event")
+            .setView(layout)
+            .setPositiveButton("Push") { _, _ ->
+                val eventName = eventNameInput.text.toString().trim()
+                if (eventName.isEmpty()) {
+                    Toast.makeText(ctx, "Event name cannot be empty", Toast.LENGTH_SHORT).show()
+                    return@setPositiveButton
+                }
+                val propertiesText = propertiesInput.text.toString().trim()
+                val properties = parseProperties(propertiesText)
+                viewModel.pushCustomEvent(eventName, properties)
+                Toast.makeText(ctx, "Event '$eventName' pushed", Toast.LENGTH_SHORT).show()
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun parseProperties(text: String): Map<String, Any>? {
+        if (text.isEmpty()) return null
+        val map = mutableMapOf<String, Any>()
+        text.split(",").forEach { pair ->
+            val trimmed = pair.trim()
+            val colonIndex = trimmed.indexOf(':')
+            if (colonIndex > 0) {
+                val key = trimmed.substring(0, colonIndex).trim()
+                val value = trimmed.substring(colonIndex + 1).trim()
+                if (key.isNotEmpty()) {
+                    map[key] = value
+                }
+            }
+        }
+        return map.ifEmpty { null }
     }
 
     private fun setupListAdapter() {

--- a/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenModel.kt
+++ b/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenModel.kt
@@ -13,7 +13,8 @@ object HomeScreenModel {
                 "Charged Event (Transaction)",
                 "Screen View Event",
                 "App Rating Event",
-                "Content Shared Event"
+                "Content Shared Event",
+                "Custom Event"
             ),
             "USER PROFILE" to listOf(
                 "Push Basic Profile",

--- a/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenViewModel.kt
+++ b/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenViewModel.kt
@@ -2,6 +2,7 @@ package com.clevertap.demo.ui.main
 
 import android.os.Looper
 import android.util.Log
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.clevertap.android.sdk.CTInboxStyleConfig
@@ -26,9 +27,15 @@ class HomeScreenViewModel(
 ) : ViewModel() {
 
     val clickCommand: MutableLiveData<String> by lazy { MutableLiveData<String>() }
-    val showCustomEventDialog: MutableLiveData<Boolean> by lazy { MutableLiveData<Boolean>() }
+
+    private val _showCustomEventDialog: MutableLiveData<Boolean> by lazy { MutableLiveData<Boolean>() }
+    val showCustomEventDialog: LiveData<Boolean> get() = _showCustomEventDialog
 
     private val exampleVariables by lazy { ExampleVariables() }
+
+    fun resetShowCustomEventDialog() {
+        _showCustomEventDialog.value = false
+    }
 
     /**
      * Handles child item clicks from the expandable list
@@ -78,7 +85,7 @@ class HomeScreenViewModel(
             6 -> recordScreenEvent()
             7 -> recordAppRatingEvent()
             8 -> recordShareEvent()
-            9 -> showCustomEventDialog.value = true
+            9 -> _showCustomEventDialog.value = true
         }
     }
 

--- a/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenViewModel.kt
+++ b/sample/src/main/java/com/clevertap/demo/ui/main/HomeScreenViewModel.kt
@@ -26,6 +26,7 @@ class HomeScreenViewModel(
 ) : ViewModel() {
 
     val clickCommand: MutableLiveData<String> by lazy { MutableLiveData<String>() }
+    val showCustomEventDialog: MutableLiveData<Boolean> by lazy { MutableLiveData<Boolean>() }
 
     private val exampleVariables by lazy { ExampleVariables() }
 
@@ -77,6 +78,18 @@ class HomeScreenViewModel(
             6 -> recordScreenEvent()
             7 -> recordAppRatingEvent()
             8 -> recordShareEvent()
+            9 -> showCustomEventDialog.value = true
+        }
+    }
+
+    fun pushCustomEvent(eventName: String, properties: Map<String, Any>?) {
+        logStep("EVENTS", "Recording custom event")
+        printVar("Event Name", eventName)
+        if (properties.isNullOrEmpty()) {
+            cleverTapAPI?.pushEvent(eventName)
+        } else {
+            printMap("Event Properties", properties)
+            cleverTapAPI?.pushEvent(eventName, properties)
         }
     }
 


### PR DESCRIPTION
When the backend does not provide an orientation key ("l" or "p") in the App Inbox payload, the SDK now falls back to a plain ImageView with match_parent width and wrap_content height, rendering the image at its natural aspect ratio using FIT_CENTER scale type. This supports the new Personalized Media feature, where customers paste arbitrary image URLs without dimension validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored media display for non-standard orientations by adding a fallback media view and ensuring it participates in image binding.

* **New Features**
  * Added a default/fallback media view across carousel, icon, and simple message layouts supporting images, GIFs, video posters and audio thumbnails.
  * Improved image scaling (FIT_CENTER) and refined aspect-ratio/sizing for landscape, portrait, and other orientations.
  * Sample app: added a "Push Custom Event" dialog and corresponding Events list entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->