### PR TITLE
SDK-5657: Mute SDK

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -2878,6 +2878,19 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     }
 
     /**
+     * Clears any active mute state set by the backend, allowing the SDK to resume
+     * normal event tracking and network operations immediately.
+     * <p>
+     * The CleverTap backend can mute a client for a set duration (e.g., during a
+     * detected abuse scenario). Call this method to override that mute and restore
+     * normal SDK operation without waiting for the mute period to expire.
+     */
+    @SuppressWarnings({"unused"})
+    public void unmute() {
+        coreState.getNetworkManager().unmute();
+    }
+
+    /**
      * Use this method to opt the current user out of all event/profile tracking.
      * You must call this method separately for each active user profile (e.g. when switching user profiles using
      * onUserLogin).

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -144,6 +144,8 @@ public interface Constants {
     String KEY_OLD_VALUE = "oldValue";
     String KEY_ITEMS = "Items";
     String KEY_MUTED = "comms_mtd";
+    String KEY_MUTE_EXPIRY = "comms_mute_expiry_ts";
+    long DEFAULT_MUTE_DURATION_MS = 24 * 60 * 60 * 1000L;
     int EMPTY_NOTIFICATION_ID = -1000;
     String KEY_MAX_PER_DAY = "istmcd_inapp";
     String KEY_COUNTS_SHOWN_TODAY = "istc_inapp";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkManager.kt
@@ -273,13 +273,32 @@ internal class NetworkManager constructor(
             ?.let { muteCommand ->
                 // muteCommand is guaranteed to be non-null and non-empty here
                 if (muteCommand == "true") {
-                    setMuted(true)
+                    val muteExpiryMs = parseMuteExpiryMs(response)
+                    setMuted(true, muteExpiryMs)
                     return true
                 } else {
                     setMuted(false)
                 }
             }
         return false
+    }
+
+    /**
+     * Parses the X-WZRK-MUTE-DURATION header value as an absolute epoch timestamp in milliseconds.
+     * @return The mute expiry epoch ms, or null if the header is absent or invalid.
+     */
+    private fun parseMuteExpiryMs(response: Response): Long? {
+        val value = response.getHeaderValue(CtApi.HEADER_MUTE_DURATION)
+            ?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        return try {
+            value.toLong()
+        } catch (_: NumberFormatException) {
+            logger.verbose(
+                config.accountId,
+                "Invalid X-WZRK-MUTE-DURATION value: $value, falling back to default mute"
+            )
+            null
+        }
     }
 
     /**
@@ -755,10 +774,20 @@ internal class NetworkManager constructor(
         ctApiWrapper.ctApi.cachedSpikyDomain = spikyDomainName
     }
 
+    /**
+     * @param mute Whether to mute or unmute the SDK.
+     * @param muteExpiryMs The absolute epoch timestamp in milliseconds when the mute should expire.
+     *                     If null, the default 24-hour mute duration is used. Only relevant when [mute] is true.
+     */
     @WorkerThread
-    private fun setMuted(mute: Boolean) {
+    private fun setMuted(mute: Boolean, muteExpiryMs: Long? = null) {
         if (mute) {
-            networkRepo.setMuted(true)
+            if (muteExpiryMs != null) {
+                networkRepo.setMuteExpiry(muteExpiryMs)
+            } else {
+                // Fallback to default 24-hour mute for older backend responses
+                networkRepo.setMuted(true)
+            }
             networkRepo.setDomain(null)
 
             // Clear all the queues
@@ -769,5 +798,14 @@ internal class NetworkManager constructor(
         } else {
             networkRepo.setMuted(false)
         }
+    }
+
+    /**
+     * Clears any active mute state set by the backend, allowing the SDK to resume
+     * normal event tracking and network operations immediately.
+     */
+    fun unmute() {
+        logger.debug(config.accountId, "unmute called, clearing mute state")
+        networkRepo.unmute()
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkRepo.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/NetworkRepo.kt
@@ -80,17 +80,48 @@ internal class NetworkRepo(
     }
 
     /**
-     * @return true if the mute command was sent anytime between now and now - 24 hours.
+     * @return true if the current time is before the mute expiry timestamp.
+     * Also handles migration from the old SDK's comms_mtd key (epoch seconds)
+     * to the new comms_mute_expiry_ts key (absolute epoch milliseconds).
      */
     fun isMuted() : Boolean {
-        val now = clock.currentTimeSecondsInt()
-        val muteTS = getMuted()
-        return now - muteTS < 24 * 60 * 60
+        val now = clock.currentTimeMillis()
+        val muteExpiryMs = getMuteExpiry()
+        if (muteExpiryMs > 0) {
+            return now < muteExpiryMs
+        }
+        // Migration: check old key for an active mute from a previous SDK version
+        @Suppress("DEPRECATION")
+        val legacyMuteTs = getMuted()
+        if (legacyMuteTs > 0) {
+            val legacyExpiryMs = (legacyMuteTs + 24 * 60 * 60) * 1000L
+            if (now < legacyExpiryMs) {
+                // Migrate to new format so this path is only hit once
+                setMuteExpiry(legacyExpiryMs)
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * @return the mute expiry timestamp in epoch milliseconds, or 0 if not muted.
+     */
+    fun getMuteExpiry() : Long {
+        return StorageHelper.getLongFromPrefs(
+            context,
+            config.accountId,
+            Constants.KEY_MUTE_EXPIRY,
+            0L,
+            null
+        )
     }
 
     /**
      * @return timestamp from epoch since SDK was muted in seconds.
+     * @deprecated Use [getMuteExpiry] instead. Retained for migration from older SDK versions.
      */
+    @Deprecated("Use getMuteExpiry() instead")
     fun getMuted() : Int {
         return StorageHelper.getIntFromPrefs(
             context,
@@ -100,23 +131,37 @@ internal class NetworkRepo(
         )
     }
 
+    /**
+     * Sets the mute state with the default 24-hour duration.
+     * When muted, stores an absolute expiry timestamp (now + 24h) in milliseconds.
+     */
     fun setMuted(mute: Boolean) {
         if (mute) {
-            val now = clock.currentTimeSecondsInt()
-            StorageHelper.putInt(
-                context,
-                config.accountId,
-                Constants.KEY_MUTED,
-                now
-            )
+            val expiryMs = clock.currentTimeMillis() + Constants.DEFAULT_MUTE_DURATION_MS
+            setMuteExpiry(expiryMs)
         } else {
-            StorageHelper.putInt(
-                context,
-                config.accountId,
-                Constants.KEY_MUTED,
-                0
-            )
+            setMuteExpiry(0L)
         }
+    }
+
+    /**
+     * Sets the mute expiry to a specific absolute epoch timestamp in milliseconds.
+     * The backend sends this value via the X-WZRK-MUTE-DURATION header.
+     */
+    fun setMuteExpiry(expiryMs: Long) {
+        StorageHelper.putLong(
+            context,
+            StorageHelper.storageKeyWithSuffix(config.accountId, Constants.KEY_MUTE_EXPIRY),
+            expiryMs
+        )
+    }
+
+    /**
+     * Clears any active mute state, allowing the SDK to resume
+     * normal event tracking and network operations immediately.
+     */
+    fun unmute() {
+        setMuteExpiry(0L)
     }
 
     fun setDomain(domainName: String?) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/api/CtApi.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/api/CtApi.kt
@@ -38,6 +38,7 @@ internal class CtApi(
 
         // Response Headers
         const val HEADER_MUTE: String = "X-WZRK-MUTE"
+        const val HEADER_MUTE_DURATION: String = "X-WZRK-MUTE-DURATION"
         const val HEADER_DOMAIN_NAME: String = "X-WZRK-RD"
         const val SPIKY_HEADER_DOMAIN_NAME: String = "X-WZRK-SPIKY-RD"
 

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/network/http/NetworkRepoTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/network/http/NetworkRepoTest.kt
@@ -1,6 +1,8 @@
 package com.clevertap.android.sdk.network.http
 
 import com.clevertap.android.sdk.CleverTapInstanceConfig
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.StorageHelper
 import com.clevertap.android.sdk.TestClock
 import com.clevertap.android.sdk.network.NetworkRepo
 import com.clevertap.android.sdk.utils.Clock
@@ -148,24 +150,24 @@ class NetworkRepoTest : BaseTestCase() {
         assertEquals(timestamp, result)
     }
 
-    // Test cases for setMuted(), getMuted(), and isMuted()
+    // Test cases for setMuted(), getMuteExpiry(), unmute(), and isMuted()
     @Test
-    fun `setMuted with true should store current timestamp and getMuted should return it`() {
+    fun `setMuted with true should store expiry timestamp and isMuted should return true`() {
         // Given
         val testClock = TestClock(1000000L * 1000) // Set fixed time
         networkRepo = createNetworkRepo(testClock)
-        val expectedTimestamp = testClock.currentTimeSecondsInt()
 
         // When
         networkRepo.setMuted(true)
         
         // Then
-        assertEquals("getMuted should return the timestamp when muted", expectedTimestamp, networkRepo.getMuted())
+        val expectedExpiry = testClock.currentTimeMillis() + 24 * 60 * 60 * 1000L
+        assertEquals("getMuteExpiry should return now + 24h", expectedExpiry, networkRepo.getMuteExpiry())
         assertTrue("Should be muted when setMuted(true) is called", networkRepo.isMuted())
     }
 
     @Test
-    fun `setMuted with false should store zero and getMuted should return zero`() {
+    fun `setMuted with false should clear expiry and isMuted should return false`() {
         // Given
         val testClock = TestClock()
         networkRepo = createNetworkRepo(testClock)
@@ -178,20 +180,20 @@ class NetworkRepoTest : BaseTestCase() {
         networkRepo.setMuted(false)
 
         // Then
-        assertEquals("getMuted should return 0 when setMuted(false)", 0, networkRepo.getMuted())
+        assertEquals("getMuteExpiry should return 0 when setMuted(false)", 0L, networkRepo.getMuteExpiry())
         assertFalse("Should not be muted when setMuted(false)", networkRepo.isMuted())
     }
 
     @Test
-    fun `getMuted should return default value 0 when no mute value stored`() {
+    fun `getMuteExpiry should return default value 0 when no mute value stored`() {
         // Given
         networkRepo = createNetworkRepo()
 
         // When
-        val result = networkRepo.getMuted()
+        val result = networkRepo.getMuteExpiry()
 
         // Then
-        assertEquals("Default muted value should be 0", 0, result)
+        assertEquals("Default mute expiry value should be 0", 0L, result)
     }
 
     @Test
@@ -264,6 +266,123 @@ class NetworkRepoTest : BaseTestCase() {
     }
 
     @Test
+    fun `setMuteExpiry should store absolute epoch ms and isMuted should respect it`() {
+        // Given
+        val testClock = TestClock(1000000L * 1000) // now = 1,000,000,000 ms
+        networkRepo = createNetworkRepo(testClock)
+        val expiryMs = testClock.currentTimeMillis() + 3 * 60 * 60 * 1000L // 3 hours from now
+
+        // When
+        networkRepo.setMuteExpiry(expiryMs)
+
+        // Then
+        assertTrue("Should be muted when expiry is in the future", networkRepo.isMuted())
+        assertEquals("getMuteExpiry should return the stored expiry", expiryMs, networkRepo.getMuteExpiry())
+
+        // Advance past expiry
+        testClock.advanceTime(4 * 60 * 60 * 1000) // 4 hours
+        assertFalse("Should not be muted after expiry has passed", networkRepo.isMuted())
+    }
+
+    @Test
+    fun `unmute should clear mute state immediately`() {
+        // Given
+        val testClock = TestClock(1000000L * 1000)
+        networkRepo = createNetworkRepo(testClock)
+        networkRepo.setMuted(true)
+        assertTrue("Should be muted initially", networkRepo.isMuted())
+
+        // When
+        networkRepo.unmute()
+
+        // Then
+        assertFalse("Should not be muted after unmute()", networkRepo.isMuted())
+        assertEquals("getMuteExpiry should return 0 after unmute()", 0L, networkRepo.getMuteExpiry())
+    }
+
+    // Migration tests: old SDK (comms_mtd) → new SDK (comms_mute_expiry_ts)
+    @Test
+    fun `isMuted should migrate active mute from old comms_mtd key`() {
+        // Given - Simulate old SDK: write epoch seconds directly to the legacy key
+        val nowMs = 1000000L * 1000 // 1,000,000,000 ms
+        val testClock = TestClock(nowMs)
+        val legacyMuteTs = (nowMs / 1000).toInt() // epoch seconds, as old SDK stored it
+        StorageHelper.putInt(
+            appCtx,
+            StorageHelper.storageKeyWithSuffix(config.accountId, Constants.KEY_MUTED),
+            legacyMuteTs
+        )
+        networkRepo = createNetworkRepo(testClock)
+
+        // When - New SDK checks isMuted, no new key exists yet
+        val result = networkRepo.isMuted()
+
+        // Then - Should detect old mute and migrate it
+        assertTrue("Should be muted via migration from old key", result)
+        val expectedExpiry = (legacyMuteTs + 24 * 60 * 60) * 1000L
+        assertEquals("Should have migrated to new key", expectedExpiry, networkRepo.getMuteExpiry())
+    }
+
+    @Test
+    fun `isMuted should not migrate expired mute from old comms_mtd key`() {
+        // Given - Simulate old SDK mute that has expired (set 25h ago)
+        val nowMs = 1000000L * 1000
+        val testClock = TestClock(nowMs)
+        val legacyMuteTs = ((nowMs / 1000) - 25 * 60 * 60).toInt() // 25h ago
+        StorageHelper.putInt(
+            appCtx,
+            StorageHelper.storageKeyWithSuffix(config.accountId, Constants.KEY_MUTED),
+            legacyMuteTs
+        )
+        networkRepo = createNetworkRepo(testClock)
+
+        // When
+        val result = networkRepo.isMuted()
+
+        // Then - Old mute was expired, should not be muted
+        assertFalse("Should not be muted when old mute has expired", result)
+        assertEquals("Should not have migrated expired mute", 0L, networkRepo.getMuteExpiry())
+    }
+
+    @Test
+    fun `isMuted should prefer new key over old key when both exist`() {
+        // Given - Both old and new keys exist (e.g. after migration + new mute)
+        val nowMs = 1000000L * 1000
+        val testClock = TestClock(nowMs)
+        // Old key with some value
+        StorageHelper.putInt(
+            appCtx,
+            StorageHelper.storageKeyWithSuffix(config.accountId, Constants.KEY_MUTED),
+            (nowMs / 1000).toInt()
+        )
+        // New key cleared (unmuted via new SDK)
+        networkRepo = createNetworkRepo(testClock)
+        networkRepo.setMuteExpiry(nowMs + 5 * 60 * 60 * 1000L) // 5h from now
+
+        // When
+        val result = networkRepo.isMuted()
+
+        // Then - New key takes precedence
+        assertTrue("New key should take precedence", result)
+    }
+
+    @Test
+    fun `unmute should clear custom expiry mute`() {
+        // Given
+        val testClock = TestClock(1000000L * 1000)
+        networkRepo = createNetworkRepo(testClock)
+        // Set a far-future expiry (simulating backend-set infinite mute)
+        networkRepo.setMuteExpiry(253402300799000L) // 9999-12-31
+        assertTrue("Should be muted with far-future expiry", networkRepo.isMuted())
+
+        // When
+        networkRepo.unmute()
+
+        // Then
+        assertFalse("Should not be muted after unmute()", networkRepo.isMuted())
+    }
+
+    @Test
     fun `mute methods should work independently with other storage operations`() {
         // Given
         val testClock = TestClock()
@@ -280,16 +399,16 @@ class NetworkRepoTest : BaseTestCase() {
         assertEquals("Domain should be stored independently", domain, networkRepo.getDomain())
         assertEquals("First request timestamp should be stored independently", firstTs, networkRepo.getFirstRequestTs())
         assertTrue("Should be muted", networkRepo.isMuted())
-        assertTrue("Muted timestamp should be non-zero", networkRepo.getMuted() > 0)
+        assertTrue("Mute expiry should be non-zero", networkRepo.getMuteExpiry() > 0)
         
         // When - Unmute
-        networkRepo.setMuted(false)
+        networkRepo.unmute()
         
         // Then - Other values should remain, mute should be cleared
         assertEquals("Domain should still be stored", domain, networkRepo.getDomain())
         assertEquals("First request timestamp should still be stored", firstTs, networkRepo.getFirstRequestTs())
         assertFalse("Should not be muted", networkRepo.isMuted())
-        assertEquals("Muted timestamp should be zero", 0, networkRepo.getMuted())
+        assertEquals("Mute expiry should be zero", 0L, networkRepo.getMuteExpiry())
     }
 
     // Test cases for setDomain()


### PR DESCRIPTION
…ic unmute API

- Refactor mute from relative 24h check to absolute expiry timestamp model
- Add X-WZRK-MUTE-DURATION response header support (absolute epoch ms from backend)
- Store mute expiry in new Long key (comms_mute_expiry_ts) replacing Int key (comms_mtd)
- Add migration logic in isMuted() to read old comms_mtd key and convert to new format
- Add setMuteExpiry(epochMs) for backend-provided mute durations
- Add unmute() public API on CleverTapAPI to programmatically clear mute state
- Add parseMuteExpiryMs() in NetworkManager to extract duration from response headers
- Retain backward compatibility: old SDKs ignore new header and use 24h default
- Mark getMuted() as deprecated in favor of getMuteExpiry()
- Add unit tests for migration, custom expiry, unmute, and edge cases

Constants.java:
  - Add KEY_MUTE_EXPIRY and DEFAULT_MUTE_DURATION_MS constants

CtApi.kt:
  - Add HEADER_MUTE_DURATION response header constant

NetworkRepo.kt:
  - isMuted(): now checks absolute expiry with migration fallback for old key
  - getMuteExpiry(): reads Long expiry from new storage key
  - setMuted(): stores now + 24h as absolute expiry
  - setMuteExpiry(): stores arbitrary absolute epoch ms expiry
  - unmute(): clears mute expiry to 0

NetworkManager.kt:
  - shouldMuteSdk(): extracts mute duration before calling setMuted
  - parseMuteExpiryMs(): parses X-WZRK-MUTE-DURATION header safely
  - setMuted(): accepts optional muteExpiryMs instead of Response object
  - unmute(): public method delegating to NetworkRepo

CleverTapAPI.java:
  - Add public unmute() method with Javadoc

NetworkRepoTest.kt:
  - Update existing mute tests for new expiry-based model
  - Add migration tests (active mute, expired mute, key precedence)
  - Add setMuteExpiry, unmute, and infinite mute tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `unmute()` method to immediately clear backend-imposed mute state and resume normal network and event operations.

* **Improvements**
  * Enhanced mute handling to support backend-defined expiry timestamps, enabling more granular communication control independent of offline/online settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->