### PR TITLE
fix: ArrayIndexOutOfBounds crash in VarCache when nameComponents is empty

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -3526,8 +3526,9 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      * @param name Name of the variable.
      * @param defaultValue Default value of variable, used when resolving the underlying value type.
      * @param <T> Type of value.
-     * @return Returns the Var instance.
+     * @return Returns the Var instance, or null if the name is empty, invalid, or cannot be parsed.
      */
+    @Nullable
     public <T> Var<T> defineVariable(String name, T defaultValue) {
         return Var.define(name, defaultValue,coreState.getCTVariables());
     }
@@ -3536,8 +3537,9 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      * Defines a new file variable. Disclaimer: cannot be used with @Variable annotation.
      *
      * @param name Name of the variable.
-     * @return Returns the Var instance.
+     * @return Returns the Var instance, or null if the name is empty, invalid, or cannot be parsed.
      */
+    @Nullable
     public Var<String> defineFileVariable(String name) {
         return Var.define(name, null , CTVariableUtils.FILE, coreState.getCTVariables());
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/Var.java
@@ -93,6 +93,10 @@ public class Var<T> {
         try {
             var.name = name;
             var.nameComponents = CTVariableUtils.getNameComponents(name);
+            if (var.nameComponents.length == 0) {
+                log("Variable name could not be parsed into components, skipping: " + name);
+                return null;
+            }
             var.defaultValue = defaultValue;
             var.value = defaultValue;
             var.kind = kind;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/VarCache.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/variables/VarCache.java
@@ -85,6 +85,11 @@ public class VarCache {
             return;
         }
 
+        if (var.nameComponents().length == 0) {
+            log("mergeVariable() called, but var has empty `nameComponents`. Var name: [" + var.name() + "]");
+            return;
+        }
+
         String firstComponent = var.nameComponents()[0];
         Object defaultValue = valuesFromClient.get(firstComponent);
         Map<String, Object> mergedMap = JsonUtil.uncheckedCast(merged);

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/variables/VarCacheTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/variables/VarCacheTest.kt
@@ -349,6 +349,7 @@ class VarCacheTest : BaseTestCase() {
         assertEquals(4, varCache.getMergedValue("var4"))
     }
 
+    @Test
     fun `test getMergedValue with groups`() {
         ctVariables.init()
 
@@ -360,7 +361,7 @@ class VarCacheTest : BaseTestCase() {
         assertEquals(1, varCache.getMergedValue("group1.var1"))
         assertEquals(2, varCache.getMergedValue("group1.var2"))
         assertEquals(3, varCache.getMergedValue("group1.group2.var3"))
-        assertEquals(3, varCache.getMergedValue("group1.group2.var4"))
+        assertEquals(4, varCache.getMergedValue("group1.group2.var4"))
     }
 
     @Test
@@ -565,9 +566,17 @@ class VarCacheTest : BaseTestCase() {
         ctVariables.init()
         val var1: Var<String> = Var.define("var1", null, "file", ctVariables)
         varCache.merged = mutableMapOf<String, Any>("var1" to "http://example.com/file.png")
+        val mergedBefore = (varCache.merged as Map<*, *>).toMap()
+
+        // Force empty nameComponents via reflection to simulate a corrupted state,
+        // bypassing Var.define()'s own guard, and verify VarCache's defensive fallback.
         val field = Var::class.java.getDeclaredField("nameComponents")
         field.isAccessible = true
         field.set(var1, emptyArray<String>())
-        varCache.mergeVariable(var1) // should return gracefully without ArrayIndexOutOfBoundsException
+
+        varCache.mergeVariable(var1)
+
+        // guard returned early — merged map should remain unchanged
+        assertEquals(mergedBefore, varCache.merged)
     }
 }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/variables/VarCacheTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/variables/VarCacheTest.kt
@@ -559,4 +559,15 @@ class VarCacheTest : BaseTestCase() {
         }
         verify(exactly = 2) { handler.run() }
     }
+
+    @Test
+    fun `test mergeVariable with empty nameComponents does not crash`() {
+        ctVariables.init()
+        val var1: Var<String> = Var.define("var1", null, "file", ctVariables)
+        varCache.merged = mutableMapOf<String, Any>("var1" to "http://example.com/file.png")
+        val field = Var::class.java.getDeclaredField("nameComponents")
+        field.isAccessible = true
+        field.set(var1, emptyArray<String>())
+        varCache.mergeVariable(var1) // should return gracefully without ArrayIndexOutOfBoundsException
+    }
 }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/variables/VarTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/variables/VarTest.kt
@@ -231,14 +231,18 @@ class VarTest : BaseTestCase() {
     @Test
     fun `define() should return null when nameComponents is empty`() {
         mockkStatic(CTVariableUtils::class)
-        val variableName = "validName"
-        every { varCache.getVariable<String>(variableName) } returns null
-        every { CTVariableUtils.getNameComponents(variableName) } returns emptyArray()
+        try {
+            val variableName = "validName"
+            every { varCache.getVariable<String>(variableName) } returns null
+            every { CTVariableUtils.getNameComponents(variableName) } returns emptyArray()
 
-        val result = Var.define(variableName, "default", "string", ctVariables)
+            val result = Var.define(variableName, "default", "string", ctVariables)
 
-        assertNull(result)
-        verify { Logger.v("variable", "Variable name could not be parsed into components, skipping: $variableName") }
+            assertNull(result)
+            verify { Logger.v("variable", "Variable name could not be parsed into components, skipping: $variableName") }
+        } finally {
+            unmockkStatic(CTVariableUtils::class)
+        }
     }
 
     @Test

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/variables/VarTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/variables/VarTest.kt
@@ -229,6 +229,19 @@ class VarTest : BaseTestCase() {
 
 
     @Test
+    fun `define() should return null when nameComponents is empty`() {
+        mockkStatic(CTVariableUtils::class)
+        val variableName = "validName"
+        every { varCache.getVariable<String>(variableName) } returns null
+        every { CTVariableUtils.getNameComponents(variableName) } returns emptyArray()
+
+        val result = Var.define(variableName, "default", "string", ctVariables)
+
+        assertNull(result)
+        verify { Logger.v("variable", "Variable name could not be parsed into components, skipping: $variableName") }
+    }
+
+    @Test
     fun `triggerFileIsReady() should invoke all registered file ready handlers`() {
         every { varCache.getVariable<String>("testFileVar") } returns null
         val varObj = Var.define("testFileVar", null, "file", ctVariables)


### PR DESCRIPTION

## Problem
ArrayIndexOutOfBoundsException crash in VarCache.mergeVariable() when nameComponents()[0] is accessed on an empty array.

## Root Cause
When a file variable has an invalid name, CTVariableUtils.getNameComponents() returns an empty String[] from the catch block. No bounds check exists before accessing index [0], causing a crash after file download completes.

## Fix
1. Added empty check in `Var.define()` — rejects variable at definition time if nameComponents is empty
2. Added safety guard in `VarCache.mergeVariable()` — logs and returns early as a fallback

## Testing
- Unit test added for empty nameComponents scenario in VarCache
- Verified crash no longer occurs when invalid variable name is received from server


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Creation and merging of variables now safely skip entries with unparseable or empty names and log the condition, preventing runtime errors.

* **Documentation**
  * Variable-definition APIs now document and annotate that they may return null for empty, invalid, or unparseable names.

* **Tests**
  * Added unit tests to cover unparseable/empty-name edge cases for variable definition and merge behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->