### PR TITLE
Support all video formats inside in-app and inbox players

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inapps/ExoplayerHandle.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inapps/ExoplayerHandle.kt
@@ -14,7 +14,7 @@ import com.clevertap.android.sdk.video.InAppVideoPlayerHandle
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.source.hls.HlsMediaSource
+import com.google.android.exoplayer2.source.DefaultMediaSourceFactory
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.trackselection.ExoTrackSelection
@@ -73,10 +73,12 @@ class ExoplayerHandle : InAppVideoPlayerHandle {
         val dsf = DefaultHttpDataSource.Factory().setUserAgent(userAgent).setTransferListener(listener)
         val dataSourceFactory: DataSource.Factory = DefaultDataSource.Factory(context, dsf)
         val mediaItem = MediaItem.fromUri(url)
-        val hlsMediaSource = HlsMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
 
-        player = ExoPlayer.Builder(context).setTrackSelector(trackSelector).build().apply {
-            setMediaSource(hlsMediaSource)
+        player = ExoPlayer.Builder(context)
+            .setTrackSelector(trackSelector)
+            .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
+            .build().apply {
+            setMediaItem(mediaItem)
             prepare()
             repeatMode = Player.REPEAT_MODE_ONE
             volume = InAppVideoPlayerHandle.VOLUME_MUTED

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inapps/Media3Handle.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inapps/Media3Handle.kt
@@ -17,7 +17,7 @@ import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.trackselection.ExoTrackSelection
@@ -62,10 +62,12 @@ class Media3Handle : InAppVideoPlayerHandle {
         val dsf = DefaultHttpDataSource.Factory().setUserAgent(userAgent).setTransferListener(listener)
         val dataSourceFactory: DataSource.Factory = DefaultDataSource.Factory(context, dsf)
         val mediaItem = MediaItem.fromUri(url)
-        val hlsMediaSource = HlsMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
 
-        player = ExoPlayer.Builder(context).setTrackSelector(trackSelector).build().apply {
-            setMediaSource(hlsMediaSource)
+        player = ExoPlayer.Builder(context)
+            .setTrackSelector(trackSelector)
+            .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
+            .build().apply {
+            setMediaItem(mediaItem)
             prepare()
             repeatMode = Player.REPEAT_MODE_ONE
             volume = InAppVideoPlayerHandle.VOLUME_MUTED

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/ExoplayerHandle.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/ExoplayerHandle.kt
@@ -9,14 +9,13 @@ import com.clevertap.android.sdk.video.InboxVideoPlayerHandle
 import com.google.android.exoplayer2.ExoPlayer
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.Player
-import com.google.android.exoplayer2.source.hls.HlsMediaSource
+import com.google.android.exoplayer2.source.DefaultMediaSourceFactory
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 import com.google.android.exoplayer2.trackselection.ExoTrackSelection
 import com.google.android.exoplayer2.trackselection.TrackSelector
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout
 import com.google.android.exoplayer2.ui.StyledPlayerView
-import com.google.android.exoplayer2.upstream.DataSource
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter
 import com.google.android.exoplayer2.upstream.DefaultDataSource
 import com.google.android.exoplayer2.upstream.DefaultHttpDataSource
@@ -51,8 +50,15 @@ class ExoplayerHandle : InboxVideoPlayerHandle {
         val videoTrackSelectionFactory: ExoTrackSelection.Factory = AdaptiveTrackSelection.Factory()
         val trackSelector: TrackSelector = DefaultTrackSelector(context, videoTrackSelectionFactory)
 
+        val defaultBandwidthMeter = DefaultBandwidthMeter.Builder(context).build()
+        val userAgent = Util.getUserAgent(context, context.packageName)
+        val dsf = DefaultHttpDataSource.Factory().setUserAgent(userAgent)
+            .setTransferListener(defaultBandwidthMeter)
+        val dataSourceFactory = DefaultDataSource.Factory(context, dsf)
+
         player = ExoPlayer.Builder(context)
             .setTrackSelector(trackSelector)
+            .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
             .build()
             .apply {
                 volume = 0f // start off muted
@@ -150,15 +156,8 @@ class ExoplayerHandle : InboxVideoPlayerHandle {
         }
         // Prepare the player with the source.
         player?.let { ep ->
-            val defaultBandwidthMeter = DefaultBandwidthMeter.Builder(ctx).build()
-            val userAgent = Util.getUserAgent(ctx, ctx.packageName)
             val mediaItem: MediaItem = MediaItem.fromUri(uriString)
-            val dsf = DefaultHttpDataSource.Factory().setUserAgent(userAgent)
-                .setTransferListener(defaultBandwidthMeter)
-            val dataSourceFactory: DataSource.Factory = DefaultDataSource.Factory(ctx, dsf)
-            val hlsMediaSource = HlsMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
-
-            ep.setMediaSource(hlsMediaSource)
+            ep.setMediaItem(mediaItem)
             ep.prepare()
             if (isMediaAudio) {
                 videoSurfaceView?.showController() //show controller for audio as it is not autoplay

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/Media3Handle.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/Media3Handle.kt
@@ -9,16 +9,15 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.common.util.Util
-import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.exoplayer.trackselection.AdaptiveTrackSelection
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.trackselection.ExoTrackSelection
 import androidx.media3.exoplayer.trackselection.TrackSelector
-import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 import com.clevertap.android.sdk.video.InboxVideoPlayerHandle
@@ -41,8 +40,15 @@ class Media3Handle: InboxVideoPlayerHandle {
         val videoTrackSelectionFactory: ExoTrackSelection.Factory = AdaptiveTrackSelection.Factory()
         val trackSelector: TrackSelector = DefaultTrackSelector(context, videoTrackSelectionFactory)
 
+        val defaultBandwidthMeter = DefaultBandwidthMeter.Builder(context).build()
+        val userAgent = Util.getUserAgent(context, context.packageName)
+        val dsf = DefaultHttpDataSource.Factory().setUserAgent(userAgent)
+            .setTransferListener(defaultBandwidthMeter)
+        val dataSourceFactory = DefaultDataSource.Factory(context, dsf)
+
         player = ExoPlayer.Builder(context)
             .setTrackSelector(trackSelector)
+            .setMediaSourceFactory(DefaultMediaSourceFactory(dataSourceFactory))
             .build()
             .apply {
                 volume = 0f // start off muted
@@ -140,15 +146,8 @@ class Media3Handle: InboxVideoPlayerHandle {
         }
         // Prepare the player with the source.
         player?.let { ep ->
-            val defaultBandwidthMeter = DefaultBandwidthMeter.Builder(ctx).build()
-            val userAgent = Util.getUserAgent(ctx, ctx.packageName)
             val mediaItem: MediaItem = MediaItem.fromUri(uriString)
-            val dsf = DefaultHttpDataSource.Factory().setUserAgent(userAgent)
-                .setTransferListener(defaultBandwidthMeter)
-            val dataSourceFactory: DataSource.Factory = DefaultDataSource.Factory(ctx, dsf)
-            val hlsMediaSource = HlsMediaSource.Factory(dataSourceFactory).createMediaSource(mediaItem)
-
-            ep.setMediaSource(hlsMediaSource)
+            ep.setMediaItem(mediaItem)
             ep.prepare()
             if (isMediaAudio) {
                 videoSurfaceView?.showController() //show controller for audio as it is not autoplay


### PR DESCRIPTION
Replace hardcoded HlsMediaSource.Factory with DefaultMediaSourceFactory in all 4 ExoPlayer/Media3 handle files (inapps + inbox). This enables auto-detection of video format (MP4, HLS, DASH, etc.) from URI, aligning with PIP player behavior. Existing HLS streams continue to work since the HLS module dependencies are still included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized video playback infrastructure across in-app and inbox video components to streamline media source initialization and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->