### PR TITLE
docs(SDK-5664): Docs for Release CleverTap Android SDK v8.1.0 & Push Templates SDK v2.4.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## CHANGE LOG.
 
+### April 6, 2026
+* [CleverTap Android SDK v8.1.0](docs/CTCORECHANGELOG.md).
+* [CleverTap Push Templates SDK v2.4.0](docs/CTPUSHTEMPLATESCHANGELOG.md).
+
 ### March 6, 2026
 * [CleverTap Push Templates SDK v2.3.0](docs/CTPUSHTEMPLATESCHANGELOG.md).
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ Interstitial InApp Notification templates support Audio and Video with the help 
     implementation "com.google.android.exoplayer:exoplayer-ui:2.19.1"
 ```  
 
+PIP (Picture-in-Picture) In-App Notifications with video media require `AndroidX Media3`. Add the following dependencies in your `build.gradle` file:
+```groovy
+    implementation "androidx.media3:media3-exoplayer:1.4.0"
+    implementation "androidx.media3:media3-exoplayer-hls:1.4.0"
+    implementation "androidx.media3:media3-ui:1.4.0"
+```
+**Note:** PIP image and GIF media types work without Media3. The dependency is only required for PIP video playback.
+
 Once you've updated your module `build.gradle` file, make sure you have specified `mavenCentral()` and `google()` as a repositories in your project `build.gradle` and then sync your project in File -> Sync Project with Gradle Files.
 
 ## 🎉 Integration

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We publish the SDK to `mavenCentral` as an `AAR` file. Just declare it as depend
 
 ```groovy
     dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:8.0.0"
+         implementation "com.clevertap.android:clevertap-android-sdk:8.1.0"
     }
 ```
 
@@ -34,7 +34,7 @@ Alternatively, you can download and add the AAR file included in this repo in yo
     
  ```groovy
     dependencies {      
-        implementation (name: "clevertap-android-sdk-8.0.0", ext: 'aar')
+        implementation (name: "clevertap-android-sdk-8.1.0", ext: 'aar')
     }
 ```
 
@@ -46,7 +46,7 @@ Add the Firebase Messaging library and Android Support Library v4 as dependencie
 
 ```groovy
      dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:8.0.0"
+         implementation "com.clevertap.android:clevertap-android-sdk:8.1.0"
          implementation "androidx.core:core:1.13.0"
          implementation "com.google.firebase:firebase-messaging:24.0.0"
          implementation "com.google.android.gms:play-services-ads:23.6.0" // Required only if you enable Google ADID collection in the SDK (turned off by default).

--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -3,6 +3,7 @@
 
 #### New Features
 * **InApp Media Support:** Adds GIF and Video support for all InApp notification templates, enabling richer in-app experiences.
+* **App Inbox Default Media View:** Adds a fallback media view for App Inbox when the backend does not provide a media orientation, rendering images, GIFs, video posters, and audio thumbnails at their natural aspect ratio.
 
 #### Improvements
 * **Network Monitoring:** Replaces deprecated network APIs with a modern `NetworkMonitor` for more accurate connectivity detection, including captive portal support.

--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -7,6 +7,7 @@
 #### Improvements
 * **Network Monitoring:** Replaces deprecated network APIs with a modern `NetworkMonitor` for more accurate connectivity detection, including captive portal support.
 * **Minimum SDK Version Updated:** Bumps the minimum supported Android API level from 21 (Android 5.0) to 23 (Android 6.0).
+* **ExoPlayer Deprecated:** Deprecates ExoPlayer (`com.google.android.exoplayer2`) support. Developers using ExoPlayer for video playback should migrate to Media3 (`androidx.media3`) before v9.0.0, when ExoPlayer support will be removed. IDE tooling provides automatic migration suggestions.
 
 #### Bug Fixes
 * Fixes an `IndexOutOfBoundsException` in file cleanup by using a thread-safe collection.

--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -4,6 +4,7 @@
 #### New Features
 * **InApp Media Support:** Adds GIF and Video support for all InApp notification templates, enabling richer in-app experiences.
 * **App Inbox Default Media View:** Adds a fallback media view for App Inbox when the backend does not provide a media orientation, rendering images, GIFs, video posters, and audio thumbnails at their natural aspect ratio.
+* **Picture-in-Picture (PIP) In-App Notifications:** Adds support for Picture-in-Picture in-app notifications — compact, draggable floating windows that overlay app content. Supports image, GIF, and video media with expand/collapse, drag-to-reposition (9-point snap grid), and configurable controls. Video playback requires AndroidX Media3 dependencies.
 
 #### Improvements
 * **Network Monitoring:** Replaces deprecated network APIs with a modern `NetworkMonitor` for more accurate connectivity detection, including captive portal support.

--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -1,4 +1,16 @@
 ## CleverTap Android SDK CHANGE LOG
+### Version 8.1.0 (April 6, 2026)
+
+#### New Features
+* **InApp Media Support:** Adds GIF and Video support for all InApp notification templates, enabling richer in-app experiences.
+
+#### Improvements
+* **Network Monitoring:** Replaces deprecated network APIs with a modern `NetworkMonitor` for more accurate connectivity detection, including captive portal support.
+* **Minimum SDK Version Updated:** Bumps the minimum supported Android API level from 21 (Android 5.0) to 23 (Android 6.0).
+
+#### Bug Fixes
+* Fixes an `IndexOutOfBoundsException` in file cleanup by using a thread-safe collection.
+
 ### Version 8.0.0 (February 20, 2026)
 #### New Features
 * **Android 16 Support:** Adds support for Android 16, making the SDK compliant with Android 16 requirements. Details [here](https://developer.android.com/about/versions/16/summary)

--- a/docs/CTGEOFENCE.md
+++ b/docs/CTGEOFENCE.md
@@ -17,7 +17,7 @@ Add the following dependencies to the `build.gradle`
 
 ```Groovy
 implementation "com.clevertap.android:clevertap-geofence-sdk:1.4.0"
-implementation "com.clevertap.android:clevertap-android-sdk:8.0.0" // 3.9.0 and above
+implementation "com.clevertap.android:clevertap-android-sdk:8.1.0" // 3.9.0 and above
 implementation "com.google.android.gms:play-services-location:21.3.0"
 implementation "androidx.work:work-runtime:2.10.2" // required for FETCH_LAST_LOCATION_PERIODIC
 implementation "androidx.concurrent:concurrent-futures:1.2.0" // required for FETCH_LAST_LOCATION_PERIODIC

--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -20,8 +20,8 @@ CleverTap Push Templates SDK helps you engage with your users using fancy push n
 1. Add the dependencies to the `build.gradle`
 
 ```groovy
-implementation "com.clevertap.android:push-templates:2.3.0"
-implementation "com.clevertap.android:clevertap-android-sdk:8.0.0" // 4.4.0 and above
+implementation "com.clevertap.android:push-templates:2.4.0"
+implementation "com.clevertap.android:clevertap-android-sdk:8.1.0" // 4.4.0 and above
 ```
 
 2. Add the following line to your Application class before the `onCreate()`

--- a/docs/CTPUSHTEMPLATESCHANGELOG.md
+++ b/docs/CTPUSHTEMPLATESCHANGELOG.md
@@ -5,9 +5,6 @@
 * **Vertical Image Template:** Adds a new `pt_vertical_image` push notification template with support for multiple images, action buttons, gradient backgrounds, and rounded corners.
 * **Timer Template Enhancements:** Adds configurable border radius (`pt_chrono_border_radius`), border width (`pt_chrono_border_width`), border color (`pt_chrono_border_clr`), and gradient background support (`pt_chrono_style`, `pt_chrono_grad_clr1`, `pt_chrono_grad_clr2`, `pt_chrono_grad_dir`) for the chronometer display.
 
-#### Bug Fixes
-* Fixes button click tracking for the `Vertical Image` template.
-
 ### Version 2.3.0 (March 6, 2026)
 
 #### New features

--- a/docs/CTPUSHTEMPLATESCHANGELOG.md
+++ b/docs/CTPUSHTEMPLATESCHANGELOG.md
@@ -2,7 +2,7 @@
 ### Version 2.4.0 (April 6, 2026)
 
 #### New Features
-* **Vertical Image Template:** Adds a new `pt_vertical_image` push notification template with support for multiple images, action buttons, gradient backgrounds, and rounded corners.
+* **Image with CTA:** Adds a new `pt_vertical_image` push notification template with support for multiple images, action buttons, gradient backgrounds, and rounded corners.
 * **Timer Template Enhancements:** Adds configurable border radius (`pt_chrono_border_radius`), border width (`pt_chrono_border_width`), border color (`pt_chrono_border_clr`), and gradient background support (`pt_chrono_style`, `pt_chrono_grad_clr1`, `pt_chrono_grad_clr2`, `pt_chrono_grad_dir`) for the chronometer display.
 
 ### Version 2.3.0 (March 6, 2026)

--- a/docs/CTPUSHTEMPLATESCHANGELOG.md
+++ b/docs/CTPUSHTEMPLATESCHANGELOG.md
@@ -1,4 +1,13 @@
 ## CleverTap Push Templates SDK CHANGE LOG
+### Version 2.4.0 (April 6, 2026)
+
+#### New Features
+* **Vertical Image Template:** Adds a new `pt_vertical_image` push notification template with support for multiple images, action buttons, gradient backgrounds, and rounded corners.
+* **Timer Template Enhancements:** Adds configurable border radius (`pt_chrono_border_radius`), border width (`pt_chrono_border_width`), border color (`pt_chrono_border_clr`), and gradient background support (`pt_chrono_style`, `pt_chrono_grad_clr1`, `pt_chrono_grad_clr2`, `pt_chrono_grad_dir`) for the chronometer display.
+
+#### Bug Fixes
+* Fixes button click tracking for the `Vertical Image` template.
+
 ### Version 2.3.0 (March 6, 2026)
 
 #### New features

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,11 +49,11 @@ lifecycleRuntimeTesting = "2.9.4"
 installreferrer = "2.2"
 
 #SDK Versions
-clevertap_android_sdk = "8.0.0"
+clevertap_android_sdk = "8.1.0"
 clevertap_rendermax_sdk = "1.0.3"
 clevertap_geofence_sdk = "1.4.0"
 clevertap_hms_sdk = "1.5.1"
-clevertap_push_templates_sdk = "2.3.0"
+clevertap_push_templates_sdk = "2.4.0"
 
 # Glide
 glide = "4.12.0"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,8 +22,8 @@ android {
         applicationId "com.clevertap.demo"
         minSdkVersion 23
         targetSdkVersion 36
-        versionCode 8000000
-        versionName "8.0.0"
+        versionCode 8010000
+        versionName "8.1.0"
         multiDexEnabled true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -179,14 +179,14 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
     implementation "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.1.1"*/
 
-    remoteImplementation("com.clevertap.android:clevertap-android-sdk:8.0.0")
+    remoteImplementation("com.clevertap.android:clevertap-android-sdk:8.1.0")
     remoteImplementation("com.clevertap.android:clevertap-geofence-sdk:1.4.0")
-    remoteImplementation("com.clevertap.android:push-templates:2.3.0")
+    remoteImplementation("com.clevertap.android:push-templates:2.4.0")
     remoteImplementation("com.clevertap.android:clevertap-hms-sdk:1.5.1")
 
-    stagingImplementation("com.clevertap.android:clevertap-android-sdk:8.0.0")
+    stagingImplementation("com.clevertap.android:clevertap-android-sdk:8.1.0")
     stagingImplementation("com.clevertap.android:clevertap-geofence-sdk:1.4.0")
-    stagingImplementation("com.clevertap.android:push-templates:2.3.0")
+    stagingImplementation("com.clevertap.android:push-templates:2.4.0")
     stagingImplementation("com.clevertap.android:clevertap-hms-sdk:1.5.1")
 }
 

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -3,6 +3,7 @@
 
 #### New Features
 * **InApp Media Support:** Adds GIF and Video support for all InApp notification templates, enabling richer in-app experiences.
+* **App Inbox Default Media View:** Adds a fallback media view for App Inbox when the backend does not provide a media orientation, rendering images, GIFs, video posters, and audio thumbnails at their natural aspect ratio.
 
 #### Improvements
 * **Network Monitoring:** Replaces deprecated network APIs with a modern `NetworkMonitor` for more accurate connectivity detection, including captive portal support.

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -7,6 +7,7 @@
 #### Improvements
 * **Network Monitoring:** Replaces deprecated network APIs with a modern `NetworkMonitor` for more accurate connectivity detection, including captive portal support.
 * **Minimum SDK Version Updated:** Bumps the minimum supported Android API level from 21 (Android 5.0) to 23 (Android 6.0).
+* **ExoPlayer Deprecated:** Deprecates ExoPlayer (`com.google.android.exoplayer2`) support. Developers using ExoPlayer for video playback should migrate to Media3 (`androidx.media3`) before v9.0.0, when ExoPlayer support will be removed. IDE tooling provides automatic migration suggestions.
 
 #### Bug Fixes
 * Fixes an `IndexOutOfBoundsException` in file cleanup by using a thread-safe collection.

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -4,6 +4,7 @@
 #### New Features
 * **InApp Media Support:** Adds GIF and Video support for all InApp notification templates, enabling richer in-app experiences.
 * **App Inbox Default Media View:** Adds a fallback media view for App Inbox when the backend does not provide a media orientation, rendering images, GIFs, video posters, and audio thumbnails at their natural aspect ratio.
+* **Picture-in-Picture (PIP) In-App Notifications:** Adds support for Picture-in-Picture in-app notifications — compact, draggable floating windows that overlay app content. Supports image, GIF, and video media with expand/collapse, drag-to-reposition (9-point snap grid), and configurable controls. Video playback requires AndroidX Media3 dependencies.
 
 #### Improvements
 * **Network Monitoring:** Replaces deprecated network APIs with a modern `NetworkMonitor` for more accurate connectivity detection, including captive portal support.

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -1,4 +1,16 @@
 ## CleverTap Android SDK CHANGE LOG
+### Version 8.1.0 (April 6, 2026)
+
+#### New Features
+* **InApp Media Support:** Adds GIF and Video support for all InApp notification templates, enabling richer in-app experiences.
+
+#### Improvements
+* **Network Monitoring:** Replaces deprecated network APIs with a modern `NetworkMonitor` for more accurate connectivity detection, including captive portal support.
+* **Minimum SDK Version Updated:** Bumps the minimum supported Android API level from 21 (Android 5.0) to 23 (Android 6.0).
+
+#### Bug Fixes
+* Fixes an `IndexOutOfBoundsException` in file cleanup by using a thread-safe collection.
+
 ### Version 8.0.0 (February 20, 2026)
 #### New Features
 * **Android 16 Support:** Adds support for Android 16, making the SDK compliant with Android 16 requirements. Details [here](https://developer.android.com/about/versions/16/summary)

--- a/templates/CTPUSHTEMPLATESCHANGELOG.md
+++ b/templates/CTPUSHTEMPLATESCHANGELOG.md
@@ -5,9 +5,6 @@
 * **Vertical Image Template:** Adds a new `pt_vertical_image` push notification template with support for multiple images, action buttons, gradient backgrounds, and rounded corners.
 * **Timer Template Enhancements:** Adds configurable border radius (`pt_chrono_border_radius`), border width (`pt_chrono_border_width`), border color (`pt_chrono_border_clr`), and gradient background support (`pt_chrono_style`, `pt_chrono_grad_clr1`, `pt_chrono_grad_clr2`, `pt_chrono_grad_dir`) for the chronometer display.
 
-#### Bug Fixes
-* Fixes button click tracking for the `Vertical Image` template.
-
 ### Version 2.3.0 (March 6, 2026)
 
 #### New features

--- a/templates/CTPUSHTEMPLATESCHANGELOG.md
+++ b/templates/CTPUSHTEMPLATESCHANGELOG.md
@@ -2,7 +2,7 @@
 ### Version 2.4.0 (April 6, 2026)
 
 #### New Features
-* **Vertical Image Template:** Adds a new `pt_vertical_image` push notification template with support for multiple images, action buttons, gradient backgrounds, and rounded corners.
+* **Image with CTA:** Adds a new `pt_vertical_image` push notification template with support for multiple images, action buttons, gradient backgrounds, and rounded corners.
 * **Timer Template Enhancements:** Adds configurable border radius (`pt_chrono_border_radius`), border width (`pt_chrono_border_width`), border color (`pt_chrono_border_clr`), and gradient background support (`pt_chrono_style`, `pt_chrono_grad_clr1`, `pt_chrono_grad_clr2`, `pt_chrono_grad_dir`) for the chronometer display.
 
 ### Version 2.3.0 (March 6, 2026)

--- a/templates/CTPUSHTEMPLATESCHANGELOG.md
+++ b/templates/CTPUSHTEMPLATESCHANGELOG.md
@@ -1,4 +1,13 @@
 ## CleverTap Push Templates SDK CHANGE LOG
+### Version 2.4.0 (April 6, 2026)
+
+#### New Features
+* **Vertical Image Template:** Adds a new `pt_vertical_image` push notification template with support for multiple images, action buttons, gradient backgrounds, and rounded corners.
+* **Timer Template Enhancements:** Adds configurable border radius (`pt_chrono_border_radius`), border width (`pt_chrono_border_width`), border color (`pt_chrono_border_clr`), and gradient background support (`pt_chrono_style`, `pt_chrono_grad_clr1`, `pt_chrono_grad_clr2`, `pt_chrono_grad_dir`) for the chronometer display.
+
+#### Bug Fixes
+* Fixes button click tracking for the `Vertical Image` template.
+
 ### Version 2.3.0 (March 6, 2026)
 
 #### New features

--- a/templates/README.md
+++ b/templates/README.md
@@ -92,6 +92,14 @@ Interstitial InApp Notification templates support Audio and Video with the help 
     implementation "${ext.exoplayer_ui}"
 ```  
 
+PIP (Picture-in-Picture) In-App Notifications with video media require `AndroidX Media3`. Add the following dependencies in your `build.gradle` file:
+```groovy
+    implementation "androidx.media3:media3-exoplayer:1.4.0"
+    implementation "androidx.media3:media3-exoplayer-hls:1.4.0"
+    implementation "androidx.media3:media3-ui:1.4.0"
+```
+**Note:** PIP image and GIF media types work without Media3. The dependency is only required for PIP video playback.
+
 Once you've updated your module `build.gradle` file, make sure you have specified `mavenCentral()` and `google()` as a repositories in your project `build.gradle` and then sync your project in File -> Sync Project with Gradle Files.
 
 ## 🎉 Integration


### PR DESCRIPTION
  ## Release: CleverTap Android SDK v8.1.0 & Push Templates SDK v2.4.0

  ### Changes     
  - Bumped `clevertap-android-sdk` version: `8.0.0` → `8.1.0`
  - Bumped `clevertap-push-templates-sdk` version: `2.3.0` → `2.4.0`
  - Updated changelogs for Core SDK and Push Templates SDK                                                                                                                           
  - Updated sample app version 