### PR TITLE
task(SDK-5668) - Deprecates Exoplayer support in CleverTap

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/VideoLibChecker.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/VideoLibChecker.kt
@@ -16,6 +16,7 @@ internal object VideoLibChecker {
             VideoLibraryIntegrated.MEDIA3
         }
         hasExoplayer -> {
+            Logger.i("ExoPlayer (com.google.android.exoplayer2) support in CleverTap is deprecated and will be removed in v9.0.0. Please migrate to Media3 (androidx.media3).")
             VideoLibraryIntegrated.EXOPLAYER
         }
         else -> {
@@ -88,5 +89,11 @@ internal object VideoLibChecker {
 }
 
 enum class VideoLibraryIntegrated {
-    EXOPLAYER, MEDIA3, NONE
+    @Deprecated(
+        message = "ExoPlayer (com.google.android.exoplayer2) support in CleverTap is deprecated and will be removed in v9.0.0. Migrate to Media3 (androidx.media3).",
+        replaceWith = ReplaceWith("MEDIA3")
+    )
+    EXOPLAYER,
+    MEDIA3,
+    NONE
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inapps/ExoplayerHandle.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inapps/ExoplayerHandle.kt
@@ -30,7 +30,14 @@ import com.google.android.exoplayer2.util.Util
  * Handle wrapping exoplayer library used to render video and audio for Inapps feature.
  * All the player and surface related functionality to be limited to this class to we can have multiple
  * handles for video/audio support.
+ *
+ * @deprecated ExoPlayer (com.google.android.exoplayer2) support in CleverTap is deprecated and will be removed
+ * in v9.0.0. Migrate to Media3 (androidx.media3) and use [com.clevertap.android.sdk.video.inapps.Media3Handle] instead.
  */
+@Deprecated(
+    message = "ExoPlayer (com.google.android.exoplayer2) support in CleverTap is deprecated and will be removed in v9.0.0. Migrate to Media3 (androidx.media3) and use Media3Handle instead.",
+    replaceWith = ReplaceWith("Media3Handle()", "com.clevertap.android.sdk.video.inapps.Media3Handle")
+)
 class ExoplayerHandle : InAppVideoPlayerHandle {
 
     private var player: ExoPlayer? = null

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/ExoplayerHandle.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/ExoplayerHandle.kt
@@ -26,7 +26,14 @@ import com.google.android.exoplayer2.util.Util
  * Handle wrapping exoplayer library used to render video and audio for Inbox feature.
  * All the player and surface related functionality to be limited to this class to we can have multiple
  * handles for video/audio support.
+ *
+ * @deprecated ExoPlayer (com.google.android.exoplayer2) support in CleverTap is deprecated and will be removed
+ * in v9.0.0. Migrate to Media3 (androidx.media3) and use [com.clevertap.android.sdk.video.inbox.Media3Handle] instead.
  */
+@Deprecated(
+    message = "ExoPlayer (com.google.android.exoplayer2) support in CleverTap is deprecated and will be removed in v9.0.0. Migrate to Media3 (androidx.media3) and use Media3Handle instead.",
+    replaceWith = ReplaceWith("Media3Handle()", "com.clevertap.android.sdk.video.inbox.Media3Handle")
+)
 class ExoplayerHandle : InboxVideoPlayerHandle {
 
     private var videoSurfaceView: StyledPlayerView? = null

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/ExoplayerPlayerListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/ExoplayerPlayerListener.kt
@@ -11,7 +11,14 @@ import com.google.android.exoplayer2.video.VideoSize
 /**
  * This class addresses an AbstractMethodError because of the Java 8 feature of default methods in interfaces.
  * Default methods are somewhat not supported if minSDKVersion < 24
+ *
+ * @deprecated ExoPlayer (com.google.android.exoplayer2) support in CleverTap is deprecated and will be removed
+ * in v9.0.0. Migrate to Media3 (androidx.media3) and use [Media3PlayerListener] instead.
  */
+@Deprecated(
+    message = "ExoPlayer (com.google.android.exoplayer2) support in CleverTap is deprecated and will be removed in v9.0.0. Migrate to Media3 (androidx.media3) and use Media3PlayerListener instead.",
+    replaceWith = ReplaceWith("Media3PlayerListener()")
+)
 open class ExoplayerPlayerListener : Player.Listener {
     override fun onEvents(player: Player, events: Player.Events) {}
     override fun onTimelineChanged(timeline: Timeline, reason: Int) {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deprecated ExoPlayer video player support with migration guidance to Media3. Developers using ExoPlayer for video playback should migrate to Media3 before v9.0.0, when ExoPlayer support will be removed. IDE tooling provides automatic migration suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->