### PR TITLE
  test(SDK-5618): add unit tests for timer template chronometer enhancements

### DIFF
--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
@@ -1888,4 +1888,336 @@ class TemplateDataFactoryTest {
         assertEquals(actions, result)
         assertEquals(1, result?.length())
     }
+
+    @Test
+    fun `createTimerTemplateData should use default border radius of 6f when not provided`() {
+        // Given
+        setupBasicMockBundle()
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(6f, result.chronometerBorderRadius)
+    }
+
+    @Test
+    fun `createTimerTemplateData should parse custom border radius when provided`() {
+        // Given
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_CHRONO_BORDER_RADIUS) } returns "12.5"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(12.5f, result.chronometerBorderRadius)
+    }
+
+    @Test
+    fun `createTimerTemplateData should return null border width when not provided`() {
+        // Given
+        setupBasicMockBundle()
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertNull(result.chronometerBorderWidth)
+    }
+
+    @Test
+    fun `createTimerTemplateData should parse custom border width when provided`() {
+        // Given
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_CHRONO_BORDER_WIDTH) } returns "4.0"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(4.0f, result.chronometerBorderWidth)
+    }
+
+    @Test
+    fun `createTimerTemplateData should use default gradient direction of 90 when not provided`() {
+        // Given
+        setupBasicMockBundle()
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(90.0, result.chronometerGradientDirection, 0.0)
+    }
+
+    @Test
+    fun `createTimerTemplateData should parse custom gradient direction when provided`() {
+        // Given
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_CHRONO_GRAD_DIR) } returns "45.0"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(45.0, result.chronometerGradientDirection, 0.0)
+    }
+
+    @Test
+    fun `createTimerTemplateData should default chronometerStyle to SOLID when not provided`() {
+        // Given
+        setupBasicMockBundle()
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(ButtonStyle.SOLID, result.chronometerStyle)
+    }
+
+    @Test
+    fun `createTimerTemplateData should parse chronometerStyle as SOLID`() {
+        // Given
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_CHRONO_STYLE) } returns "solid"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(ButtonStyle.SOLID, result.chronometerStyle)
+    }
+
+    @Test
+    fun `createTimerTemplateData should parse chronometerStyle as GRADIENT_LINEAR`() {
+        // Given
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_CHRONO_STYLE) } returns "gradient_linear"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(ButtonStyle.GRADIENT_LINEAR, result.chronometerStyle)
+    }
+
+    @Test
+    fun `createTimerTemplateData should parse chronometerStyle as GRADIENT_RADIAL`() {
+        // Given
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_CHRONO_STYLE) } returns "gradient_radial"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(ButtonStyle.GRADIENT_RADIAL, result.chronometerStyle)
+    }
+
+    @Test
+    fun `createTimerTemplateData should parse chronometerBorderColor from colorMap`() {
+        // Given
+        setupBasicMockBundle()
+        val borderColor = "#FF0000"
+        every { Utils.createColorMap(any(), any()) } returns mapOf(
+            PT_CHRONO_BORDER_CLR to borderColor
+        )
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(borderColor, result.chronometerBorderColor)
+    }
+
+    @Test
+    fun `createTimerTemplateData should parse gradient colors from colorMap`() {
+        // Given
+        setupBasicMockBundle()
+        val gradColor1 = "#FF0000"
+        val gradColor2 = "#0000FF"
+        every { Utils.createColorMap(any(), any()) } returns mapOf(
+            PT_CHRONO_GRAD_CLR1 to gradColor1,
+            PT_CHRONO_GRAD_CLR2 to gradColor2
+        )
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(gradColor1, result.chronometerGradientColor1)
+        assertEquals(gradColor2, result.chronometerGradientColor2)
+    }
+
+    @Test
+    fun `createTimerTemplateData should use default border radius when invalid string is provided`() {
+        // Given
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_CHRONO_BORDER_RADIUS) } returns "abc"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(6f, result.chronometerBorderRadius)
+    }
+
+    @Test
+    fun `createTimerTemplateData should use default gradient direction when invalid string is provided`() {
+        // Given
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_CHRONO_GRAD_DIR) } returns "abc"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(90.0, result.chronometerGradientDirection, 0.0)
+    }
+
+
+    @Test
+    fun `createTimerTemplateData should return null border width when invalid string is provided`() {
+        // Given
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_CHRONO_BORDER_WIDTH) } returns "abc"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertNull(result.chronometerBorderWidth)
+    }
+
+    @Test
+    fun `createTimerTemplateData should default chronometerStyle to SOLID when unknown string is provided`() {
+        // Given
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_CHRONO_STYLE) } returns "unknown_style"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(ButtonStyle.SOLID, result.chronometerStyle)
+    }
+
+    @Test
+    fun `createTimerTemplateData should parse chronometerBgColor from colorMap`() {
+        // Given
+        setupBasicMockBundle()
+        val bgColor = "#FFFF00"
+        every { Utils.createColorMap(any(), any()) } returns mapOf(
+            PT_CHRONO_BG_CLR to bgColor
+        )
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.TIMER,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as TimerTemplateData
+
+        // Then
+        assertEquals(bgColor, result.chronometerBgColor)
+    }
 }

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtilsTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtilsTest.kt
@@ -1,7 +1,9 @@
 package com.clevertap.android.pushtemplates.content
 
+import android.graphics.Bitmap
 import android.graphics.Color
 import android.os.Build
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -21,6 +23,14 @@ class NotificationBitmapUtilsTest {
     private val color2 = Color.BLUE
     private val borderColor = Color.BLACK
 
+    private val bitmapsToRecycle = mutableListOf<Bitmap>()
+
+    @After
+    fun tearDown() {
+        bitmapsToRecycle.forEach { it.recycle() }
+        bitmapsToRecycle.clear()
+    }
+
     // createSolidBitmap tests
 
     @Test
@@ -35,7 +45,7 @@ class NotificationBitmapUtilsTest {
             width = width,
             height = height,
             cornerRadius = cornerRadius
-        )
+        ).also { bitmapsToRecycle.add(it) }
 
         // Then
         assertNotNull(bitmap)
@@ -55,7 +65,7 @@ class NotificationBitmapUtilsTest {
             width = width,
             height = height,
             cornerRadius = cornerRadius
-        )
+        ).also { bitmapsToRecycle.add(it) }
 
         // Then
         assertNotNull(bitmap)
@@ -76,7 +86,7 @@ class NotificationBitmapUtilsTest {
             height = height,
             cornerRadius = cornerRadius,
             borderWidth = null
-        )
+        ).also { bitmapsToRecycle.add(it) }
 
         // Then
         assertNotNull(bitmap)
@@ -97,7 +107,7 @@ class NotificationBitmapUtilsTest {
             height = height,
             cornerRadius = cornerRadius,
             borderWidth = 4f
-        )
+        ).also { bitmapsToRecycle.add(it) }
 
         // Then
         assertNotNull(bitmap)
@@ -120,7 +130,7 @@ class NotificationBitmapUtilsTest {
             width = width,
             height = height,
             cornerRadius = cornerRadius
-        )
+        ).also { bitmapsToRecycle.add(it) }
 
         // Then
         assertNotNull(bitmap)
@@ -142,7 +152,7 @@ class NotificationBitmapUtilsTest {
             height = height,
             cornerRadius = cornerRadius,
             borderColor = borderColor
-        )
+        ).also { bitmapsToRecycle.add(it) }
 
         // Then
         assertNotNull(bitmap)
@@ -163,7 +173,7 @@ class NotificationBitmapUtilsTest {
             width = width,
             height = height,
             cornerRadius = cornerRadius
-        )
+        ).also { bitmapsToRecycle.add(it) }
 
         // Then
         assertNotNull(bitmap)
@@ -186,7 +196,7 @@ class NotificationBitmapUtilsTest {
             cornerRadius = cornerRadius,
             borderColor = borderColor,
             borderWidth = 4f
-        )
+        ).also { bitmapsToRecycle.add(it) }
 
         // Then
         assertNotNull(bitmap)
@@ -208,7 +218,7 @@ class NotificationBitmapUtilsTest {
             width = width,
             height = height,
             cornerRadius = cornerRadius
-        )
+        ).also { bitmapsToRecycle.add(it) }
 
         // Then
         assertNotNull(bitmap)
@@ -229,7 +239,7 @@ class NotificationBitmapUtilsTest {
             height = height,
             cornerRadius = cornerRadius,
             borderColor = borderColor
-        )
+        ).also { bitmapsToRecycle.add(it) }
 
         // Then
         assertNotNull(bitmap)
@@ -251,7 +261,7 @@ class NotificationBitmapUtilsTest {
             cornerRadius = cornerRadius,
             borderColor = borderColor,
             borderWidth = 4f
-        )
+        ).also { bitmapsToRecycle.add(it) }
 
         // Then
         assertNotNull(bitmap)

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtilsTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtilsTest.kt
@@ -1,0 +1,261 @@
+package com.clevertap.android.pushtemplates.content
+
+import android.graphics.Color
+import android.os.Build
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.M])
+class NotificationBitmapUtilsTest {
+
+    private val width = 100
+    private val height = 50
+    private val cornerRadius = 8f
+    private val bgColor = Color.RED
+    private val color1 = Color.RED
+    private val color2 = Color.BLUE
+    private val borderColor = Color.BLACK
+
+    // createSolidBitmap tests
+
+    @Test
+    fun `createSolidBitmap should return non-null bitmap without border`() {
+        // Given
+        // borderColor = null, borderWidth = null
+
+        // When
+        val bitmap = NotificationBitmapUtils.createSolidBitmap(
+            bgColor = bgColor,
+            borderColor = null,
+            width = width,
+            height = height,
+            cornerRadius = cornerRadius
+        )
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+    }
+
+    @Test
+    fun `createSolidBitmap should return non-null bitmap with border`() {
+        // Given
+        // borderColor provided
+
+        // When
+        val bitmap = NotificationBitmapUtils.createSolidBitmap(
+            bgColor = bgColor,
+            borderColor = borderColor,
+            width = width,
+            height = height,
+            cornerRadius = cornerRadius
+        )
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+    }
+
+    @Test
+    fun `createSolidBitmap should return non-null bitmap with border and null borderWidth`() {
+        // Given
+        // borderColor provided, borderWidth = null → BORDER_STROKE_RATIO used internally
+
+        // When
+        val bitmap = NotificationBitmapUtils.createSolidBitmap(
+            bgColor = bgColor,
+            borderColor = borderColor,
+            width = width,
+            height = height,
+            cornerRadius = cornerRadius,
+            borderWidth = null
+        )
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+    }
+
+    @Test
+    fun `createSolidBitmap should return non-null bitmap with explicit borderWidth`() {
+        // Given
+        // borderColor and explicit borderWidth provided
+
+        // When
+        val bitmap = NotificationBitmapUtils.createSolidBitmap(
+            bgColor = bgColor,
+            borderColor = borderColor,
+            width = width,
+            height = height,
+            cornerRadius = cornerRadius,
+            borderWidth = 4f
+        )
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+    }
+
+    // createLinearGradientBitmap tests
+
+    @Test
+    fun `createLinearGradientBitmap should return non-null bitmap without border`() {
+        // Given
+        // direction = 90.0, no border
+
+        // When
+        val bitmap = NotificationBitmapUtils.createLinearGradientBitmap(
+            color1 = color1,
+            color2 = color2,
+            direction = 90.0,
+            width = width,
+            height = height,
+            cornerRadius = cornerRadius
+        )
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+    }
+
+    @Test
+    fun `createLinearGradientBitmap should return non-null bitmap with border`() {
+        // Given
+        // direction = 90.0, borderColor provided
+
+        // When
+        val bitmap = NotificationBitmapUtils.createLinearGradientBitmap(
+            color1 = color1,
+            color2 = color2,
+            direction = 90.0,
+            width = width,
+            height = height,
+            cornerRadius = cornerRadius,
+            borderColor = borderColor
+        )
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+    }
+
+    @Test
+    fun `createLinearGradientBitmap should return non-null bitmap with custom direction angle`() {
+        // Given
+        // direction = 45.0 (diagonal gradient)
+
+        // When
+        val bitmap = NotificationBitmapUtils.createLinearGradientBitmap(
+            color1 = color1,
+            color2 = color2,
+            direction = 45.0,
+            width = width,
+            height = height,
+            cornerRadius = cornerRadius
+        )
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+    }
+
+    @Test
+    fun `createLinearGradientBitmap should return non-null bitmap with border and explicit borderWidth`() {
+        // Given
+        // borderColor and explicit borderWidth provided
+
+        // When
+        val bitmap = NotificationBitmapUtils.createLinearGradientBitmap(
+            color1 = color1,
+            color2 = color2,
+            direction = 90.0,
+            width = width,
+            height = height,
+            cornerRadius = cornerRadius,
+            borderColor = borderColor,
+            borderWidth = 4f
+        )
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+    }
+
+    // createRadialBitmap tests
+
+    @Test
+    fun `createRadialBitmap should return non-null bitmap without border`() {
+        // Given
+        // no border
+
+        // When
+        val bitmap = NotificationBitmapUtils.createRadialBitmap(
+            color1 = color1,
+            color2 = color2,
+            width = width,
+            height = height,
+            cornerRadius = cornerRadius
+        )
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+    }
+
+    @Test
+    fun `createRadialBitmap should return non-null bitmap with border`() {
+        // Given
+        // borderColor provided
+
+        // When
+        val bitmap = NotificationBitmapUtils.createRadialBitmap(
+            color1 = color1,
+            color2 = color2,
+            width = width,
+            height = height,
+            cornerRadius = cornerRadius,
+            borderColor = borderColor
+        )
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+    }
+
+    @Test
+    fun `createRadialBitmap should return non-null bitmap with border and explicit borderWidth`() {
+        // Given
+        // borderColor and explicit borderWidth provided
+
+        // When
+        val bitmap = NotificationBitmapUtils.createRadialBitmap(
+            color1 = color1,
+            color2 = color2,
+            width = width,
+            height = height,
+            cornerRadius = cornerRadius,
+            borderColor = borderColor,
+            borderWidth = 4f
+        )
+
+        // Then
+        assertNotNull(bitmap)
+        assertEquals(width, bitmap.width)
+        assertEquals(height, bitmap.height)
+    }
+}


### PR DESCRIPTION
 ## Summary
  Adds unit test coverage for the Timer Template chronometer enhancements introduced in SDK-5618.

  **TemplateDataFactoryTest.kt**
  - Chronometer border radius — default `6f`, custom value, invalid string fallback
  - Chronometer border width — null, custom value, invalid string fallback
  - Chronometer gradient direction — default `90.0`, custom value, invalid string fallback
  - Chronometer style (ButtonStyle) — SOLID, GRADIENT_LINEAR, GRADIENT_RADIAL, null default, unknown string default
  - Chronometer colors — borderColor, bgColor, gradientColor1, gradientColor2 from colorMap
  - renderTerminal — true, false

  **NotificationBitmapUtilsTest.kt** 
  - createSolidBitmap — with/without border, null borderWidth, explicit borderWidth
  - createLinearGradientBitmap — with/without border, custom direction angle, explicit borderWidth
  - createRadialBitmap — with/without border, explicit borderWidth