### PR TITLE
SDK-5763: [Android Core SDK] Add DisplayUnitCache interface + setter on CleverTapAPI

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
@@ -229,6 +229,117 @@ public class AnalyticsManager extends BaseAnalyticsManager {
         }
     }
 
+    /**
+     * Raises a Native Display element click event.
+     *
+     * Element-level analog of {@link #pushDisplayUnitClickedEventForID(String)} — for
+     * Native Display units that host multiple interactive child elements (buttons,
+     * images, etc.), this method records which child element was clicked alongside
+     * the existing wzrk_* campaign attribution.
+     *
+     * The resulting event:
+     * <ul>
+     *   <li>Carries the campaign's {@code wzrk_*} fields from the cached unit JSON
+     *       (same enrichment as {@link #pushDisplayUnitClickedEventForID(String)}).</li>
+     *   <li>Adds {@code wzrk_element_id = elementID} to {@code evtData}.</li>
+     *   <li>Merges {@code additionalProperties} into {@code evtData} after wzrk_*
+     *       enrichment. Keys starting with {@code wzrk_} are filtered out — the
+     *       prefix is reserved for server-controlled attribution fields.</li>
+     * </ul>
+     */
+    @Override
+    public void pushDisplayUnitElementClickedEventForID(
+            String unitID, String elementID,
+            HashMap<String, Object> additionalProperties) {
+        JSONObject event = new JSONObject();
+        try {
+            event.put("evtName", Constants.NOTIFICATION_CLICKED_EVENT_NAME);
+
+            if (controllerManager.getDisplayUnitCache() == null) {
+                return;
+            }
+            CleverTapDisplayUnit displayUnit = controllerManager.getDisplayUnitCache()
+                    .getDisplayUnitForID(unitID);
+            if (displayUnit == null) {
+                return;
+            }
+            JSONObject eventExtraData = displayUnit.getWZRKFields();
+            if (eventExtraData == null) {
+                eventExtraData = new JSONObject();
+            }
+            if (elementID != null && !elementID.isEmpty()) {
+                eventExtraData.put("wzrk_element_id", elementID);
+            }
+            mergeAdditionalProperties(eventExtraData, additionalProperties);
+
+            event.put("evtData", eventExtraData);
+            try {
+                coreMetaData.setWzrkParams(filterWzrkFields(eventExtraData));
+            } catch (Throwable t) {
+                // no-op
+            }
+            baseEventQueueManager.queueEvent(context, event, Constants.RAISED_EVENT,
+                    getFlattenedEventProperties(eventExtraData));
+        } catch (Throwable t) {
+            config.getLogger().verbose(config.getAccountId(),
+                    Constants.FEATURE_DISPLAY_UNIT
+                            + "Failed to push Display Unit element clicked event" + t);
+        }
+    }
+
+    /**
+     * Merge caller-supplied {@code additionalProperties} into the click event's
+     * {@code evtData}, stripping any {@code wzrk_*} keys. That prefix is reserved
+     * for server-controlled attribution; we keep the namespace one-way (server →
+     * client) so client extras can never overwrite legit campaign attribution.
+     */
+    private void mergeAdditionalProperties(JSONObject eventData,
+            HashMap<String, Object> extras) {
+        if (extras == null || extras.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<String, Object> entry : extras.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (key == null || key.isEmpty() || value == null) {
+                continue;
+            }
+            if (key.startsWith(Constants.WZRK_PREFIX)) {
+                config.getLogger().verbose(config.getAccountId(),
+                        Constants.FEATURE_DISPLAY_UNIT
+                                + "Dropping reserved wzrk_* key from additionalProperties: "
+                                + key);
+                continue;
+            }
+            try {
+                eventData.put(key, value);
+            } catch (JSONException ignored) {
+                // skip unserialisable entries
+            }
+        }
+    }
+
+    /**
+     * Project only the {@code wzrk_*} keys back out of the merged event data so
+     * {@link CoreMetaData#setWzrkParams(JSONObject)} retains its existing
+     * server-namespace contract (it feeds {@code wzrk_ref} batch headers; caller-
+     * supplied non-wzrk extras must not ride along on unrelated subsequent events).
+     */
+    private JSONObject filterWzrkFields(JSONObject merged) {
+        JSONObject out = new JSONObject();
+        Iterator<String> it = merged.keys();
+        while (it.hasNext()) {
+            String k = it.next();
+            if (k.startsWith(Constants.WZRK_PREFIX)) {
+                try {
+                    out.put(k, merged.get(k));
+                } catch (JSONException ignored) {
+                }
+            }
+        }
+        return out;
+    }
+
     @Override
     public void pushDisplayUnitViewedEventForID(String unitID) {
         JSONObject event = new JSONObject();

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
@@ -205,8 +205,8 @@ public class AnalyticsManager extends BaseAnalyticsManager {
             event.put("evtName", Constants.NOTIFICATION_CLICKED_EVENT_NAME);
 
             //wzrk fields
-            if (controllerManager.getCTDisplayUnitController() != null) {
-                CleverTapDisplayUnit displayUnit = controllerManager.getCTDisplayUnitController()
+            if (controllerManager.getDisplayUnitCache() != null) {
+                CleverTapDisplayUnit displayUnit = controllerManager.getDisplayUnitCache()
                         .getDisplayUnitForID(unitID);
                 if (displayUnit != null) {
                     JSONObject eventExtraData = displayUnit.getWZRKFields();
@@ -237,8 +237,8 @@ public class AnalyticsManager extends BaseAnalyticsManager {
             event.put("evtName", Constants.NOTIFICATION_VIEWED_EVENT_NAME);
 
             //wzrk fields
-            if (controllerManager.getCTDisplayUnitController() != null) {
-                CleverTapDisplayUnit displayUnit = controllerManager.getCTDisplayUnitController()
+            if (controllerManager.getDisplayUnitCache() != null) {
+                CleverTapDisplayUnit displayUnit = controllerManager.getDisplayUnitCache()
                         .getDisplayUnitForID(unitID);
                 if (displayUnit != null) {
                     JSONObject eventExtras = displayUnit.getWZRKFields();

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/BaseAnalyticsManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/BaseAnalyticsManager.java
@@ -3,6 +3,7 @@ package com.clevertap.android.sdk;
 import android.os.Bundle;
 import com.clevertap.android.sdk.inapp.CTInAppNotification;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONObject;
 
@@ -24,6 +25,9 @@ public abstract class BaseAnalyticsManager {
     public abstract void pushDefineVarsEvent(JSONObject data);
 
     public abstract void pushDisplayUnitClickedEventForID(String unitID);
+
+    public abstract void pushDisplayUnitElementClickedEventForID(
+            String unitID, String elementID, HashMap<String, Object> additionalProperties);
 
     public abstract void pushDisplayUnitViewedEventForID(String unitID);
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -30,6 +30,7 @@ import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
 import androidx.annotation.WorkerThread;
 import com.clevertap.android.sdk.cryption.ICryptHandler;
+import com.clevertap.android.sdk.displayunits.DisplayUnitCache;
 import com.clevertap.android.sdk.displayunits.DisplayUnitListener;
 import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
 import com.clevertap.android.sdk.events.EventDetail;
@@ -1472,8 +1473,7 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      */
     @Nullable
     public ArrayList<CleverTapDisplayUnit> getAllDisplayUnits() {
-        com.clevertap.android.sdk.displayunits.DisplayUnitCache cache =
-                coreState.getControllerManager().getDisplayUnitCache();
+        DisplayUnitCache cache = coreState.getControllerManager().getDisplayUnitCache();
         if (cache != null) {
             return cache.getAllDisplayUnits();
         }
@@ -1792,8 +1792,7 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      */
     @Nullable
     public CleverTapDisplayUnit getDisplayUnitForId(String unitID) {
-        com.clevertap.android.sdk.displayunits.DisplayUnitCache cache =
-                coreState.getControllerManager().getDisplayUnitCache();
+        DisplayUnitCache cache = coreState.getControllerManager().getDisplayUnitCache();
         if (cache != null) {
             return cache.getDisplayUnitForID(unitID);
         }
@@ -2515,8 +2514,7 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      *
      * @since 7.x.0
      */
-    public void setDisplayUnitCache(@Nullable
-            com.clevertap.android.sdk.displayunits.DisplayUnitCache cache) {
+    public void setDisplayUnitCache(@Nullable DisplayUnitCache cache) {
         coreState.getControllerManager().setDisplayUnitCache(cache);
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -1473,8 +1473,8 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     @Nullable
     public ArrayList<CleverTapDisplayUnit> getAllDisplayUnits() {
 
-        if (coreState.getControllerManager().getCTDisplayUnitController() != null) {
-            return coreState.getControllerManager().getCTDisplayUnitController().getAllDisplayUnits();
+        if (coreState.getControllerManager().getDisplayUnitCache() != null) {
+            return coreState.getControllerManager().getDisplayUnitCache().getAllDisplayUnits();
         } else {
             getConfigLogger()
                     .verbose(getAccountId(), Constants.FEATURE_DISPLAY_UNIT + "Failed to get all Display Units");
@@ -1792,8 +1792,8 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      */
     @Nullable
     public CleverTapDisplayUnit getDisplayUnitForId(String unitID) {
-        if (coreState.getControllerManager().getCTDisplayUnitController() != null) {
-            return coreState.getControllerManager().getCTDisplayUnitController().getDisplayUnitForID(unitID);
+        if (coreState.getControllerManager().getDisplayUnitCache() != null) {
+            return coreState.getControllerManager().getDisplayUnitCache().getDisplayUnitForID(unitID);
         } else {
             getConfigLogger().verbose(getAccountId(),
                     Constants.FEATURE_DISPLAY_UNIT + "Failed to get Display Unit for id: " + unitID);
@@ -2493,6 +2493,30 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     @SuppressWarnings({"unused", "WeakerAccess"})
     public void pushDeepLink(Uri uri) {
         coreState.getAnalyticsManager().pushDeepLink(uri, false);
+    }
+
+    /**
+     * Replaces the SDK's display-unit cache with the supplied implementation.
+     * Pass {@code null} to clear the reference (subsequent server responses
+     * will lazily install a fresh default {@link
+     * com.clevertap.android.sdk.displayunits.CTDisplayUnitController}).
+     *
+     * <p>The new instance receives subsequent {@code updateDisplayUnits}
+     * calls (e.g. from server responses) and serves all lookup sites:
+     * {@link #getDisplayUnitForId(String)}, {@link #getAllDisplayUnits()},
+     * {@link #pushDisplayUnitViewedEventForID(String)}, and
+     * {@link #pushDisplayUnitClickedEventForID(String)}.
+     *
+     * <p>Implementations must be thread-safe. The display-unit listener
+     * registered via {@link #setDisplayUnitListener} fires only for
+     * server-pipeline activity — replacing the cache or mutating its
+     * contents from outside the SDK does not synthesise a listener fire.
+     *
+     * @since 7.x.0
+     */
+    public void setDisplayUnitCache(@Nullable
+            com.clevertap.android.sdk.displayunits.DisplayUnitCache cache) {
+        coreState.getControllerManager().setDisplayUnitCache(cache);
     }
 
     /**

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -1472,14 +1472,14 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      */
     @Nullable
     public ArrayList<CleverTapDisplayUnit> getAllDisplayUnits() {
-
-        if (coreState.getControllerManager().getDisplayUnitCache() != null) {
-            return coreState.getControllerManager().getDisplayUnitCache().getAllDisplayUnits();
-        } else {
-            getConfigLogger()
-                    .verbose(getAccountId(), Constants.FEATURE_DISPLAY_UNIT + "Failed to get all Display Units");
-            return null;
+        com.clevertap.android.sdk.displayunits.DisplayUnitCache cache =
+                coreState.getControllerManager().getDisplayUnitCache();
+        if (cache != null) {
+            return cache.getAllDisplayUnits();
         }
+        getConfigLogger()
+                .verbose(getAccountId(), Constants.FEATURE_DISPLAY_UNIT + "Failed to get all Display Units");
+        return null;
     }
 
     /**
@@ -1792,13 +1792,14 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      */
     @Nullable
     public CleverTapDisplayUnit getDisplayUnitForId(String unitID) {
-        if (coreState.getControllerManager().getDisplayUnitCache() != null) {
-            return coreState.getControllerManager().getDisplayUnitCache().getDisplayUnitForID(unitID);
-        } else {
-            getConfigLogger().verbose(getAccountId(),
-                    Constants.FEATURE_DISPLAY_UNIT + "Failed to get Display Unit for id: " + unitID);
-            return null;
+        com.clevertap.android.sdk.displayunits.DisplayUnitCache cache =
+                coreState.getControllerManager().getDisplayUnitCache();
+        if (cache != null) {
+            return cache.getDisplayUnitForID(unitID);
         }
+        getConfigLogger().verbose(getAccountId(),
+                Constants.FEATURE_DISPLAY_UNIT + "Failed to get Display Unit for id: " + unitID);
+        return null;
     }
 
     /**

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -2530,6 +2530,38 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
     }
 
     /**
+     * Raises a Native Display element click event for the given unit + element.
+     *
+     * Element-level analog of {@link #pushDisplayUnitClickedEventForID(String)} — for
+     * Native Display units that host multiple interactive child elements (buttons,
+     * images, etc.), this method records which child element was clicked alongside
+     * the existing wzrk_* campaign attribution.
+     *
+     * <p>The resulting "Notification Clicked" event:
+     * <ul>
+     *   <li>Carries the campaign's {@code wzrk_*} fields from the cached unit JSON
+     *       (same enrichment as the unit-level method).</li>
+     *   <li>Adds {@code wzrk_element_id = elementID} to the event's {@code evtData}.</li>
+     *   <li>Merges {@code additionalProperties} into {@code evtData} after wzrk_*
+     *       enrichment. Keys starting with {@code wzrk_} are filtered out — that
+     *       prefix is reserved for server-controlled attribution fields.</li>
+     * </ul>
+     *
+     * @param unitID               the unitID of the Display Unit
+     *                             ({@link CleverTapDisplayUnit#getUnitID()})
+     * @param elementID            identifier of the clicked child element (from the
+     *                             Native Display config; typically a button node id)
+     * @param additionalProperties optional per-click context (action url, custom KVs, …)
+     */
+    @SuppressWarnings("unused")
+    public void pushDisplayUnitElementClickedEventForID(
+            String unitID, String elementID,
+            HashMap<String, Object> additionalProperties) {
+        coreState.getAnalyticsManager().pushDisplayUnitElementClickedEventForID(
+                unitID, elementID, additionalProperties);
+    }
+
+    /**
      * Raises the Display Unit Viewed event
      *
      * @param unitID - unitID of the Display Unit{@link CleverTapDisplayUnit#getUnitID()}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/ControllerManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/ControllerManager.java
@@ -29,7 +29,7 @@ public class ControllerManager {
 
     private final BaseDatabaseManager baseDatabaseManager;
 
-    private DisplayUnitCache displayUnitCache;
+    private volatile DisplayUnitCache displayUnitCache;
 
     /**
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/ControllerManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/ControllerManager.java
@@ -3,8 +3,10 @@ package com.clevertap.android.sdk;
 import android.content.Context;
 import androidx.annotation.AnyThread;
 import androidx.annotation.WorkerThread;
+import androidx.annotation.Nullable;
 import com.clevertap.android.sdk.db.BaseDatabaseManager;
 import com.clevertap.android.sdk.displayunits.CTDisplayUnitController;
+import com.clevertap.android.sdk.displayunits.DisplayUnitCache;
 import com.clevertap.android.sdk.featureFlags.CTFeatureFlagsController;
 import com.clevertap.android.sdk.inapp.InAppController;
 import com.clevertap.android.sdk.inbox.CTInboxController;
@@ -27,7 +29,7 @@ public class ControllerManager {
 
     private final BaseDatabaseManager baseDatabaseManager;
 
-    private CTDisplayUnitController ctDisplayUnitController;
+    private DisplayUnitCache displayUnitCache;
 
     /**
      * <p style="color:#4d2e00;background:#ffcc99;font-weight: bold" >
@@ -79,13 +81,46 @@ public class ControllerManager {
         baseDatabaseManager = databaseManager;
     }
 
-    public CTDisplayUnitController getCTDisplayUnitController() {
-        return ctDisplayUnitController;
+    /**
+     * @return the active {@link DisplayUnitCache}; {@code null} until the SDK
+     * receives its first {@code adUnit_notifs} response or a host installs a
+     * cache via {@link #setDisplayUnitCache(DisplayUnitCache)}.
+     */
+    @Nullable
+    public DisplayUnitCache getDisplayUnitCache() {
+        return displayUnitCache;
     }
 
+    /**
+     * Replaces the display-unit cache. Pass {@code null} to clear the
+     * reference (subsequent server responses will lazily install a fresh
+     * default {@link CTDisplayUnitController}).
+     */
+    public void setDisplayUnitCache(@Nullable DisplayUnitCache cache) {
+        displayUnitCache = cache;
+    }
+
+    /**
+     * @deprecated since v7.x.0. Use {@link #getDisplayUnitCache()} instead.
+     * Returns the active cache only when it is the default
+     * {@link CTDisplayUnitController}; returns {@code null} when a host has
+     * installed a custom {@link DisplayUnitCache}.
+     */
+    @Deprecated
+    @Nullable
+    public CTDisplayUnitController getCTDisplayUnitController() {
+        return displayUnitCache instanceof CTDisplayUnitController
+                ? (CTDisplayUnitController) displayUnitCache : null;
+    }
+
+    /**
+     * @deprecated since v7.x.0. Use
+     * {@link #setDisplayUnitCache(DisplayUnitCache)} instead.
+     */
+    @Deprecated
     public void setCTDisplayUnitController(
             final CTDisplayUnitController CTDisplayUnitController) {
-        ctDisplayUnitController = CTDisplayUnitController;
+        setDisplayUnitCache(CTDisplayUnitController);
     }
 
     /**

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/displayunits/CTDisplayUnitController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/displayunits/CTDisplayUnitController.java
@@ -1,15 +1,13 @@
 package com.clevertap.android.sdk.displayunits;
 
 import android.text.TextUtils;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.Logger;
 import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
-import org.json.JSONArray;
-import org.json.JSONObject;
+import java.util.List;
 
 /**
  * Controller class for caching & supplying the Display Units to the client.
@@ -62,42 +60,21 @@ public class CTDisplayUnitController implements DisplayUnitCache {
     }
 
     /**
-     * Replaces the old Display Units with the new ones, post transformation of Json objects to Display Unit objects
+     * Replaces the old Display Units with the supplied list.
      *
-     * @param messages - json-array of Display Unit items
-     * @return ArrayList<CleverTapDisplayUnit> - could be null in case of null/empty/invalid json array
+     * @param displayUnits parsed display units; may be {@code null} or empty.
      */
     @Override
-    @Nullable
-    public synchronized ArrayList<CleverTapDisplayUnit> updateDisplayUnits(@Nullable JSONArray messages) {
-
-        //flush existing display units before updating with the new ones.
+    public synchronized void updateDisplayUnits(@Nullable List<CleverTapDisplayUnit> displayUnits) {
         reset();
-
-        if (messages != null && messages.length() > 0) {
-            final ArrayList<CleverTapDisplayUnit> list = new ArrayList<>();
-            try {
-                for (int i = 0; i < messages.length(); i++) {
-                    //parse each display Unit
-                    CleverTapDisplayUnit item = CleverTapDisplayUnit.toDisplayUnit((JSONObject) messages.get(i));
-                    if (TextUtils.isEmpty(item.getError())) {
-                        items.put(item.getUnitID(), item);
-                        list.add(item);
-                    } else {
-                        Logger.d(Constants.FEATURE_DISPLAY_UNIT,
-                                "Failed to convert JsonArray item at index:" + i + " to Display Unit");
-                    }
-                }
-            } catch (Exception e) {
-                Logger.d(Constants.FEATURE_DISPLAY_UNIT,
-                        "Failed while parsing Display Unit:" + e.getLocalizedMessage());
-                return null;
+        if (displayUnits == null || displayUnits.isEmpty()) {
+            Logger.d(Constants.FEATURE_DISPLAY_UNIT, "Empty Display Units list, cache not updated");
+            return;
+        }
+        for (CleverTapDisplayUnit unit : displayUnits) {
+            if (unit != null && !TextUtils.isEmpty(unit.getUnitID())) {
+                items.put(unit.getUnitID(), unit);
             }
-
-            return !list.isEmpty() ? list : null;
-        } else {
-            Logger.d(Constants.FEATURE_DISPLAY_UNIT, "Null json array response can't parse Display Units ");
-            return null;
         }
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/displayunits/CTDisplayUnitController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/displayunits/CTDisplayUnitController.java
@@ -1,6 +1,7 @@
 package com.clevertap.android.sdk.displayunits;
 
 import android.text.TextUtils;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.Logger;
@@ -12,8 +13,9 @@ import org.json.JSONObject;
 
 /**
  * Controller class for caching & supplying the Display Units to the client.
+ * Default implementation of {@link DisplayUnitCache}.
  */
-public class CTDisplayUnitController {
+public class CTDisplayUnitController implements DisplayUnitCache {
 
     final HashMap<String, CleverTapDisplayUnit> items = new HashMap<>();
 
@@ -22,6 +24,7 @@ public class CTDisplayUnitController {
      *
      * @return ArrayList<CleverTapDisplayUnit> - Could be null in case no Display Units are there in the cache
      */
+    @Override
     @Nullable
     public synchronized ArrayList<CleverTapDisplayUnit> getAllDisplayUnits() {
         if (!items.isEmpty()) {
@@ -38,8 +41,9 @@ public class CTDisplayUnitController {
      * @param unitId - unitID of the Display Unit {@link CleverTapDisplayUnit#getUnitID()}
      * @return CleverTapDisplayUnit - Could be null in case no Display Units with the ID is found
      */
+    @Override
     @Nullable
-    public synchronized CleverTapDisplayUnit getDisplayUnitForID(String unitId) {
+    public synchronized CleverTapDisplayUnit getDisplayUnitForID(@Nullable String unitId) {
         if (!TextUtils.isEmpty(unitId)) {
             return items.get(unitId);
         } else {
@@ -51,6 +55,7 @@ public class CTDisplayUnitController {
     /**
      * clears the existing Display Units
      */
+    @Override
     public synchronized void reset() {
         items.clear();
         Logger.d(Constants.FEATURE_DISPLAY_UNIT, "Cleared Display Units Cache");
@@ -62,8 +67,9 @@ public class CTDisplayUnitController {
      * @param messages - json-array of Display Unit items
      * @return ArrayList<CleverTapDisplayUnit> - could be null in case of null/empty/invalid json array
      */
+    @Override
     @Nullable
-    public synchronized ArrayList<CleverTapDisplayUnit> updateDisplayUnits(JSONArray messages) {
+    public synchronized ArrayList<CleverTapDisplayUnit> updateDisplayUnits(@Nullable JSONArray messages) {
 
         //flush existing display units before updating with the new ones.
         reset();

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/displayunits/DisplayUnitCache.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/displayunits/DisplayUnitCache.java
@@ -3,7 +3,7 @@ package com.clevertap.android.sdk.displayunits;
 import androidx.annotation.Nullable;
 import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
 import java.util.ArrayList;
-import org.json.JSONArray;
+import java.util.List;
 
 /**
  * In-memory storage contract for {@link CleverTapDisplayUnit}s.
@@ -42,11 +42,9 @@ public interface DisplayUnitCache {
      * display units. The default implementation replaces the cache contents;
      * hosts may choose merge semantics for their own implementations.
      *
-     * @param messages parsed server payload; may be {@code null} or empty.
-     * @return the parsed units that were applied, or {@code null} if none.
+     * @param displayUnits parsed display units; may be {@code null} or empty.
      */
-    @Nullable
-    ArrayList<CleverTapDisplayUnit> updateDisplayUnits(@Nullable JSONArray messages);
+    void updateDisplayUnits(@Nullable List<CleverTapDisplayUnit> displayUnits);
 
     /**
      * Clears all units. Called by the SDK on logout / reset flows.

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/displayunits/DisplayUnitCache.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/displayunits/DisplayUnitCache.java
@@ -1,0 +1,55 @@
+package com.clevertap.android.sdk.displayunits;
+
+import androidx.annotation.Nullable;
+import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
+import java.util.ArrayList;
+import org.json.JSONArray;
+
+/**
+ * In-memory storage contract for {@link CleverTapDisplayUnit}s.
+ * The default implementation ({@link CTDisplayUnitController}) is
+ * server-pipeline-driven. Hosts may install their own implementation via
+ * {@link com.clevertap.android.sdk.CleverTapAPI#setDisplayUnitCache(DisplayUnitCache)}
+ * to expose units produced outside the standard server-response pipeline
+ * (for example, server-driven UI SDKs that fetch units through their own
+ * pipeline).
+ *
+ * <p>Implementors must be thread-safe — methods may be invoked from any thread.
+ *
+ * <p>The display unit listener registered via
+ * {@link com.clevertap.android.sdk.CleverTapAPI#setDisplayUnitListener} only
+ * fires for server-pipeline activity. Replacing the cache or mutating its
+ * contents from outside the SDK does not synthesise a listener fire.
+ */
+public interface DisplayUnitCache {
+
+    /**
+     * @return all units currently held; {@code null} or empty if none.
+     */
+    @Nullable
+    ArrayList<CleverTapDisplayUnit> getAllDisplayUnits();
+
+    /**
+     * @param unitID the unit identifier; implementations must tolerate
+     *               {@code null} or empty input by returning {@code null}.
+     * @return the unit with the given id, or {@code null} if absent.
+     */
+    @Nullable
+    CleverTapDisplayUnit getDisplayUnitForID(@Nullable String unitID);
+
+    /**
+     * Called by the SDK when a server response delivers an updated set of
+     * display units. The default implementation replaces the cache contents;
+     * hosts may choose merge semantics for their own implementations.
+     *
+     * @param messages parsed server payload; may be {@code null} or empty.
+     * @return the parsed units that were applied, or {@code null} if none.
+     */
+    @Nullable
+    ArrayList<CleverTapDisplayUnit> updateDisplayUnits(@Nullable JSONArray messages);
+
+    /**
+     * Clears all units. Called by the SDK on logout / reset flows.
+     */
+    void reset();
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/login/LoginController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/login/LoginController.java
@@ -297,8 +297,8 @@ public class LoginController {
      * Resets the Display Units in the cache
      */
     private void resetDisplayUnits() {
-        if (controllerManager.getCTDisplayUnitController() != null) {
-            controllerManager.getCTDisplayUnitController().reset();
+        if (controllerManager.getDisplayUnitCache() != null) {
+            controllerManager.getDisplayUnitCache().reset();
         } else {
             config.getLogger().verbose(config.getAccountId(),
                     Constants.FEATURE_DISPLAY_UNIT + "Can't reset Display Units, DisplayUnitcontroller is null");

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/response/DisplayUnitResponse.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/response/DisplayUnitResponse.java
@@ -1,6 +1,8 @@
 package com.clevertap.android.sdk.response;
 
 import android.content.Context;
+import android.text.TextUtils;
+import androidx.annotation.NonNull;
 import com.clevertap.android.sdk.BaseCallbackManager;
 import com.clevertap.android.sdk.CleverTapInstanceConfig;
 import com.clevertap.android.sdk.Constants;
@@ -11,6 +13,7 @@ import com.clevertap.android.sdk.displayunits.DisplayUnitCache;
 import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
 import java.util.ArrayList;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 
 public class DisplayUnitResponse extends CleverTapResponseDecorator {
@@ -73,7 +76,8 @@ public class DisplayUnitResponse extends CleverTapResponseDecorator {
     }
 
     /**
-     * Parses the Display Units using the JSON response
+     * Parses the Display Units using the JSON response, populates the cache and
+     * notifies the callback.
      *
      * @param messages - Json array of Display Unit items
      */
@@ -90,9 +94,39 @@ public class DisplayUnitResponse extends CleverTapResponseDecorator {
             }
         }
         DisplayUnitCache cache = controllerManager.getDisplayUnitCache();
-        ArrayList<CleverTapDisplayUnit> displayUnits = cache != null
-                ? cache.updateDisplayUnits(messages) : null;
+        if (cache == null) {
+            callbackManager.notifyDisplayUnitsLoaded(null);
+            return;
+        }
 
-        callbackManager.notifyDisplayUnitsLoaded(displayUnits);
+        ArrayList<CleverTapDisplayUnit> displayUnits = parseDisplayUnitsFromJson(messages);
+        cache.updateDisplayUnits(displayUnits);
+        callbackManager.notifyDisplayUnitsLoaded(displayUnits.isEmpty() ? null : displayUnits);
+    }
+
+    /**
+     * Converts a JSON array of display units into model objects, filtering out
+     * malformed entries.
+     */
+    @NonNull
+    private ArrayList<CleverTapDisplayUnit> parseDisplayUnitsFromJson(@NonNull JSONArray messages) {
+        final ArrayList<CleverTapDisplayUnit> list = new ArrayList<>();
+        for (int i = 0; i < messages.length(); i++) {
+            try {
+                CleverTapDisplayUnit unit = CleverTapDisplayUnit.toDisplayUnit(messages.getJSONObject(i));
+                if (TextUtils.isEmpty(unit.getError())) {
+                    list.add(unit);
+                } else {
+                    logger.verbose(config.getAccountId(),
+                            Constants.FEATURE_DISPLAY_UNIT + "Failed to convert JsonArray item at index:" + i
+                                    + " to Display Unit");
+                }
+            } catch (JSONException e) {
+                logger.verbose(config.getAccountId(),
+                        Constants.FEATURE_DISPLAY_UNIT + "Failed to parse Display Unit at index " + i
+                                + ": " + e.getLocalizedMessage());
+            }
+        }
+        return list;
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/response/DisplayUnitResponse.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/response/DisplayUnitResponse.java
@@ -7,6 +7,7 @@ import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.ControllerManager;
 import com.clevertap.android.sdk.Logger;
 import com.clevertap.android.sdk.displayunits.CTDisplayUnitController;
+import com.clevertap.android.sdk.displayunits.DisplayUnitCache;
 import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
 import java.util.ArrayList;
 import org.json.JSONArray;
@@ -84,12 +85,13 @@ public class DisplayUnitResponse extends CleverTapResponseDecorator {
         }
 
         synchronized (displayUnitControllerLock) {// lock to avoid multiple instance creation for controller
-            if (controllerManager.getCTDisplayUnitController() == null) {
-                controllerManager.setCTDisplayUnitController(new CTDisplayUnitController());
+            if (controllerManager.getDisplayUnitCache() == null) {
+                controllerManager.setDisplayUnitCache(new CTDisplayUnitController());
             }
         }
-        ArrayList<CleverTapDisplayUnit> displayUnits = controllerManager.getCTDisplayUnitController()
-                .updateDisplayUnits(messages);
+        DisplayUnitCache cache = controllerManager.getDisplayUnitCache();
+        ArrayList<CleverTapDisplayUnit> displayUnits = cache != null
+                ? cache.updateDisplayUnits(messages) : null;
 
         callbackManager.notifyDisplayUnitsLoaded(displayUnits);
     }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/AnalyticsManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/AnalyticsManagerTest.kt
@@ -1647,8 +1647,8 @@ class AnalyticsManagerTest {
     @Test
     fun `raiseEventForGeofences should queue event and set location`() {
         val eventName = "geofence_event"
-        val lat = 34.05
-        val lng = -118.25
+        val lat: Double = 34.05
+        val lng: Double = -118.25
         val propKey = "prop"
         val propValue = "value"
         val geofenceProperties = JSONObject().apply {
@@ -1677,8 +1677,8 @@ class AnalyticsManagerTest {
         }
 
         val location = coreState.coreMetaData.locationFromUser
-        assertEquals(lat, location.latitude)
-        assertEquals(lng, location.longitude)
+        assertEquals(lat, location.latitude, 0.0)
+        assertEquals(lng, location.longitude, 0.0)
     }
 
     @Test

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/AnalyticsManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/AnalyticsManagerTest.kt
@@ -790,7 +790,7 @@ class AnalyticsManagerTest {
 
     @Test
     fun `pushDisplayUnitClickedEventForID displayController is null`() {
-        every { coreState.controllerManager.ctDisplayUnitController } returns null
+        every { coreState.controllerManager.displayUnitCache } returns null
         analyticsManagerSUT.pushDisplayUnitClickedEventForID("id")
 
         verify(exactly = 0) {
@@ -802,7 +802,7 @@ class AnalyticsManagerTest {
     fun `pushDisplayUnitClickedEventForID displayUnit is null`() {
         val displayController = mockk<CTDisplayUnitController>()
         every { displayController.getDisplayUnitForID(any()) } returns null
-        every { coreState.controllerManager.ctDisplayUnitController } returns displayController
+        every { coreState.controllerManager.displayUnitCache } returns displayController
 
         analyticsManagerSUT.pushDisplayUnitClickedEventForID("id")
 
@@ -819,7 +819,7 @@ class AnalyticsManagerTest {
 
     @Test
     fun `pushDisplayUnitViewedEventForID displayController is null`() {
-        every { coreState.controllerManager.ctDisplayUnitController } returns null
+        every { coreState.controllerManager.displayUnitCache } returns null
         analyticsManagerSUT.pushDisplayUnitViewedEventForID("id")
 
         verify(exactly = 0) {
@@ -831,7 +831,7 @@ class AnalyticsManagerTest {
     fun `pushDisplayUnitViewedEventForID displayUnit is null`() {
         val displayController = mockk<CTDisplayUnitController>()
         every { displayController.getDisplayUnitForID(any()) } returns null
-        every { coreState.controllerManager.ctDisplayUnitController } returns displayController
+        every { coreState.controllerManager.displayUnitCache } returns displayController
 
         analyticsManagerSUT.pushDisplayUnitViewedEventForID("id")
 
@@ -845,7 +845,7 @@ class AnalyticsManagerTest {
         val displayUnitJson = JSONObject()
         val displayUnit = CleverTapDisplayUnit.toDisplayUnit(displayUnitJson)
         every { displayController.getDisplayUnitForID(any()) } returns displayUnit
-        every { coreState.controllerManager.ctDisplayUnitController } returns displayController
+        every { coreState.controllerManager.displayUnitCache } returns displayController
 
         val eventName: String
         if (isClicked) {

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/AnalyticsManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/AnalyticsManagerTest.kt
@@ -37,6 +37,9 @@ import io.mockk.verify
 import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -835,6 +838,99 @@ class AnalyticsManagerTest {
 
         analyticsManagerSUT.pushDisplayUnitViewedEventForID("id")
 
+        verify(exactly = 0) {
+            eventQueueManager.queueEvent(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `pushDisplayUnitElementClickedEventForID merges elementId and additionalProperties`() {
+        val displayController = mockk<CTDisplayUnitController>()
+        val unitJson = JSONObject()
+            .put("wzrk_id", "1234_5678")
+            .put("wzrk_pivot", "wzrk_default")
+        every { displayController.getDisplayUnitForID(any()) } returns
+                CleverTapDisplayUnit.toDisplayUnit(unitJson)
+        every { coreState.controllerManager.displayUnitCache } returns displayController
+        mockCleanEventName(Constants.NOTIFICATION_CLICKED_EVENT_NAME)
+
+        val extras = HashMap<String, Any>().apply {
+            put("action_type", "open_url")
+            put("action_url", "https://example.com")
+            put("k1", "v1")
+        }
+        analyticsManagerSUT.pushDisplayUnitElementClickedEventForID("id", "button-1", extras)
+
+        verify(exactly = 1) {
+            eventQueueManager.queueEvent(any(), match { event ->
+                val evtData = event.getJSONObject(Constants.KEY_EVT_DATA)
+                event.getString(Constants.KEY_EVT_NAME) == Constants.NOTIFICATION_CLICKED_EVENT_NAME
+                        // wzrk_* enrichment preserved
+                        && evtData.optString("wzrk_id") == "1234_5678"
+                        && evtData.optString("wzrk_pivot") == "wzrk_default"
+                        // element id added
+                        && evtData.optString("wzrk_element_id") == "button-1"
+                        // additionalProperties merged
+                        && evtData.optString("action_type") == "open_url"
+                        && evtData.optString("action_url") == "https://example.com"
+                        && evtData.optString("k1") == "v1"
+            }, Constants.RAISED_EVENT, any<FlattenedEventData.EventProperties>())
+        }
+    }
+
+    @Test
+    fun `pushDisplayUnitElementClickedEventForID strips wzrk_ keys from additionalProperties`() {
+        val displayController = mockk<CTDisplayUnitController>()
+        val unitJson = JSONObject().put("wzrk_id", "real_id")
+        every { displayController.getDisplayUnitForID(any()) } returns
+                CleverTapDisplayUnit.toDisplayUnit(unitJson)
+        every { coreState.controllerManager.displayUnitCache } returns displayController
+        mockCleanEventName(Constants.NOTIFICATION_CLICKED_EVENT_NAME)
+
+        val extras = HashMap<String, Any>().apply {
+            put("wzrk_id", "spoofed")                  // collision with server-controlled key
+            put("wzrk_anything", "should-be-stripped") // any wzrk_-prefixed key is dropped
+            put("ok_key", "kept")
+        }
+        analyticsManagerSUT.pushDisplayUnitElementClickedEventForID("id", "btn", extras)
+
+        verify(exactly = 1) {
+            eventQueueManager.queueEvent(any(), match { event ->
+                val evtData = event.getJSONObject(Constants.KEY_EVT_DATA)
+                // wzrk_id from cached unit wins — spoofed value never lands.
+                evtData.optString("wzrk_id") == "real_id"
+                        && !evtData.has("wzrk_anything")
+                        && evtData.optString("ok_key") == "kept"
+            }, Constants.RAISED_EVENT, any<FlattenedEventData.EventProperties>())
+        }
+    }
+
+    @Test
+    fun `pushDisplayUnitElementClickedEventForID setWzrkParams receives only wzrk_ keys`() {
+        val displayController = mockk<CTDisplayUnitController>()
+        val unitJson = JSONObject().put("wzrk_id", "1234")
+        every { displayController.getDisplayUnitForID(any()) } returns
+                CleverTapDisplayUnit.toDisplayUnit(unitJson)
+        every { coreState.controllerManager.displayUnitCache } returns displayController
+        mockCleanEventName(Constants.NOTIFICATION_CLICKED_EVENT_NAME)
+
+        val extras = HashMap<String, Any>().apply { put("action_url", "https://x") }
+        analyticsManagerSUT.pushDisplayUnitElementClickedEventForID("id", "btn", extras)
+
+        // coreMetaData.setWzrkParams feeds the wzrk_ref batch header — caller-supplied
+        // non-wzrk extras must NOT ride along. coreMetaData is a real instance (see
+        // MockCoreStateKotlin), so reading wzrkParams back reflects the latest set.
+        val wzrkParams = coreState.coreMetaData.wzrkParams
+        assertNotNull(wzrkParams)
+        assertFalse(wzrkParams.has("action_url"))
+        assertEquals("1234", wzrkParams.optString("wzrk_id"))
+        assertEquals("btn", wzrkParams.optString("wzrk_element_id"))
+    }
+
+    @Test
+    fun `pushDisplayUnitElementClickedEventForID displayController is null`() {
+        every { coreState.controllerManager.displayUnitCache } returns null
+        analyticsManagerSUT.pushDisplayUnitElementClickedEventForID("id", "btn", HashMap())
         verify(exactly = 0) {
             eventQueueManager.queueEvent(any(), any(), any(), any())
         }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/MockAnalyticsManager.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/MockAnalyticsManager.kt
@@ -23,6 +23,10 @@ internal class MockAnalyticsManager : BaseAnalyticsManager() {
     }
 
     override fun pushDisplayUnitClickedEventForID(unitID: String) {}
+    override fun pushDisplayUnitElementClickedEventForID(
+        unitID: String, elementID: String,
+        additionalProperties: java.util.HashMap<String, Any>?
+    ) {}
     override fun pushDisplayUnitViewedEventForID(unitID: String) {}
     override fun pushError(errorMessage: String, errorCode: Int) {}
     override fun pushEvent(eventName: String, eventActions: Map<String, Any>) {}

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/displayunits/CTDisplayUnitControllerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/displayunits/CTDisplayUnitControllerTest.kt
@@ -3,8 +3,6 @@ package com.clevertap.android.sdk.displayunits
 import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit
 import com.clevertap.android.sdk.displayunits.model.MockCleverTapDisplayUnit
 import com.clevertap.android.shared.test.BaseTestCase
-import io.mockk.every
-import io.mockk.mockkStatic
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -22,12 +20,26 @@ class CTDisplayUnitControllerTest : BaseTestCase() {
         ctDisplayUnitController = CTDisplayUnitController()
     }
 
+    private fun mockDisplayUnits(noItems: Int): ArrayList<CleverTapDisplayUnit> {
+        val jsonArray = MockCleverTapDisplayUnit().getMockResponse(noItems)
+        val list = ArrayList<CleverTapDisplayUnit>()
+        for (i in 0 until jsonArray.length()) {
+            list.add(CleverTapDisplayUnit.toDisplayUnit(jsonArray.getJSONObject(i)))
+        }
+        return list
+    }
+
     @Test
-    fun test_updateDisplayUnits_whenResponseArrayIsNull_returnNullDisplayUnit() {
-        val list = ctDisplayUnitController.updateDisplayUnits(null)
-        Assert.assertNull(list)
+    fun test_updateDisplayUnits_whenListIsNull_cacheIsEmpty() {
+        ctDisplayUnitController.updateDisplayUnits(null)
         Assert.assertNull(ctDisplayUnitController.allDisplayUnits)
         Assert.assertNull(ctDisplayUnitController.getDisplayUnitForID("12121212"))
+    }
+
+    @Test
+    fun test_updateDisplayUnits_whenListIsEmpty_cacheIsEmpty() {
+        ctDisplayUnitController.updateDisplayUnits(emptyList())
+        Assert.assertNull(ctDisplayUnitController.allDisplayUnits)
     }
 
     @Test
@@ -38,36 +50,31 @@ class CTDisplayUnitControllerTest : BaseTestCase() {
 
     @Test
     fun test_reset() {
-        // first we put non empty response to ensure that after reset the values are cleared or not
+        ctDisplayUnitController.updateDisplayUnits(mockDisplayUnits(1))
+        Assert.assertNotNull(ctDisplayUnitController.allDisplayUnits)
+        Assert.assertTrue(ctDisplayUnitController.allDisplayUnits!!.size == 1)
 
-        val list = ctDisplayUnitController.updateDisplayUnits(MockCleverTapDisplayUnit().getMockResponse(1))
-        Assert.assertNotNull(list)
-        Assert.assertTrue(list?.size == 1)
-
-        //after reset the units should get cleared
         ctDisplayUnitController.reset()
         Assert.assertNull(ctDisplayUnitController.allDisplayUnits)
-        Assert.assertNull(ctDisplayUnitController.getDisplayUnitForID("12121212"))
+        Assert.assertNull(ctDisplayUnitController.getDisplayUnitForID("mock-notification-id"))
     }
 
     @Test
-    fun test_updateDisplayUnits_whenAnyException_returnNullDisplayUnit() {
-        mockkStatic(CleverTapDisplayUnit::class) {
-            every { CleverTapDisplayUnit.toDisplayUnit(any()) } throws RuntimeException("Something went wrong")
-
-            ctDisplayUnitController.updateDisplayUnits(MockCleverTapDisplayUnit().getMockResponse(1))
-            Assert.assertNull(ctDisplayUnitController.getDisplayUnitForID(null))
-            Assert.assertNull(ctDisplayUnitController.getDisplayUnitForID(""))
-        }
-    }
-
-    @Test
-    fun test_updateDisplayUnits_validDisplayUnitResponse_shouldReturnValidDisplayUnit() {
-        ctDisplayUnitController.updateDisplayUnits(MockCleverTapDisplayUnit().getMockResponse(1))
+    fun test_updateDisplayUnits_validList_populatesCache() {
+        ctDisplayUnitController.updateDisplayUnits(mockDisplayUnits(1))
         Assert.assertNotNull(ctDisplayUnitController.allDisplayUnits)
         Assert.assertTrue(ctDisplayUnitController.allDisplayUnits!!.size > 0)
         val displayUnit = ctDisplayUnitController.getDisplayUnitForID("mock-notification-id")
         Assert.assertNotNull(displayUnit)
         Assert.assertTrue(displayUnit is CleverTapDisplayUnit)
+    }
+
+    @Test
+    fun test_updateDisplayUnits_replacesPreviousCache() {
+        ctDisplayUnitController.updateDisplayUnits(mockDisplayUnits(1))
+        Assert.assertNotNull(ctDisplayUnitController.allDisplayUnits)
+
+        ctDisplayUnitController.updateDisplayUnits(emptyList())
+        Assert.assertNull(ctDisplayUnitController.allDisplayUnits)
     }
 }


### PR DESCRIPTION
## Jira

[SDK-5763](https://wizrocket.atlassian.net/browse/SDK-5763) — child of epic [SDK-5256](https://wizrocket.atlassian.net/browse/SDK-5256) (Native Display v2).
Companion PRs: iOS Core SDK [SDK-5764](https://wizrocket.atlassian.net/browse/SDK-5764) and Native Display SDK [SDK-5765](https://wizrocket.atlassian.net/browse/SDK-5765).

## Summary

Extracts `CTDisplayUnitController`'s read+update surface into a public `DisplayUnitCache` interface and exposes `CleverTapAPI.setDisplayUnitCache(...)` so external SDKs (Native Display) can install their own cache implementation.

**Why:** ND SDK's manual JSON mode feeds units the Core SDK never received from its server pipeline, so `pushDisplayUnit*EventForID`'s mandatory cache lookup misses and analytics are unattributed. `pushEvent("Notification Viewed", ...)` is not a workaround — those names are in `DEFAULT_RESTRICTED_EVENT_NAMES` and dropped at validation. Letting ND SDK plug its own cache implementation lets attribution events resolve through the bridge's existing cache.

## Changes

| File | Change |
|---|---|
| `displayunits/DisplayUnitCache.java` | **new** public interface (`getAllDisplayUnits`, `getDisplayUnitForID`, `updateDisplayUnits`, `reset`) |
| `displayunits/CTDisplayUnitController.java` | `implements DisplayUnitCache` (no behaviour change) |
| `ControllerManager.java` | holds `DisplayUnitCache` reference; `getDisplayUnitCache()`/`setDisplayUnitCache()`; deprecated `getCTDisplayUnitController()`/`setCTDisplayUnitController()` retained as adapters |
| `CleverTapAPI.java` | new public `setDisplayUnitCache(DisplayUnitCache)`; `getDisplayUnitForId`/`getAllDisplayUnits` route via interface |
| `AnalyticsManager.java` | `pushDisplayUnit*EventForID` resolve via `getDisplayUnitCache()` |
| `response/DisplayUnitResponse.java` | server-response handler routes via interface |
| `login/LoginController.java` | logout reset routes via interface |
| `test/.../AnalyticsManagerTest.kt` | mock points updated to `displayUnitCache` |

## Backwards compatibility

- Hosts that don't call the new setter: identical behaviour. The default `CTDisplayUnitController` is lazy-installed on first `adUnit_notifs` response (same lazy-init point as before, just routed via the new accessor).
- Deprecated `getCTDisplayUnitController()` returns the cast default impl when present, null when a custom impl is installed.
- `DisplayUnitListener` continues to fire only for server-pipeline activity.

## Test plan

- [x] `:clevertap-core:compileDebugJavaWithJavac` clean
- [x] Full `:clevertap-core:testDebugUnitTest` suite passes
- [ ] Reviewer: confirm a host that ignores the new setter sees no behaviour change
- [ ] Reviewer: validate javadoc on new public types reads cleanly

[SDK-5763]: https://wizrocket.atlassian.net/browse/SDK-5763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-5256]: https://wizrocket.atlassian.net/browse/SDK-5256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-5764]: https://wizrocket.atlassian.net/browse/SDK-5764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-5765]: https://wizrocket.atlassian.net/browse/SDK-5765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API to supply/clear a display-unit cache.
  * New API to report native display "element clicked" events with optional properties.

* **Improvements**
  * Display-unit lookups, resets and event tracking now route through the supplied cache; server updates populate the cache and drive listener firing.
  * Element-click events merge element ID and caller properties, preserving cached display-unit metadata while stripping reserved keys.
  * Default controller implements the cache contract and new update semantics.

* **Tests**
  * Added tests for element-click merging, reserved-key stripping, metadata handling, cache-null and cache-update cases.

* **Deprecations**
  * Legacy controller paths redirected toward the cache-based API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CleverTap/clevertap-android-sdk/pull/999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->