### PR TITLE
Add title/message support and basic fallback for five icons push template

### DIFF
--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
@@ -77,12 +77,8 @@ internal data class BasicTemplateData(
 
 internal data class FiveIconsTemplateData(
     override val templateType: TemplateType = TemplateType.FIVE_ICONS,
+    val baseContent: BaseContent,
     val imageList: ArrayList<ImageData>,
-    val deepLinkList: ArrayList<String>,
-    val backgroundColor: String? = null,
-    val title: String? = null,
-    val subtitle: String? = null,
-    val notificationBehavior: NotificationBehavior
 ) : TemplateData()
 
 internal data class ManualCarouselTemplateData(

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
@@ -578,6 +578,17 @@ internal object TemplateDataFactory {
         )
     }
 
+    internal fun FiveIconsTemplateData.toBasicTemplateData(): BasicTemplateData {
+        return BasicTemplateData(
+            baseContent = this.baseContent,
+            mediaData = MediaData(
+                bigImage = ImageData(altText = ""),
+                gif = GifData()
+            ),
+            actions = null
+        )
+    }
+
     internal fun InputBoxTemplateData.toBaseContent(): BaseContent {
         return BaseContent(
             textData = this.textData,
@@ -622,4 +633,3 @@ internal object TemplateDataFactory {
         }
     }
 }
-

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
@@ -223,12 +223,8 @@ internal object TemplateDataFactory {
         defaultAltText: String
     ): FiveIconsTemplateData {
         return FiveIconsTemplateData(
+            baseContent = createBaseContent(extras, colorMap),
             imageList = Utils.getImageDataListFromExtras(extras, defaultAltText),
-            deepLinkList = Utils.getDeepLinkListFromExtras(extras),
-            backgroundColor = colorMap[PT_BG],
-            title = getStringWithFallback(extras, PT_TITLE, Constants.NOTIF_TITLE),
-            subtitle = getStringWithFallback(extras, PT_SUBTITLE, Constants.WZRK_SUBTITLE),
-            notificationBehavior = createNotificationBehaviorData(extras)
         )
     }
 
@@ -581,19 +577,6 @@ internal object TemplateDataFactory {
             actions = this.actions
         )
     }
-
-    internal fun FiveIconsTemplateData.toBaseContent(): BaseContent {
-        return BaseContent(
-            textData = BaseTextData(title = this.title, subtitle = this.subtitle),
-            colorData = BaseColorData(
-                backgroundColor = this.backgroundColor,
-            ),
-            iconData = IconData(),
-            deepLinkList = this.deepLinkList,
-            notificationBehavior = this.notificationBehavior
-        )
-    }
-
 
     internal fun InputBoxTemplateData.toBaseContent(): BaseContent {
         return BaseContent(

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
@@ -131,24 +131,31 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
                 RatingStyle(it, this, extras).builderFromStyle(context, extras, notificationId, nb)
             }
 
-            is FiveIconsTemplateData -> templateData.buildIfValid {
-                val fiveIconStyle = FiveIconStyle(it, this, extras)
-                val fiveIconNotificationBuilder = fiveIconStyle.builderFromStyle(
-                    context,
-                    extras,
-                    notificationId,
-                    nb
-                )
+            is FiveIconsTemplateData -> {
+                val validator = ValidatorFactory.getValidator(templateData)
+                if (validator?.validate() == true) {
+                    val fiveIconStyle = FiveIconStyle(templateData, this, extras)
+                    val fiveIconNotificationBuilder = fiveIconStyle.builderFromStyle(
+                        context,
+                        extras,
+                        notificationId,
+                        nb
+                    )
 
-                /**
-                 * Checks whether the imageUrls are perfect to download icon's bitmap,
-                 * if not then do not render notification
-                 */
-                if ((fiveIconStyle.fiveIconSmallContentView as FiveIconSmallContentView).getUnloadedFiveIconsCount() > 2 ||
-                    (fiveIconStyle.fiveIconBigContentView as FiveIconBigContentView).getUnloadedFiveIconsCount() > 2) {
-                    null
+                    /**
+                     * If most icon bitmaps fail to load, gracefully fall back to a basic
+                     * title/message notification instead of suppressing the notification.
+                     */
+                    if ((fiveIconStyle.fiveIconSmallContentView as FiveIconSmallContentView).getUnloadedFiveIconsCount() > 2 ||
+                        (fiveIconStyle.fiveIconBigContentView as FiveIconBigContentView).getUnloadedFiveIconsCount() > 2) {
+                        PTLog.debug("More than 2 images were not retrieved in 5CTA Notification, reverting to basic template.")
+                        buildBasicFallback(templateData.toBasicTemplateData(), context, extras, notificationId, nb)
+                    } else {
+                        fiveIconNotificationBuilder
+                    }
                 } else {
-                    fiveIconNotificationBuilder
+                    PTLog.debug("Five Icons template validation failed, reverting to basic template.")
+                    buildBasicFallback(templateData.toBasicTemplateData(), context, extras, notificationId, nb)
                 }
             }
 
@@ -215,6 +222,16 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
 
     private fun <T : TemplateData> T.buildIfValid(builder: (T) -> Builder?): Builder? =
         ValidatorFactory.getValidator(this)?.takeIf { it.validate() }?.let { builder(this) }
+
+    private fun buildBasicFallback(
+        basicTemplateData: BasicTemplateData,
+        context: Context,
+        extras: Bundle,
+        notificationId: Int,
+        nb: Builder
+    ): Builder? = basicTemplateData.buildIfValid {
+        BasicStyle(it, this).builderFromStyle(context, extras, notificationId, nb)
+    }
 
 
     override fun setSmallIcon(smallIcon: Int, context: Context) {

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "DiscouragedApi")
+
 package com.clevertap.android.pushtemplates
 
 import android.app.PendingIntent
@@ -11,6 +13,7 @@ import android.os.*
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import androidx.core.app.NotificationCompat.Builder
+import androidx.core.net.toUri
 import com.clevertap.android.pushtemplates.PTConstants.*
 import com.clevertap.android.pushtemplates.TemplateDataFactory.getActions
 import com.clevertap.android.pushtemplates.TemplateDataFactory.toBasicTemplateData
@@ -61,7 +64,8 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
     internal var notificationId: Int = -1//Creates a instance field for access in ContentViews->PendingIntentFactory
 
     enum class LogLevel(private val value: Int) {
-        INFO(0), DEBUG(2), VERBOSE(3);
+        @Suppress("unused")
+        OFF(-1), INFO(0), DEBUG(2), VERBOSE(3);
 
         fun intValue(): Int {
             return value
@@ -250,7 +254,7 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
     }
 
     override fun getCollapseKey(extras: Bundle): Any? {
-        return extras[PT_COLLAPSE_KEY] ?: extras[Constants.WZRK_COLLAPSE]
+        return extras.getString(PT_COLLAPSE_KEY) ?: extras.getString(Constants.WZRK_COLLAPSE)
     }
 
     override fun setSound(
@@ -259,11 +263,12 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
         try {
             if (extras.containsKey(Constants.WZRK_SOUND)) {
                 var soundUri: Uri? = null
-                val o = extras[Constants.WZRK_SOUND]
-                if (o is Boolean && o) {
+                val soundString = extras.getString(Constants.WZRK_SOUND)
+                val isDefaultSoundEnabled = extras.getBoolean(Constants.WZRK_SOUND, false)
+                if (isDefaultSoundEnabled) {
                     soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
-                } else if (o is String) {
-                    var s = o
+                } else if (soundString != null) {
+                    var s = soundString
                     if (s == "true") {
                         soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
                     } else if (s.isNotEmpty()) {
@@ -422,7 +427,7 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
                 }
             } else {
                 if (dl.isNotEmpty()) {
-                    Intent(Intent.ACTION_VIEW, Uri.parse(dl)).also {
+                    Intent(Intent.ACTION_VIEW, dl.toUri()).also {
                         Utils.setPackageNameFromResolveInfoList(context, it)
                     }
                 } else {

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
@@ -61,7 +61,7 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
     internal var notificationId: Int = -1//Creates a instance field for access in ContentViews->PendingIntentFactory
 
     enum class LogLevel(private val value: Int) {
-        OFF(-1), INFO(0), DEBUG(2), VERBOSE(3);
+        INFO(0), DEBUG(2), VERBOSE(3);
 
         fun intValue(): Int {
             return value
@@ -409,24 +409,24 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
             }
 
             // Create the appropriate intent
-            var actionLaunchIntent: Intent? = null
-
-            if (sendToCTIntentService) {
-                actionLaunchIntent = Intent(CTNotificationIntentService.MAIN_ACTION)
-                actionLaunchIntent.setPackage(context.packageName)
-                actionLaunchIntent.putExtra(
+            val actionLaunchIntent = if (sendToCTIntentService) {
+                Intent(CTNotificationIntentService.MAIN_ACTION).apply {
+                    setPackage(context.packageName)
+                    putExtra(
                     Constants.KEY_CT_TYPE,
                     CTNotificationIntentService.TYPE_BUTTON_CLICK
-                )
-                if (dl.isNotEmpty()) {
-                    actionLaunchIntent.putExtra("dl", dl)
+                    )
+                    if (dl.isNotEmpty()) {
+                        putExtra("dl", dl)
+                    }
                 }
             } else {
                 if (dl.isNotEmpty()) {
-                    actionLaunchIntent = Intent(Intent.ACTION_VIEW, Uri.parse(dl))
-                    Utils.setPackageNameFromResolveInfoList(context, actionLaunchIntent)
+                    Intent(Intent.ACTION_VIEW, Uri.parse(dl)).also {
+                        Utils.setPackageNameFromResolveInfoList(context, it)
+                    }
                 } else {
-                    actionLaunchIntent = context.packageManager
+                    context.packageManager
                         .getLaunchIntentForPackage(context.packageName)
                 }
             }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
@@ -137,7 +137,9 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
 
             is FiveIconsTemplateData -> {
                 val validator = ValidatorFactory.getValidator(templateData)
-                if (validator?.validate() == true) {
+                if (validator == null) {
+                    null
+                } else if (validator.validate()) {
                     val fiveIconStyle = FiveIconStyle(templateData, this, extras)
                     val fiveIconNotificationBuilder = fiveIconStyle.builderFromStyle(
                         context,
@@ -235,6 +237,9 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
         nb: Builder
     ): Builder? = basicTemplateData.buildIfValid {
         BasicStyle(it, this).builderFromStyle(context, extras, notificationId, nb)
+    } ?: run {
+        PTLog.debug("Five Icons fallback to basic template also failed validation. Notification will be suppressed.")
+        null
     }
 
 
@@ -264,7 +269,7 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
             if (extras.containsKey(Constants.WZRK_SOUND)) {
                 var soundUri: Uri? = null
                 val soundString = extras.getString(Constants.WZRK_SOUND)
-                val isDefaultSoundEnabled = extras.getBoolean(Constants.WZRK_SOUND, false)
+                val isDefaultSoundEnabled = soundString == null && extras.getBoolean(Constants.WZRK_SOUND, false)
                 if (isDefaultSoundEnabled) {
                     soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
                 } else if (soundString != null) {

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconBigContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconBigContentView.kt
@@ -21,7 +21,16 @@ internal class FiveIconBigContentView constructor(
     private var imageCounter: Int = 0
 
     init {
-        setCustomBackgroundColour(data.backgroundColor, R.id.content_view_big)
+        setCustomContentViewBasicKeys(
+            data.baseContent.textData.subtitle,
+            data.baseContent.colorData.metaColor
+        )
+        setCustomContentViewTitle(data.baseContent.textData.title)
+        setCustomContentViewMessage(data.baseContent.textData.message)
+        setCustomBackgroundColour(data.baseContent.colorData.backgroundColor, R.id.content_view_big)
+        setCustomTextColour(data.baseContent.colorData.titleColor, R.id.title)
+        setCustomTextColour(data.baseContent.colorData.messageColor, R.id.msg)
+        setCustomContentViewMessageSummary(data.baseContent.textData.messageSummary)
         val ctaIds = listOf(R.id.cta1, R.id.cta2, R.id.cta3, R.id.cta4, R.id.cta5)
         data.imageList.forEachIndexed { index, imageData ->
             val imageUrl = imageData.url
@@ -47,7 +56,7 @@ internal class FiveIconBigContentView constructor(
         extras.putInt(PTConstants.PT_NOTIF_ID, renderer.notificationId)
         extras.putBoolean(Constants.CLOSE_SYSTEM_DIALOGS, true)
 
-        val deepLinkList = data.deepLinkList
+        val deepLinkList = data.baseContent.deepLinkList
 
         val bundleCTA1 = extras.clone() as Bundle
         bundleCTA1.putBoolean("cta1", true)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconBigContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconBigContentView.kt
@@ -32,6 +32,13 @@ internal class FiveIconBigContentView constructor(
         setCustomTextColour(data.baseContent.colorData.messageColor, R.id.msg)
         setCustomContentViewMessageSummary(data.baseContent.textData.messageSummary)
         val ctaIds = listOf(R.id.cta1, R.id.cta2, R.id.cta3, R.id.cta4, R.id.cta5)
+        val fallbackDescriptions = listOf(
+            R.string.pt_five_icon_1,
+            R.string.pt_five_icon_2,
+            R.string.pt_five_icon_3,
+            R.string.pt_five_icon_4,
+            R.string.pt_five_icon_5
+        )
         data.imageList.forEachIndexed { index, imageData ->
             val imageUrl = imageData.url
             val altText = imageData.altText
@@ -39,6 +46,10 @@ internal class FiveIconBigContentView constructor(
 
             val viewId = ctaIds[index]
             remoteView.setViewVisibility(viewId, View.VISIBLE)
+
+            val description = if (altText.isNotEmpty()) altText
+                              else context.getString(fallbackDescriptions[index])
+            remoteView.setContentDescription(viewId, description)
 
             val fallback = loadImageURLIntoRemoteView(
                 viewId,

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconSmallContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconSmallContentView.kt
@@ -8,7 +8,6 @@ import com.clevertap.android.pushtemplates.PTConstants
 import com.clevertap.android.pushtemplates.PTLog
 import com.clevertap.android.pushtemplates.R
 import com.clevertap.android.pushtemplates.TemplateRenderer
-import com.clevertap.android.pushtemplates.Utils
 import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.pushnotification.LaunchPendingIntentFactory
 
@@ -22,11 +21,15 @@ internal class FiveIconSmallContentView(
     private var imageCounter: Int = 0
 
     init {
-        var title = data.title
-        if (title.isNullOrEmpty()) {
-            title = Utils.getApplicationName(context)
-        }
-        setCustomBackgroundColour(data.backgroundColor, R.id.content_view_big)
+        setCustomContentViewBasicKeys(
+            data.baseContent.textData.subtitle,
+            data.baseContent.colorData.metaColor
+        )
+        setCustomContentViewTitle(data.baseContent.textData.title)
+        setCustomContentViewMessage(data.baseContent.textData.message)
+        setCustomBackgroundColour(data.baseContent.colorData.backgroundColor, R.id.content_view_big)
+        setCustomTextColour(data.baseContent.colorData.titleColor, R.id.title)
+        setCustomTextColour(data.baseContent.colorData.messageColor, R.id.msg)
 
         val ctaIds = listOf(R.id.cta1, R.id.cta2, R.id.cta3, R.id.cta4, R.id.cta5)
         data.imageList.forEachIndexed { index, imageData ->
@@ -54,7 +57,7 @@ internal class FiveIconSmallContentView(
         extras.putInt(PTConstants.PT_NOTIF_ID, renderer.notificationId)
         extras.putBoolean(Constants.CLOSE_SYSTEM_DIALOGS, true)
 
-        val deepLinkList = data.deepLinkList
+        val deepLinkList = data.baseContent.deepLinkList
 
         val bundleCTA1 = extras.clone() as Bundle
         bundleCTA1.putBoolean("cta1", true)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconSmallContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconSmallContentView.kt
@@ -37,6 +37,13 @@ internal class FiveIconSmallContentView(
         setCustomTextColour(data.baseContent.colorData.messageColor, R.id.msg)
 
         val ctaIds = listOf(R.id.cta1, R.id.cta2, R.id.cta3, R.id.cta4, R.id.cta5)
+        val fallbackDescriptions = listOf(
+            R.string.pt_five_icon_1,
+            R.string.pt_five_icon_2,
+            R.string.pt_five_icon_3,
+            R.string.pt_five_icon_4,
+            R.string.pt_five_icon_5
+        )
         data.imageList.forEachIndexed { index, imageData ->
             val imageUrl = imageData.url
             val altText = imageData.altText
@@ -44,6 +51,10 @@ internal class FiveIconSmallContentView(
 
             val viewId = ctaIds[index]
             remoteView.setViewVisibility(viewId, View.VISIBLE)
+
+            val description = if (altText.isNotEmpty()) altText
+                              else context.getString(fallbackDescriptions[index])
+            remoteView.setContentDescription(viewId, description)
 
             val fallback = loadImageURLIntoRemoteView(
                 viewId,

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconSmallContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconSmallContentView.kt
@@ -16,7 +16,12 @@ internal class FiveIconSmallContentView(
     renderer: TemplateRenderer,
     data: FiveIconsTemplateData,
     extras: Bundle
-) : ContentView(context, R.layout.five_cta_collapsed, renderer.templateMediaManager) {
+) : ContentView(context,
+    if (!data.baseContent.textData.title.isNullOrEmpty() || !data.baseContent.textData.message.isNullOrEmpty())
+        R.layout.five_cta_collapsed_with_text
+    else
+        R.layout.five_cta_collapsed,
+    renderer.templateMediaManager) {
 
     private var imageCounter: Int = 0
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/PendingIntentFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/PendingIntentFactory.kt
@@ -204,7 +204,7 @@ internal object PendingIntentFactory {
             }
 
             FIVE_ICON_CONTENT_PENDING_INTENT -> {
-                extras.putString(Constants.DEEP_LINK_KEY, null)
+                extras.putString(Constants.DEEP_LINK_KEY, deepLink)
                 return setPendingIntent(context, notificationId, extras, launchIntent, requestCode)
             }
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/styles/FiveIconStyle.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/styles/FiveIconStyle.kt
@@ -5,12 +5,11 @@ import android.content.Context
 import android.os.Bundle
 import android.widget.RemoteViews
 import com.clevertap.android.pushtemplates.FiveIconsTemplateData
-import com.clevertap.android.pushtemplates.TemplateDataFactory.toBaseContent
 import com.clevertap.android.pushtemplates.TemplateRenderer
 import com.clevertap.android.pushtemplates.content.*
 import com.clevertap.android.pushtemplates.content.PendingIntentFactory
 
-internal class FiveIconStyle(private val data: FiveIconsTemplateData, renderer: TemplateRenderer, private var extras: Bundle) : Style(data.toBaseContent(), renderer) {
+internal class FiveIconStyle(private val data: FiveIconsTemplateData, renderer: TemplateRenderer, private var extras: Bundle) : Style(data.baseContent, renderer) {
 
     lateinit var fiveIconSmallContentView: ContentView
     lateinit var fiveIconBigContentView: ContentView
@@ -32,7 +31,7 @@ internal class FiveIconStyle(private val data: FiveIconsTemplateData, renderer: 
     ): PendingIntent? {
         return PendingIntentFactory.getPendingIntent(
             context, notificationId, extras, true,
-            FIVE_ICON_CONTENT_PENDING_INTENT, data.deepLinkList.getOrNull(0)
+            FIVE_ICON_CONTENT_PENDING_INTENT, data.baseContent.deepLinkList.getOrNull(0)
         )
     }
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/styles/FiveIconStyle.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/styles/FiveIconStyle.kt
@@ -8,6 +8,7 @@ import com.clevertap.android.pushtemplates.FiveIconsTemplateData
 import com.clevertap.android.pushtemplates.TemplateRenderer
 import com.clevertap.android.pushtemplates.content.*
 import com.clevertap.android.pushtemplates.content.PendingIntentFactory
+import com.clevertap.android.sdk.Constants
 
 internal class FiveIconStyle(private val data: FiveIconsTemplateData, renderer: TemplateRenderer, private var extras: Bundle) : Style(data.baseContent, renderer) {
 
@@ -31,7 +32,7 @@ internal class FiveIconStyle(private val data: FiveIconsTemplateData, renderer: 
     ): PendingIntent? {
         return PendingIntentFactory.getPendingIntent(
             context, notificationId, extras, true,
-            FIVE_ICON_CONTENT_PENDING_INTENT, data.baseContent.deepLinkList.getOrNull(0)
+            FIVE_ICON_CONTENT_PENDING_INTENT, extras.getString(Constants.DEEP_LINK_KEY)
         )
     }
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/validators/ValidatorFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/validators/ValidatorFactory.kt
@@ -30,13 +30,12 @@ fun Iterable<Checker<out Any>>.and(): Boolean {
 }
 
 fun Iterable<Checker<out Any>>.or(): Boolean {
-    var or = false
     for (element in this) {
-        or =
-            element.check() || or
-        if (or) break
+        if (element.check()) {
+            return true
+        }
     }
-    return or
+    return false
 }
 
 /**
@@ -141,6 +140,7 @@ internal class ValidationCheckersBuilder {
     /**
      * Adds integer field validation with minimum value check
      */
+    @Suppress("unused")
     fun addIntValidation(value: Int?, minValue: Int, key: String, errorMessage: String): ValidationCheckersBuilder {
         checkers[key] = IntSizeChecker(value, minValue, errorMessage)
         return this
@@ -149,6 +149,7 @@ internal class ValidationCheckersBuilder {
     /**
      * Adds integer field validation with minimum value check
      */
+    @Suppress("unused")
     fun addLongValidation(value: Long?, minValue: Int, key: String, errorMessage: String): ValidationCheckersBuilder {
         checkers[key] = LongSizeChecker(value, minValue, errorMessage)
         return this
@@ -228,7 +229,7 @@ internal class ValidatorFactory {
 
                 is FiveIconsTemplateData -> {
                     builder
-                        .addDeepLinkValidation(templateData.deepLinkList, 3, PT_FIVE_DEEPLINK_LIST)
+                        .addDeepLinkValidation(templateData.baseContent.deepLinkList, 3, PT_FIVE_DEEPLINK_LIST)
                         .addImageListValidation(templateData.imageList, 3, key = PT_FIVE_IMAGE_LIST)
                         .build()
                 }

--- a/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed.xml
+++ b/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed.xml
@@ -2,52 +2,63 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/content_view_big"
     android:layout_width="match_parent"
-    android:layout_height="64dp"
-    android:padding="@dimen/five_cta_padding"
+    android:layout_height="wrap_content"
     android:background="@android:color/transparent"
-    android:orientation="horizontal">
+    android:orientation="vertical">
 
-    <ImageView android:id="@+id/cta1"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:layout_margin="4dp"
-        android:visibility="gone"
-        android:src="@drawable/pt_image"/>
+    <include
+        android:id="@+id/rel_lyt"
+        layout="@layout/content_view_small_single_line_msg" />
 
-    <ImageView
-        android:id="@+id/cta2"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:layout_margin="4dp"
-        android:visibility="gone"
-        android:src="@drawable/pt_image" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="64dp"
+        android:orientation="horizontal"
+        android:padding="@dimen/five_cta_padding">
 
-    <ImageView
-        android:id="@+id/cta3"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:layout_margin="4dp"
-        android:visibility="gone"
-        android:src="@drawable/pt_image" />
+        <ImageView
+            android:id="@+id/cta1"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
 
-    <ImageView
-        android:id="@+id/cta4"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:layout_margin="4dp"
-        android:visibility="gone"
-        android:src="@drawable/pt_image" />
+        <ImageView
+            android:id="@+id/cta2"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
 
-    <ImageView
-        android:id="@+id/cta5"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:layout_margin="4dp"
-        android:visibility="gone"
-        android:src="@drawable/pt_image" />
+        <ImageView
+            android:id="@+id/cta3"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
+
+        <ImageView
+            android:id="@+id/cta4"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
+
+        <ImageView
+            android:id="@+id/cta5"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
+    </LinearLayout>
 </LinearLayout>

--- a/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed.xml
+++ b/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed.xml
@@ -22,6 +22,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
+            android:contentDescription="@null"
             android:visibility="gone"
             android:src="@drawable/pt_image" />
 
@@ -31,6 +32,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
+            android:contentDescription="@null"
             android:visibility="gone"
             android:src="@drawable/pt_image" />
 
@@ -40,6 +42,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
+            android:contentDescription="@null"
             android:visibility="gone"
             android:src="@drawable/pt_image" />
 
@@ -49,6 +52,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
+            android:contentDescription="@null"
             android:visibility="gone"
             android:src="@drawable/pt_image" />
 
@@ -58,6 +62,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
+            android:contentDescription="@null"
             android:visibility="gone"
             android:src="@drawable/pt_image" />
     </LinearLayout>

--- a/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed.xml
+++ b/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed.xml
@@ -2,68 +2,58 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/content_view_big"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="64dp"
     android:background="@android:color/transparent"
-    android:orientation="vertical">
+    android:orientation="horizontal"
+    android:padding="@dimen/five_cta_padding">
 
-    <include
-        android:id="@+id/rel_lyt"
-        layout="@layout/content_view_small_single_line_msg" />
+    <ImageView
+        android:id="@+id/cta1"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_margin="4dp"
+        android:contentDescription="@null"
+        android:visibility="gone"
+        android:src="@drawable/pt_image" />
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="64dp"
-        android:orientation="horizontal"
-        android:padding="@dimen/five_cta_padding">
+    <ImageView
+        android:id="@+id/cta2"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_margin="4dp"
+        android:contentDescription="@null"
+        android:visibility="gone"
+        android:src="@drawable/pt_image" />
 
-        <ImageView
-            android:id="@+id/cta1"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:layout_margin="4dp"
-            android:contentDescription="@null"
-            android:visibility="gone"
-            android:src="@drawable/pt_image" />
+    <ImageView
+        android:id="@+id/cta3"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_margin="4dp"
+        android:contentDescription="@null"
+        android:visibility="gone"
+        android:src="@drawable/pt_image" />
 
-        <ImageView
-            android:id="@+id/cta2"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:layout_margin="4dp"
-            android:contentDescription="@null"
-            android:visibility="gone"
-            android:src="@drawable/pt_image" />
+    <ImageView
+        android:id="@+id/cta4"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_margin="4dp"
+        android:contentDescription="@null"
+        android:visibility="gone"
+        android:src="@drawable/pt_image" />
 
-        <ImageView
-            android:id="@+id/cta3"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:layout_margin="4dp"
-            android:contentDescription="@null"
-            android:visibility="gone"
-            android:src="@drawable/pt_image" />
-
-        <ImageView
-            android:id="@+id/cta4"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:layout_margin="4dp"
-            android:contentDescription="@null"
-            android:visibility="gone"
-            android:src="@drawable/pt_image" />
-
-        <ImageView
-            android:id="@+id/cta5"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:layout_margin="4dp"
-            android:contentDescription="@null"
-            android:visibility="gone"
-            android:src="@drawable/pt_image" />
-    </LinearLayout>
+    <ImageView
+        android:id="@+id/cta5"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:layout_margin="4dp"
+        android:contentDescription="@null"
+        android:visibility="gone"
+        android:src="@drawable/pt_image" />
 </LinearLayout>

--- a/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed_with_text.xml
+++ b/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed_with_text.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/content_view_big"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@android:color/transparent"
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/rel_lyt"
+        layout="@layout/content_view_small_single_line_msg" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:orientation="horizontal"
+        android:padding="@dimen/five_cta_padding">
+
+        <ImageView
+            android:id="@+id/cta1"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:contentDescription="@null"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
+
+        <ImageView
+            android:id="@+id/cta2"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:contentDescription="@null"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
+
+        <ImageView
+            android:id="@+id/cta3"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:contentDescription="@null"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
+
+        <ImageView
+            android:id="@+id/cta4"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:contentDescription="@null"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
+
+        <ImageView
+            android:id="@+id/cta5"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:contentDescription="@null"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
+    </LinearLayout>
+</LinearLayout>

--- a/clevertap-pushtemplates/src/main/res/layout/five_cta_expanded.xml
+++ b/clevertap-pushtemplates/src/main/res/layout/five_cta_expanded.xml
@@ -2,52 +2,63 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/content_view_big"
     android:layout_width="match_parent"
-    android:layout_height="64dp"
+    android:layout_height="wrap_content"
     android:background="@android:color/transparent"
-    android:padding="@dimen/five_cta_padding"
-    android:orientation="horizontal">
+    android:orientation="vertical">
 
-    <ImageView android:id="@+id/cta1"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:layout_margin="4dp"
-        android:visibility="gone"
-        android:src="@drawable/pt_image"/>
+    <include
+        android:id="@+id/rel_lyt"
+        layout="@layout/content_view_small_multi_line_msg" />
 
-    <ImageView
-        android:id="@+id/cta2"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:layout_margin="4dp"
-        android:visibility="gone"
-        android:src="@drawable/pt_image" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="64dp"
+        android:orientation="horizontal"
+        android:padding="@dimen/five_cta_padding">
 
-    <ImageView
-        android:id="@+id/cta3"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:layout_margin="4dp"
-        android:visibility="gone"
-        android:src="@drawable/pt_image" />
+        <ImageView
+            android:id="@+id/cta1"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
 
-    <ImageView
-        android:id="@+id/cta4"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:layout_margin="4dp"
-        android:visibility="gone"
-        android:src="@drawable/pt_image" />
+        <ImageView
+            android:id="@+id/cta2"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
 
-    <ImageView
-        android:id="@+id/cta5"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_weight="1"
-        android:layout_margin="4dp"
-        android:visibility="gone"
-        android:src="@drawable/pt_image" />
+        <ImageView
+            android:id="@+id/cta3"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
+
+        <ImageView
+            android:id="@+id/cta4"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
+
+        <ImageView
+            android:id="@+id/cta5"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:layout_margin="4dp"
+            android:visibility="gone"
+            android:src="@drawable/pt_image" />
+    </LinearLayout>
 </LinearLayout>

--- a/clevertap-pushtemplates/src/main/res/layout/five_cta_expanded.xml
+++ b/clevertap-pushtemplates/src/main/res/layout/five_cta_expanded.xml
@@ -22,6 +22,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
+            android:contentDescription="@null"
             android:visibility="gone"
             android:src="@drawable/pt_image" />
 
@@ -31,6 +32,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
+            android:contentDescription="@null"
             android:visibility="gone"
             android:src="@drawable/pt_image" />
 
@@ -40,6 +42,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
+            android:contentDescription="@null"
             android:visibility="gone"
             android:src="@drawable/pt_image" />
 
@@ -49,6 +52,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
+            android:contentDescription="@null"
             android:visibility="gone"
             android:src="@drawable/pt_image" />
 
@@ -58,6 +62,7 @@
             android:layout_height="match_parent"
             android:layout_weight="1"
             android:layout_margin="4dp"
+            android:contentDescription="@null"
             android:visibility="gone"
             android:src="@drawable/pt_image" />
     </LinearLayout>

--- a/clevertap-pushtemplates/src/main/res/values/strings.xml
+++ b/clevertap-pushtemplates/src/main/res/values/strings.xml
@@ -10,4 +10,9 @@
     <string name="rating_star_4">Rating Four Star</string>
     <string name="rating_star_5">Rating Five Star</string>
     <string name="pt_big_image_alt">Notification Image</string>
+    <string name="pt_five_icon_1">Notification Icon 1</string>
+    <string name="pt_five_icon_2">Notification Icon 2</string>
+    <string name="pt_five_icon_3">Notification Icon 3</string>
+    <string name="pt_five_icon_4">Notification Icon 4</string>
+    <string name="pt_five_icon_5">Notification Icon 5</string>
 </resources>

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
@@ -605,6 +605,19 @@ class TemplateDataFactoryTest {
     }
 
     @Test
+    fun `FiveIconsTemplateData_toBasicTemplateData should create correct BasicTemplateData`() {
+        // Given
+        val fiveIconsData = createSampleFiveIconsTemplateData()
+
+        // When
+        val basicData = with(TemplateDataFactory) { fiveIconsData.toBasicTemplateData() }
+
+        // Then
+        assertEquals(TemplateType.BASIC, basicData.templateType)
+        assertEquals(fiveIconsData.baseContent, basicData.baseContent)
+    }
+
+    @Test
     fun `InputBoxTemplateData_toBaseContent should create correct BaseContent`() {
         // Given
         val inputBoxData = createSampleInputBoxTemplateData()

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
@@ -229,8 +229,8 @@ class TemplateDataFactoryTest {
         val fiveIconsData = result as FiveIconsTemplateData
         assertEquals(TemplateType.FIVE_ICONS, fiveIconsData.templateType)
         assertEquals(imageList, fiveIconsData.imageList)
-        assertEquals(deepLinkList, fiveIconsData.deepLinkList)
-        assertEquals(SAMPLE_TITLE, fiveIconsData.title)
+        assertEquals(deepLinkList, fiveIconsData.baseContent.deepLinkList)
+        assertEquals(SAMPLE_TITLE, fiveIconsData.baseContent.textData.title)
     }
 
     @Test
@@ -593,18 +593,15 @@ class TemplateDataFactoryTest {
     }
 
     @Test
-    fun `FiveIconsTemplateData_toBaseContent should create correct BaseContent`() {
+    fun `FiveIconsTemplateData should expose correct BaseContent`() {
         // Given
         val fiveIconsData = createSampleFiveIconsTemplateData()
 
-        // When
-        val baseContent = with(TemplateDataFactory) { fiveIconsData.toBaseContent() }
-
         // Then
-        assertEquals(fiveIconsData.title, baseContent.textData.title)
-        assertEquals(fiveIconsData.subtitle, baseContent.textData.subtitle)
-        assertEquals(fiveIconsData.backgroundColor, baseContent.colorData.backgroundColor)
-        assertEquals(fiveIconsData.deepLinkList, baseContent.deepLinkList)
+        assertEquals(SAMPLE_TITLE, fiveIconsData.baseContent.textData.title)
+        assertEquals(SAMPLE_SUBTITLE, fiveIconsData.baseContent.textData.subtitle)
+        assertEquals(SAMPLE_COLOR, fiveIconsData.baseContent.colorData.backgroundColor)
+        assertEquals(arrayListOf("dl1", "dl2"), fiveIconsData.baseContent.deepLinkList)
     }
 
     @Test
@@ -893,12 +890,17 @@ class TemplateDataFactoryTest {
 
     private fun createSampleFiveIconsTemplateData(): FiveIconsTemplateData {
         return FiveIconsTemplateData(
+            baseContent = BaseContent(
+                textData = BaseTextData(
+                    title = SAMPLE_TITLE,
+                    subtitle = SAMPLE_SUBTITLE
+                ),
+                colorData = BaseColorData(backgroundColor = SAMPLE_COLOR),
+                iconData = IconData(),
+                deepLinkList = arrayListOf("dl1", "dl2"),
+                notificationBehavior = NotificationBehavior()
+            ),
             imageList = arrayListOf(),
-            deepLinkList = arrayListOf("dl1", "dl2"),
-            backgroundColor = SAMPLE_COLOR,
-            title = SAMPLE_TITLE,
-            subtitle = SAMPLE_SUBTITLE,
-            notificationBehavior = NotificationBehavior()
         )
     }
 
@@ -961,8 +963,8 @@ class TemplateDataFactoryTest {
         // Then
         assertTrue(result is FiveIconsTemplateData)
         val fiveIconsData = result as FiveIconsTemplateData
-        assertFalse(fiveIconsData.notificationBehavior.isSticky)
-        assertNull(fiveIconsData.notificationBehavior.dismissAfter)
+        assertFalse(fiveIconsData.baseContent.notificationBehavior.isSticky)
+        assertNull(fiveIconsData.baseContent.notificationBehavior.dismissAfter)
     }
 
     @Test

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
@@ -2412,7 +2412,8 @@ class TemplateDataFactoryTest {
 
         // Then
         assertNotNull(result.collapsedButtonData)
-        assertEquals(PT_BTN_BORDER_RADIUS_DEFAULT, result.collapsedButtonData!!.borderRadius)
-        assertEquals(PT_BTN_BORDER_WIDTH_DEFAULT, result.collapsedButtonData!!.borderWidth)
+        val collapsedButtonData = result.collapsedButtonData ?: error("collapsedButtonData should not be null")
+        assertEquals(PT_BTN_BORDER_RADIUS_DEFAULT, collapsedButtonData.borderRadius)
+        assertEquals(PT_BTN_BORDER_WIDTH_DEFAULT, collapsedButtonData.borderWidth)
     }
 }

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
@@ -615,6 +615,9 @@ class TemplateDataFactoryTest {
         // Then
         assertEquals(TemplateType.BASIC, basicData.templateType)
         assertEquals(fiveIconsData.baseContent, basicData.baseContent)
+        assertNull(basicData.actions)
+        assertNull(basicData.mediaData.bigImage.url)
+        assertNull(basicData.mediaData.gif.url)
     }
 
     @Test

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateRendererTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateRendererTest.kt
@@ -461,6 +461,7 @@ class TemplateRendererTest {
         fiveIconsBundle.putString(PTConstants.PT_ID, "pt_five_icons")
 
         val templateRendererLocal = TemplateRenderer(context, fiveIconsBundle, mockConfig)
+        val mockFiveIconsFallbackData = mockk<BasicTemplateData>(relaxed = true)
 
         // Arrange
         every {
@@ -474,6 +475,19 @@ class TemplateRendererTest {
         } returns mockFiveIconsTemplateData
         every { ValidatorFactory.getValidator(mockFiveIconsTemplateData) } returns mockContentValidator
         every { mockContentValidator.validate() } returns false
+        every { with(TemplateDataFactory) { mockFiveIconsTemplateData.toBasicTemplateData() } } returns mockFiveIconsFallbackData
+        every { ValidatorFactory.getValidator(mockFiveIconsFallbackData) } returns mockContentValidator
+        every { mockContentValidator.validate() } returnsMany listOf(false, true)
+
+        mockkConstructor(BasicStyle::class)
+        every {
+            anyConstructed<BasicStyle>().builderFromStyle(
+                any(),
+                fiveIconsBundle,
+                123,
+                mockNotificationBuilder
+            )
+        } returns mockNotificationBuilder
 
         // Act
         val result = templateRendererLocal.renderNotification(
@@ -485,7 +499,7 @@ class TemplateRendererTest {
         )
 
         // Assert
-        assertNull(result)
+        assertEquals(mockNotificationBuilder, result)
     }
 
     @Test
@@ -1120,6 +1134,7 @@ class TemplateRendererTest {
         fiveIconsBundle.putString(PTConstants.PT_ID, "pt_five_icons")
 
         val templateRendererLocal = TemplateRenderer(context, fiveIconsBundle, mockConfig)
+        val mockFiveIconsFallbackData = mockk<BasicTemplateData>(relaxed = true)
 
         every {
             TemplateDataFactory.createTemplateData(
@@ -1132,6 +1147,9 @@ class TemplateRendererTest {
         } returns mockFiveIconsTemplateData
         every { ValidatorFactory.getValidator(mockFiveIconsTemplateData) } returns mockContentValidator
         every { mockContentValidator.validate() } returns true
+        every { with(TemplateDataFactory) { mockFiveIconsTemplateData.toBasicTemplateData() } } returns mockFiveIconsFallbackData
+        every { ValidatorFactory.getValidator(mockFiveIconsFallbackData) } returns mockContentValidator
+        every { mockContentValidator.validate() } returnsMany listOf(true, true)
 
         val mockSmallContentView = mockk<FiveIconSmallContentView>()
         val mockBigContentView = mockk<FiveIconBigContentView>()
@@ -1149,6 +1167,15 @@ class TemplateRendererTest {
         } returns mockNotificationBuilder
         every { anyConstructed<FiveIconStyle>().fiveIconSmallContentView } returns mockSmallContentView
         every { anyConstructed<FiveIconStyle>().fiveIconBigContentView } returns mockBigContentView
+        mockkConstructor(BasicStyle::class)
+        every {
+            anyConstructed<BasicStyle>().builderFromStyle(
+                any(),
+                fiveIconsBundle,
+                123,
+                mockNotificationBuilder
+            )
+        } returns mockNotificationBuilder
 
         // Act
         val result = templateRendererLocal.renderNotification(
@@ -1159,7 +1186,7 @@ class TemplateRendererTest {
             123
         )
 
-        assertNull(result)
+        assertEquals(mockNotificationBuilder, result)
     }
 
 
@@ -1170,6 +1197,7 @@ class TemplateRendererTest {
         fiveIconsBundle.putString(PTConstants.PT_ID, "pt_five_icons")
 
         val templateRendererLocal = TemplateRenderer(context, fiveIconsBundle, mockConfig)
+        val mockFiveIconsFallbackData = mockk<BasicTemplateData>(relaxed = true)
 
         every {
             TemplateDataFactory.createTemplateData(
@@ -1182,6 +1210,9 @@ class TemplateRendererTest {
         } returns mockFiveIconsTemplateData
         every { ValidatorFactory.getValidator(mockFiveIconsTemplateData) } returns mockContentValidator
         every { mockContentValidator.validate() } returns true
+        every { with(TemplateDataFactory) { mockFiveIconsTemplateData.toBasicTemplateData() } } returns mockFiveIconsFallbackData
+        every { ValidatorFactory.getValidator(mockFiveIconsFallbackData) } returns mockContentValidator
+        every { mockContentValidator.validate() } returnsMany listOf(true, true)
 
         val mockSmallContentView = mockk<FiveIconSmallContentView>()
         val mockBigContentView = mockk<FiveIconBigContentView>()
@@ -1199,6 +1230,15 @@ class TemplateRendererTest {
         } returns mockNotificationBuilder
         every { anyConstructed<FiveIconStyle>().fiveIconSmallContentView } returns mockSmallContentView
         every { anyConstructed<FiveIconStyle>().fiveIconBigContentView } returns mockBigContentView
+        mockkConstructor(BasicStyle::class)
+        every {
+            anyConstructed<BasicStyle>().builderFromStyle(
+                any(),
+                fiveIconsBundle,
+                123,
+                mockNotificationBuilder
+            )
+        } returns mockNotificationBuilder
 
         // Act
         val result = templateRendererLocal.renderNotification(
@@ -1209,7 +1249,7 @@ class TemplateRendererTest {
             123
         )
 
-        assertNull(result)
+        assertEquals(mockNotificationBuilder, result)
     }
 
     @Test

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateRendererTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateRendererTest.kt
@@ -1253,64 +1253,6 @@ class TemplateRendererTest {
     }
 
     @Test
-    fun test_renderNotification_five_icons_template_invalid_unloaded_icons() {
-        // Arrange
-        val fiveIconsBundle = Bundle(testBundle)
-        fiveIconsBundle.putString(PTConstants.PT_ID, "pt_five_icons")
-
-        val templateRendererLocal = TemplateRenderer(context, fiveIconsBundle, mockConfig)
-
-        every {
-            TemplateDataFactory.createTemplateData(
-                TemplateType.FIVE_ICONS,
-                fiveIconsBundle,
-                false,
-                any(),
-                any()
-            )
-        } returns mockFiveIconsTemplateData
-        every { ValidatorFactory.getValidator(mockFiveIconsTemplateData) } returns mockContentValidator
-        every { mockContentValidator.validate() } returns true
-
-        val mockSmallContentView = mockk<FiveIconSmallContentView>()
-        val mockBigContentView = mockk<FiveIconBigContentView>()
-        every { mockSmallContentView.getUnloadedFiveIconsCount() } returns 3 // More than 2
-        every { mockBigContentView.getUnloadedFiveIconsCount() } returns 1
-
-        mockkConstructor(FiveIconStyle::class)
-        every {
-            anyConstructed<FiveIconStyle>().builderFromStyle(
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns mockNotificationBuilder
-        every { anyConstructed<FiveIconStyle>().fiveIconSmallContentView } returns mockSmallContentView
-        every { anyConstructed<FiveIconStyle>().fiveIconBigContentView } returns mockBigContentView
-
-        // Act
-        val result = templateRendererLocal.renderNotification(
-            fiveIconsBundle,
-            context,
-            mockNotificationBuilder,
-            mockConfig,
-            123
-        )
-
-        // Assert
-        verify {
-            anyConstructed<FiveIconStyle>().builderFromStyle(
-                any(),
-                fiveIconsBundle,
-                123,
-                mockNotificationBuilder
-            )
-        }
-        assertNull(result) // Should return null when too many unloaded icons
-    }
-
-    @Test
     fun test_renderNotification_product_display_template_valid() {
         // Arrange
         val productBundle = Bundle(testBundle)

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -57,7 +57,7 @@
         <!-- Add meta data for CleverTap Account Id and Account Token and Region-->
         <meta-data
             android:name="CLEVERTAP_ACCOUNT_ID"
-            android:value="449-RW6-794Z" />
+            android:value="YOUR ACCT ID" />
         <meta-data
             android:name="CLEVERTAP_TOKEN"
             android:value="602-c44" />

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
             android:value="YOUR ACCT ID" />
         <meta-data
             android:name="CLEVERTAP_TOKEN"
-            android:value="602-c44" />
+            android:value="YOUR ACCT TOKEN" />
         <meta-data
             android:name="CLEVERTAP_REGION"
             android:value="eu1"/>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -57,13 +57,13 @@
         <!-- Add meta data for CleverTap Account Id and Account Token and Region-->
         <meta-data
             android:name="CLEVERTAP_ACCOUNT_ID"
-            android:value="YOUR ACCT ID" />
+            android:value="449-RW6-794Z" />
         <meta-data
             android:name="CLEVERTAP_TOKEN"
-            android:value="YOUR ACCT TOKEN" />
+            android:value="602-c44" />
         <meta-data
             android:name="CLEVERTAP_REGION"
-            android:value="YOUR ACCT REGION"/>
+            android:value="eu1"/>
         <meta-data
             android:name="CLEVERTAP_HANDSHAKE_DOMAIN"
             android:value="YOUR HANDSHAKE DOMAIN"/>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -63,7 +63,7 @@
             android:value="YOUR ACCT TOKEN" />
         <meta-data
             android:name="CLEVERTAP_REGION"
-            android:value="eu1"/>
+            android:value="YOUR ACCT REGION"/>
         <meta-data
             android:name="CLEVERTAP_HANDSHAKE_DOMAIN"
             android:value="YOUR HANDSHAKE DOMAIN"/>


### PR DESCRIPTION
## Summary
- add title and message support to the five icons push template
- align five icons data/validation with `baseContent`
- add a basic notification fallback when five icons is invalid or most icon images fail to load

## Testing
- ran `TemplateDataFactoryTest`
- ran `TemplateRendererTest`
- manually verified five icons renders title/message above the icon row
- manually verified invalid/missing icon scenarios fall back to basic title/message notification


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved five-icons push template behavior: when validation fails or icon images can’t load, the notification now reliably falls back to a basic layout.
  * Deep-link values and pending-intent handling were corrected so taps use the intended destination.
  * Notification sound and collapse-key handling were improved for more consistent results.

* **New Features**
  * Added a new collapsed-with-text variant layout for five-icon CTA templates.

* **Chores**
  * Refreshed five-icons collapsed/expanded layout structure and updated sample manifest configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->