### PR TITLE
ci: add Vision AI Review workflow

### DIFF
--- a/.github/workflows/vision-ai-review.yml
+++ b/.github/workflows/vision-ai-review.yml
@@ -1,0 +1,93 @@
+name: Vision AI Review
+
+# Secrets required (configure in repo settings):
+#   CF_REVIEW_NOTIFIER_CLIENT_ID
+#   CF_REVIEW_NOTIFIER_CLIENT_SECRET
+#
+# No GitHub App token is needed — the PR number is read directly from the
+# event payload (github.event.issue.number / github.event.pull_request.number)
+# and the actual review is generated server-side by review-notifier, which
+# handles its own GitHub auth via the Vision Bot installation.
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  # Auto-trigger on PR open / ready-for-review / non-draft push.
+  # Drafts are skipped on all three actions so we don't pay twice when a PR
+  # is opened-as-draft and later marked ready. Fork PRs are also skipped:
+  # untrusted code must not trigger our backend.
+  on-pr:
+    if: >-
+      ${{
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.draft == false &&
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'ready_for_review' ||
+          github.event.action == 'synchronize'
+        )
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger review
+        env:
+          REPO:          ${{ github.repository }}
+          PR_NUMBER:     ${{ github.event.pull_request.number }}
+          CLIENT_ID:     ${{ secrets.CF_REVIEW_NOTIFIER_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CF_REVIEW_NOTIFIER_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          payload=$(jq -n \
+            --argjson pullRequestId "$PR_NUMBER" \
+            --arg repo "$REPO" \
+            '{pullRequestId: $pullRequestId, repo: $repo}')
+          echo "Triggering Vision AI review for $REPO PR #$PR_NUMBER..."
+          curl --fail --show-error --silent --max-time 30 -X POST \
+            -H "Content-Type: application/json" \
+            -H "CF-Access-Client-Id: $CLIENT_ID" \
+            -H "CF-Access-Client-Secret: $CLIENT_SECRET" \
+            -d "$payload" \
+            https://review-notifier.clevertap.net/review-with-claude-code
+
+  # On-demand `/vision-review-deep` PR comment.
+  # Gated so only repo members can trigger — otherwise anyone could spam reviews.
+  on-comment:
+    if: >-
+      ${{
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request.url != '' &&
+        github.event.comment.body == '/vision-review-deep' &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger review
+        env:
+          REPO:          ${{ github.repository }}
+          PR_NUMBER:     ${{ github.event.issue.number }}
+          CLIENT_ID:     ${{ secrets.CF_REVIEW_NOTIFIER_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CF_REVIEW_NOTIFIER_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          payload=$(jq -n \
+            --argjson pullRequestId "$PR_NUMBER" \
+            --arg repo "$REPO" \
+            '{pullRequestId: $pullRequestId, repo: $repo}')
+          echo "Triggering Vision AI review for $REPO PR #$PR_NUMBER..."
+          curl --fail --show-error --silent --max-time 30 -X POST \
+            -H "Content-Type: application/json" \
+            -H "CF-Access-Client-Id: $CLIENT_ID" \
+            -H "CF-Access-Client-Secret: $CLIENT_SECRET" \
+            -d "$payload" \
+            https://review-notifier.clevertap.net/review-with-claude-code


### PR DESCRIPTION
> **Draft** — needs `CF_REVIEW_NOTIFIER_CLIENT_ID` and `CF_REVIEW_NOTIFIER_CLIENT_SECRET` secrets added to this repo (Settings → Secrets and variables → Actions) before this is mergeable. This repo lives in the `CleverTap` org which isn't Terraform-managed, so they need to be set via the GitHub UI.

Wires up Vision AI code review on this repo.

## Triggers
- Auto on `opened`, `ready_for_review`, and non-draft `synchronize` (drafts and fork PRs are skipped).
- On-demand via `/vision-review-deep` PR comments — gated to OWNER / MEMBER / COLLABORATOR so external commenters can't burn review budget.

## What happens on trigger
Workflow POSTs `{pullRequestId, repo}` to `review-notifier.clevertap.net/review-with-claude-code` (behind Cloudflare Access). The backend generates the review and posts results back via its own GitHub App auth — this workflow doesn't need a GitHub App token in the runner.

## Hardening
- `permissions: {}` at the top level — workflow never calls the GitHub API, so `GITHUB_TOKEN` gets zero scopes.
- `curl --fail --show-error --silent --max-time 30` so 4xx/5xx and stalled backends surface as workflow failures.
- Fork-PR filter: `head.repo.full_name == github.repository` — external PRs don't trigger the backend.
- `author_association` gate on `/vision-review-deep` — only repo members can invoke.

## Test plan (after secrets are added and PR is marked ready)
- [ ] Add `CF_REVIEW_NOTIFIER_CLIENT_ID` + `CF_REVIEW_NOTIFIER_CLIENT_SECRET` repo secrets
- [ ] Mark PR ready for review
- [ ] Open a small test PR → verify the AI review comment appears within a few minutes
- [ ] Comment `/vision-review-deep` on the test PR → verify a re-run is triggered
- [ ] Open a PR from a fork → verify nothing is triggered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated code review workflow for internal development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->