### PR TITLE
ci: gate /vision-review-deep on same-repo PRs only

### DIFF
--- a/.github/workflows/vision-ai-review.yml
+++ b/.github/workflows/vision-ai-review.yml
@@ -57,7 +57,9 @@ jobs:
             https://review-notifier.clevertap.net/review-with-claude-code
 
   # On-demand `/vision-review-deep` PR comment.
-  # Gated so only repo members can trigger — otherwise anyone could spam reviews.
+  # Gated so only repo members can trigger, AND only on same-repo PRs.
+  # issue_comment events don't expose pull_request.head.repo, so we fetch
+  # the PR via the API and check head.repo.full_name before triggering.
   on-comment:
     if: >-
       ${{
@@ -71,8 +73,25 @@ jobs:
         )
       }}
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
+      - name: Resolve PR head repo
+        id: pr
+        env:
+          PR_URL:   ${{ github.event.issue.pull_request.url }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          head=$(curl --fail --show-error --silent --max-time 15 \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_TOKEN" \
+            "$PR_URL" | jq -r '.head.repo.full_name')
+          echo "PR head repo: $head"
+          echo "head=$head" >> "$GITHUB_OUTPUT"
+
       - name: Trigger review
+        if: steps.pr.outputs.head == github.repository
         env:
           REPO:          ${{ github.repository }}
           PR_NUMBER:     ${{ github.event.issue.number }}
@@ -91,3 +110,8 @@ jobs:
             -H "CF-Access-Client-Secret: $CLIENT_SECRET" \
             -d "$payload" \
             https://review-notifier.clevertap.net/review-with-claude-code
+
+      - name: Skipped (fork PR)
+        if: steps.pr.outputs.head != github.repository
+        run: |
+          echo "PR head '${{ steps.pr.outputs.head }}' is not '${{ github.repository }}'; skipping fork PR."


### PR DESCRIPTION
Follow-up to #1014 addressing the [CodeRabbit review feedback](https://github.com/CleverTap/clevertap-android-sdk/pull/1014#pullrequestreview-4399606852).

## What this fixes
The `on-pr` job already skips fork PRs (`head.repo.full_name == github.repository`), but the `on-comment` job was firing on any PR a repo member commented on — including forks. Makes the behavior uniform across both triggers.

## Implementation
- Adds a small `pull-requests: read` scope on the `on-comment` job (`issue_comment` payload doesn't include `pull_request.head.repo`, so we fetch the PR via API to check).
- Resolves the PR head via `github.event.issue.pull_request.url`, extracts `head.repo.full_name`.
- Trigger step is gated on `steps.pr.outputs.head == github.repository`.
- A separate "Skipped (fork PR)" step logs the skip so it's visible in the Actions UI.

## Not addressed (intentional)
CodeRabbit also flagged a `concurrency` block as a nit. Skipped because our workflow is fire-and-forget — the POST to the backend completes within the workflow's runtime, and the backend already dedups via `latest_review_ids` on its end. `cancel-in-progress` would mostly cancel workflows that have already POSTed.

## Test plan
- [ ] Comment `/vision-review-deep` on a same-repo PR — verify the trigger step runs
- [ ] Comment `/vision-review-deep` on a fork PR — verify the "Skipped (fork PR)" step runs and the notifier is NOT called

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved safety handling for fork pull requests in the AI review workflow to prevent unintended review triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->