### PR TITLE
task(SDK-5810): Implement Split-of-clicks feature 

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
@@ -454,10 +454,10 @@ public class AnalyticsManager extends BaseAnalyticsManager {
                 for (String x : customData.keySet()) {
 
                     Object value = customData.get(x);
-                    if (value instanceof Bundle) {
+                    if (value instanceof Map) {
                         // Nested payloads (e.g. wzrk_data for a key-values action) are carried as a
-                        // Bundle and emitted as a nested JSON object.
-                        notif.put(x, new JSONObject(Utils.convertBundleObjectToHashMap((Bundle) value)));
+                        // Map and emitted as a nested JSON object.
+                        notif.put(x, new JSONObject((Map<?, ?>) value));
                     } else if (value != null) {
                         notif.put(x, value);
                     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
@@ -454,7 +454,11 @@ public class AnalyticsManager extends BaseAnalyticsManager {
                 for (String x : customData.keySet()) {
 
                     Object value = customData.get(x);
-                    if (value != null) {
+                    if (value instanceof Bundle) {
+                        // Nested payloads (e.g. wzrk_data for a key-values action) are carried as a
+                        // Bundle and emitted as a nested JSON object.
+                        notif.put(x, new JSONObject(Utils.convertBundleObjectToHashMap((Bundle) value)));
+                    } else if (value != null) {
                         notif.put(x, value);
                     }
                 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTWebInterface.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTWebInterface.java
@@ -423,8 +423,9 @@ public class CTWebInterface {
             }
 
             Bundle actionData = new Bundle();
+            // Element identity flows only through wzrk_element_id; button_id is no longer emitted.
             if (buttonId != null) {
-                actionData.putString("button_id", buttonId);
+                actionData.putString(Constants.KEY_WZRK_ELEMENT_ID, buttonId);
             }
 
             fragment.triggerAction(action, callToAction, actionData);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
@@ -508,6 +508,7 @@ internal object CleverTapFactory {
             SYSTEM,
             networkMonitor,
             pipManager,
+            validationResultStack,
         )
         controllerManager.inAppController = inAppController
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -178,6 +178,9 @@ public interface Constants {
     String KEY_WZRK_ACTION = "wzrk_action";
     String KEY_WZRK_DATA = "wzrk_data";
 
+    // key for parsing
+    String KEY_SWIPE_TO_DISMISS = "swipe-dismiss";
+
     // wzrk_element_id values
     String INAPP_ELEMENT_ID_IMAGE = "image-1";
     String INAPP_ELEMENT_ID_CLOSE = "closeButton";
@@ -185,8 +188,7 @@ public interface Constants {
 
     // wzrk_c2a values for dismiss gestures
     String INAPP_CTA_DISMISS_BUTTON = "Dismiss Button";
-    String KEY_SWIPE_TO_DISMISS = "swipe-dismiss";
-    String KEY_TAP_OUTSIDE_DISMISS = "tap-outside-dismiss";
+    String INAPP_CTA_SWIPE_DISMISS = "Swipe to Dismiss";
 
     // wzrk_data literal value for a close action
     String INAPP_WZRK_DATA_CLOSE = "close";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -172,6 +172,36 @@ public interface Constants {
     String IMAGE_PLACEHOLDER = "ct_image";
     String KEY_CONFIG = "config";
     String KEY_C2A = "wzrk_c2a";
+
+    // Split-of-clicks: per-element identity + action descriptors (must match iOS wire contract)
+    String KEY_WZRK_ELEMENT_ID = "wzrk_element_id";
+    String KEY_WZRK_ACTION = "wzrk_action";
+    String KEY_WZRK_DATA = "wzrk_data";
+
+    // wzrk_element_id values
+    String INAPP_ELEMENT_ID_IMAGE = "image-1";
+    String INAPP_ELEMENT_ID_CLOSE = "closeButton";
+    String INAPP_ELEMENT_ID_BUTTON_PREFIX = "button-";
+
+    // wzrk_c2a values for dismiss gestures
+    String INAPP_CTA_DISMISS_BUTTON = "Dismiss Button";
+    String KEY_SWIPE_TO_DISMISS = "swipe-dismiss";
+    String KEY_TAP_OUTSIDE_DISMISS = "tap-outside-dismiss";
+
+    // wzrk_data literal value for a close action
+    String INAPP_WZRK_DATA_CLOSE = "close";
+
+    // Media-error synthetic-close descriptors emitted by the bundled advanced-builder HTML template
+    String INAPP_CTA_IMAGE_ERROR_DISMISS = "image-error-dismiss";
+    String INAPP_CTA_VIDEO_ERROR_DISMISS = "video-error-dismiss";
+
+    // wzrk_error codes/messages for media preload failures.
+    // NOTE: 591/592 are placeholders and MUST be finalized with the backend decoder and kept identical on iOS + Android.
+    int INAPP_IMAGE_LOAD_FAILED_ERROR_CODE = 591;
+    int INAPP_VIDEO_LOAD_FAILED_ERROR_CODE = 592;
+    String INAPP_IMAGE_LOAD_FAILED_ERROR_MSG = "InApp image failed to load";
+    String INAPP_VIDEO_LOAD_FAILED_ERROR_MSG = "InApp video failed to load";
+
     String KEY_EFC = "efc";
     String KEY_EXCLUDE_GLOBAL_CAPS = "excludeGlobalFCaps";
     String KEY_TLC = "tlc";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -196,7 +196,6 @@ public interface Constants {
     String INAPP_CTA_VIDEO_ERROR_DISMISS = "video-error-dismiss";
 
     // wzrk_error codes/messages for media preload failures.
-    // NOTE: 591/592 are placeholders and MUST be finalized with the backend decoder and kept identical on iOS + Android.
     int INAPP_IMAGE_LOAD_FAILED_ERROR_CODE = 591;
     int INAPP_VIDEO_LOAD_FAILED_ERROR_CODE = 592;
     String INAPP_IMAGE_LOAD_FAILED_ERROR_MSG = "InApp image failed to load";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -209,10 +209,11 @@ public final class InAppNotificationActivity extends FragmentActivity implements
     public Bundle inAppNotificationDidClick(
             @NonNull final CTInAppNotification inAppNotification,
             @NonNull final CTInAppNotificationButton button,
+            final int buttonIndex,
             @Nullable final Context activityContext) {
         InAppListener listener = getListener();
         if (listener != null) {
-            return listener.inAppNotificationDidClick(inAppNotification, button, this);
+            return listener.inAppNotificationDidClick(inAppNotification, button, buttonIndex, this);
         } else {
             return null;
         }
@@ -332,10 +333,10 @@ public final class InAppNotificationActivity extends FragmentActivity implements
     }
 
     @Nullable
-    private Bundle didClick(CTInAppNotificationButton button) {
+    private Bundle didClick(CTInAppNotificationButton button, int buttonIndex) {
         InAppListener listener = getListener();
         if (listener != null) {
-            return listener.inAppNotificationDidClick(inAppNotification, button, this);
+            return listener.inAppNotificationDidClick(inAppNotification, button, buttonIndex, this);
         } else {
             return null;
         }
@@ -414,14 +415,14 @@ public final class InAppNotificationActivity extends FragmentActivity implements
                     .setTitle(inAppNotification.getTitle())
                     .setMessage(inAppNotification.getMessage())
                     .setPositiveButton(positiveButton.getText(),
-                            (dialogInterface, i) -> onAlertButtonClick(positiveButton, true))
+                            (dialogInterface, i) -> onAlertButtonClick(positiveButton, 0, true))
                     .create();
 
             if (inAppNotification.getButtons().size() == 2) {
                 CTInAppNotificationButton negativeButton = buttons.get(1);
                 alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE,
                         negativeButton.getText(),
-                        (dialog, which) -> onAlertButtonClick(negativeButton, false));
+                        (dialog, which) -> onAlertButtonClick(negativeButton, 1, false));
             }
 
         //By default, we will allow 2 button alerts and set a third button if it is configured
@@ -429,7 +430,7 @@ public final class InAppNotificationActivity extends FragmentActivity implements
             CTInAppNotificationButton button = buttons.get(2);
             alertDialog.setButton(DialogInterface.BUTTON_NEUTRAL,
                     button.getText(),
-                    (dialogInterface, i) -> onAlertButtonClickLegacy(button));
+                    (dialogInterface, i) -> onAlertButtonClickLegacy(button, 2));
         }
 
         alertDialog.show();
@@ -437,13 +438,13 @@ public final class InAppNotificationActivity extends FragmentActivity implements
         didShow(null);
     }
 
-    private void onAlertButtonClickLegacy(final CTInAppNotificationButton button) {
-        Bundle clickData = didClick(button);
+    private void onAlertButtonClickLegacy(final CTInAppNotificationButton button, int buttonIndex) {
+        Bundle clickData = didClick(button, buttonIndex);
         didDismiss(clickData);
     }
 
-    private void onAlertButtonClick(CTInAppNotificationButton button, boolean isPositive) {
-        Bundle clickData = didClick(button);
+    private void onAlertButtonClick(CTInAppNotificationButton button, int buttonIndex, boolean isPositive) {
+        Bundle clickData = didClick(button, buttonIndex);
 
         if (inAppNotification.isLocalInApp()) {
             if(isPositive) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppNotification.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppNotification.kt
@@ -79,6 +79,16 @@ class CTInAppNotification : Parcelable {
     var isRequestForPushPermission: Boolean = false
         private set
 
+    /**
+     * Per-campaign dismiss-gesture flags. Default to `true` when the JSON key is absent or an
+     * explicit null (parsed null-safely via [org.json.JSONObject.optBoolean]).
+     */
+    var tapOutsideDismiss: Boolean = true
+        private set
+
+    var swipeToDismiss: Boolean = true
+        private set
+
     internal var customTemplateData: CustomTemplateInAppData? = null
         private set
 
@@ -161,6 +171,10 @@ class CTInAppNotification : Parcelable {
             } else {
                 configureWithJson(jsonObject)
             }
+            // Take the server value when present (boolean or 0/1); absent key or explicit JSON null
+            // falls back to true.
+            tapOutsideDismiss = parseDismissFlag(jsonObject, Constants.KEY_TAP_OUTSIDE_DISMISS)
+            swipeToDismiss = parseDismissFlag(jsonObject, Constants.KEY_SWIPE_TO_DISMISS)
         } catch (e: JSONException) {
             error = "Invalid JSON: ${e.localizedMessage}"
         }
@@ -229,6 +243,8 @@ class CTInAppNotification : Parcelable {
             parcel.readParcelable<CustomTemplateInAppData?>(CustomTemplateInAppData::class.java.getClassLoader())
         aspectRatio = parcel.readDouble()
         isRequestForPushPermission = parcel.readByte().toInt() != 0x00
+        tapOutsideDismiss = parcel.readByte().toInt() != 0x00
+        swipeToDismiss = parcel.readByte().toInt() != 0x00
         pipConfigJson = _jsonDescription.optJSONObject("pip")
     }
 
@@ -288,7 +304,32 @@ class CTInAppNotification : Parcelable {
         dest.writeParcelable(customTemplateData, flags)
         dest.writeDouble(aspectRatio)
         dest.writeByte((if (isRequestForPushPermission) 0x01 else 0x00).toByte())
+        dest.writeByte((if (tapOutsideDismiss) 0x01 else 0x00).toByte())
+        dest.writeByte((if (swipeToDismiss) 0x01 else 0x00).toByte())
     }
+
+    /**
+     * True for the image-only native templates whose whole image is tappable. Used to tag the
+     * whole-image tap as [Constants.INAPP_ELEMENT_ID_IMAGE] instead of a CTA button.
+     */
+    internal fun isImageOnlyInApp(): Boolean =
+        inAppType == CTInAppType.CTInAppTypeCoverImageOnly ||
+                inAppType == CTInAppType.CTInAppTypeHalfInterstitialImageOnly ||
+                inAppType == CTInAppType.CTInAppTypeInterstitialImageOnly
+
+    /**
+     * True for HTML in-apps (including the advanced-builder media template, which is delivered as the
+     * in-app's HTML content). Media-error reporting is scoped to HTML in-apps: aspect ratio only affects
+     * window sizing and isn't guaranteed to be set, so gating on the in-app type is the reliable signal
+     * and still excludes native templates (so a native CTA's wzrk_c2a is never misread).
+     */
+    internal fun isHtml(): Boolean =
+        inAppType == CTInAppType.CTInAppTypeHTML ||
+                inAppType == CTInAppType.CTInAppTypeCoverHTML ||
+                inAppType == CTInAppType.CTInAppTypeInterstitialHTML ||
+                inAppType == CTInAppType.CTInAppTypeHeaderHTML ||
+                inAppType == CTInAppType.CTInAppTypeFooterHTML ||
+                inAppType == CTInAppType.CTInAppTypeHalfInterstitialHTML
 
     internal fun getInAppMediaForOrientation(orientation: Int): CTInAppNotificationMedia? {
         var returningMedia: CTInAppNotificationMedia? = null
@@ -607,6 +648,19 @@ class CTInAppNotification : Parcelable {
 
         fun defaultTtl(): Long {
             return (System.currentTimeMillis() + 2 * Constants.ONE_DAY_IN_MILLIS) / 1000
+        }
+
+        /**
+         * Parses a per-campaign dismiss-gesture flag. Uses the server value when present as a real
+         * boolean or as 0/1 (1 -> true, 0 -> false). A missing key, an explicit JSON null, or any
+         * other/unparseable value falls back to true.
+         */
+        private fun parseDismissFlag(json: JSONObject, key: String): Boolean {
+            return when (val value = json.opt(key)) {
+                is Boolean -> value
+                is Number -> value.toInt() != 0
+                else -> true // absent, JSONObject.NULL, or unexpected type
+            }
         }
 
         private fun getBundleFromJsonObject(notif: JSONObject): Bundle {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppNotification.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppNotification.kt
@@ -80,12 +80,9 @@ class CTInAppNotification : Parcelable {
         private set
 
     /**
-     * Per-campaign dismiss-gesture flags. Default to `true` when the JSON key is absent or an
+     * Per-campaign dismiss-gesture flag. Default to `true` when the JSON key is absent or an
      * explicit null (parsed null-safely via [org.json.JSONObject.optBoolean]).
      */
-    var tapOutsideDismiss: Boolean = true
-        private set
-
     var swipeToDismiss: Boolean = true
         private set
 
@@ -173,7 +170,6 @@ class CTInAppNotification : Parcelable {
             }
             // Take the server value when present (boolean or 0/1); absent key or explicit JSON null
             // falls back to true.
-            tapOutsideDismiss = parseDismissFlag(jsonObject, Constants.KEY_TAP_OUTSIDE_DISMISS)
             swipeToDismiss = parseDismissFlag(jsonObject, Constants.KEY_SWIPE_TO_DISMISS)
         } catch (e: JSONException) {
             error = "Invalid JSON: ${e.localizedMessage}"
@@ -243,7 +239,6 @@ class CTInAppNotification : Parcelable {
             parcel.readParcelable<CustomTemplateInAppData?>(CustomTemplateInAppData::class.java.getClassLoader())
         aspectRatio = parcel.readDouble()
         isRequestForPushPermission = parcel.readByte().toInt() != 0x00
-        tapOutsideDismiss = parcel.readByte().toInt() != 0x00
         swipeToDismiss = parcel.readByte().toInt() != 0x00
         pipConfigJson = _jsonDescription.optJSONObject("pip")
     }
@@ -304,7 +299,6 @@ class CTInAppNotification : Parcelable {
         dest.writeParcelable(customTemplateData, flags)
         dest.writeDouble(aspectRatio)
         dest.writeByte((if (isRequestForPushPermission) 0x01 else 0x00).toByte())
-        dest.writeByte((if (tapOutsideDismiss) 0x01 else 0x00).toByte())
         dest.writeByte((if (swipeToDismiss) 0x01 else 0x00).toByte())
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -409,6 +409,7 @@ internal class InAppController(
     override fun inAppNotificationDidClick(
         inAppNotification: CTInAppNotification,
         button: CTInAppNotificationButton,
+        buttonIndex: Int,
         activityContext: Context?
     ): Bundle? {
         val action = button.action
@@ -416,13 +417,14 @@ internal class InAppController(
             return null
         }
         // Tag the clicked element for CTA buttons that don't route through the fragment's
-        // handleButtonClickAtIndex (e.g. alert-template buttons). 1-based index, matching iOS.
-        val index = inAppNotification.buttons.indexOf(button)
-        val additionalData = if (index >= 0) {
+        // handleButtonClickAtIndex (e.g. alert-template buttons). The caller passes the exact clicked
+        // index (buttons are built from a JSON array and CTInAppNotificationButton.equals is value-based,
+        // so indexOf would resolve a duplicate CTA payload to the wrong slot). 1-based, matching iOS.
+        val additionalData = if (buttonIndex >= 0) {
             val elementId = if (inAppNotification.isImageOnlyInApp()) {
                 Constants.INAPP_ELEMENT_ID_IMAGE
             } else {
-                Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX + (index + 1)
+                Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX + (buttonIndex + 1)
             }
             Bundle().apply { putString(Constants.KEY_WZRK_ELEMENT_ID, elementId) }
         } else {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -394,9 +394,8 @@ internal class InAppController(
             InAppActionType.KEY_VALUES -> {
                 val keyValues = action.keyValues
                 if (!keyValues.isNullOrEmpty()) {
-                    val kvBundle = Bundle()
-                    keyValues.forEach { (key, value) -> kvBundle.putString(key, value) }
-                    data.putBundle(Constants.KEY_WZRK_DATA, kvBundle)
+                    // Nested payload carried as a Serializable map; analytics emits it as a nested JSON object.
+                    data.putSerializable(Constants.KEY_WZRK_DATA, HashMap(keyValues))
                 }
             }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -13,6 +13,8 @@ import com.clevertap.android.sdk.AnalyticsManager
 import com.clevertap.android.sdk.BaseCallbackManager
 import com.clevertap.android.sdk.CleverTapInstanceConfig
 import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.validation.ValidationResult
+import com.clevertap.android.sdk.validation.ValidationResultStack
 import com.clevertap.android.sdk.ControllerManager
 import com.clevertap.android.sdk.CoreMetaData
 import com.clevertap.android.sdk.DeviceInfo
@@ -80,6 +82,7 @@ internal class InAppController(
     private val clock: Clock,
     private val networkMonitor: NetworkMonitor,
     private val pipManager: PIPManager,
+    private val validationResultStack: ValidationResultStack,
 ) : InAppListener, PIPShowFailureHandler {
 
     private enum class InAppState {
@@ -280,12 +283,25 @@ internal class InAppController(
             data.putString(Constants.DEEP_LINK_KEY, deepLink)
         }
 
+        // Media preload failures from the bundled advanced-builder template (delivered as HTML content)
+        // arrive as a synthetic close carrying a reserved wzrk_c2a. Report them as a structured wzrk_error
+        // and DO NOT raise a click or viewed event. Scoped to HTML in-apps only: aspect ratio isn't a
+        // reliable signal, and gating on the HTML type excludes native templates so a native CTA's
+        // wzrk_c2a is never misread as a media error.
+        if (inAppNotification.isHtml() && reportMediaErrorIfAny(callToAction)) {
+            return data
+        }
+
+        val type = action.type
+        // Enrich the clicked event with the action descriptors (wzrk_action/wzrk_data) at this single
+        // choke point, derived from the action being triggered.
+        addActionDescriptors(data, action, type)
+
         // send clicked event
         if (!inAppNotification.isLocalInApp) {
             analyticsManager.pushInAppNotificationStateEvent(true, inAppNotification, data)
         }
 
-        val type = action.type
         if (type == null) {
             logger.debug("Triggered in-app action without type")
             return data
@@ -330,6 +346,66 @@ internal class InAppController(
         return data
     }
 
+    /**
+     * Maps a media-error synthetic-close [callToAction] to a structured [ValidationResult] and pushes it
+     * onto the validation stack, so it rides along on the next queued event as the top-level `wzrk_error`.
+     * No event is raised here. Returns true if the callToAction was a media-error descriptor.
+     */
+    private fun reportMediaErrorIfAny(callToAction: String): Boolean {
+        val validationResult = when (callToAction) {
+            Constants.INAPP_CTA_IMAGE_ERROR_DISMISS -> ValidationResult(
+                Constants.INAPP_IMAGE_LOAD_FAILED_ERROR_CODE,
+                Constants.INAPP_IMAGE_LOAD_FAILED_ERROR_MSG
+            )
+
+            Constants.INAPP_CTA_VIDEO_ERROR_DISMISS -> ValidationResult(
+                Constants.INAPP_VIDEO_LOAD_FAILED_ERROR_CODE,
+                Constants.INAPP_VIDEO_LOAD_FAILED_ERROR_MSG
+            )
+
+            else -> return false
+        }
+        logger.debug("InApp media failed to load, reporting wzrk_error ${validationResult.errorCode}")
+        validationResultStack.pushValidationResult(validationResult)
+        return true
+    }
+
+    /**
+     * Adds `wzrk_action` (the action type) and `wzrk_data` (the action payload) to the clicked-event
+     * extras. `wzrk_data` for a key-values action is a nested object.
+     */
+    private fun addActionDescriptors(data: Bundle, action: CTInAppAction, type: InAppActionType?) {
+        if (type == null) {
+            return
+        }
+        data.putString(Constants.KEY_WZRK_ACTION, type.toString())
+        when (type) {
+            InAppActionType.OPEN_URL ->
+                action.actionUrl?.takeIf { it.isNotEmpty() }
+                    ?.let { data.putString(Constants.KEY_WZRK_DATA, it) }
+
+            InAppActionType.CLOSE ->
+                data.putString(Constants.KEY_WZRK_DATA, Constants.INAPP_WZRK_DATA_CLOSE)
+
+            InAppActionType.CUSTOM_CODE ->
+                action.customTemplateInAppData?.templateName?.takeIf { it.isNotEmpty() }
+                    ?.let { data.putString(Constants.KEY_WZRK_DATA, it) }
+
+            InAppActionType.KEY_VALUES -> {
+                val keyValues = action.keyValues
+                if (!keyValues.isNullOrEmpty()) {
+                    val kvBundle = Bundle()
+                    keyValues.forEach { (key, value) -> kvBundle.putString(key, value) }
+                    data.putBundle(Constants.KEY_WZRK_DATA, kvBundle)
+                }
+            }
+
+            else -> {
+                // no wzrk_data payload for other action types
+            }
+        }
+    }
+
     override fun inAppNotificationDidClick(
         inAppNotification: CTInAppNotification,
         button: CTInAppNotificationButton,
@@ -339,11 +415,24 @@ internal class InAppController(
         if (action == null) {
             return null
         }
+        // Tag the clicked element for CTA buttons that don't route through the fragment's
+        // handleButtonClickAtIndex (e.g. alert-template buttons). 1-based index, matching iOS.
+        val index = inAppNotification.buttons.indexOf(button)
+        val additionalData = if (index >= 0) {
+            val elementId = if (inAppNotification.isImageOnlyInApp()) {
+                Constants.INAPP_ELEMENT_ID_IMAGE
+            } else {
+                Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX + (index + 1)
+            }
+            Bundle().apply { putString(Constants.KEY_WZRK_ELEMENT_ID, elementId) }
+        } else {
+            null
+        }
         return inAppNotificationActionTriggered(
             inAppNotification,
             action,
             button.text,
-            null,
+            additionalData,
             activityContext
         )
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppListener.kt
@@ -8,6 +8,7 @@ internal interface InAppListener {
     fun inAppNotificationDidClick(
         inAppNotification: CTInAppNotification,
         button: CTInAppNotificationButton,
+        buttonIndex: Int,
         activityContext: Context?
     ): Bundle?
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -83,13 +83,6 @@ internal abstract class CTInAppBaseFragment : Fragment() {
     private var listenerWeakReference: WeakReference<InAppListener>? = null
     private var didClickForHardPermissionListener: DidClickForHardPermissionListener? = null
 
-    /**
-     * Per-presentation dedup guard. Ensures at most one `Notification Clicked` is raised for a single
-     * display (e.g. repeated swipe/tap-outside gestures fired while the in-app animates out). Reset in
-     * [didShow] so a reused fragment can raise its click again on a later presentation.
-     */
-    private var actionTriggered = false
-
     protected abstract fun cleanup()
     protected abstract fun generateListener()
 
@@ -220,8 +213,6 @@ internal abstract class CTInAppBaseFragment : Fragment() {
     }
 
     fun didShow(data: Bundle?) {
-        // Reset the dedup guard on every presentation so a re-shown in-app can raise its click again.
-        actionTriggered = false
         getListener()?.inAppNotificationDidShow(inAppNotification, data)
     }
 
@@ -306,11 +297,6 @@ internal abstract class CTInAppBaseFragment : Fragment() {
     private fun notifyActionTriggered(
         action: CTInAppAction, callToAction: String, additionalData: Bundle?
     ): Bundle? {
-        // Single choke point + dedup: at most one Notification Clicked per presentation.
-        if (actionTriggered) {
-            return null
-        }
-        actionTriggered = true
         return getListener()?.inAppNotificationActionTriggered(
             inAppNotification, action, callToAction, additionalData, activity
         )

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -289,8 +289,8 @@ internal abstract class CTInAppBaseFragment : Fragment() {
             Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX + (index + 1)
         }
         val extras = Bundle().apply { putString(Constants.KEY_WZRK_ELEMENT_ID, elementId) }
-        // For the image-only tap wzrk_c2a stays empty (unchanged legacy behaviour).
-        val callToAction = if (isImageTap) "" else button.text
+        // wzrk_c2a: for a whole-image tap use the element id ("image-1"); for a CTA button use its text.
+        val callToAction = if (isImageTap) elementId else button.text
         return notifyActionTriggered(action, callToAction, extras)
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -196,7 +196,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
      */
     fun triggerSwipeDismissAction() {
         triggerAction(
-            CTInAppAction.CREATOR.createCloseAction(), Constants.KEY_SWIPE_TO_DISMISS, null
+            CTInAppAction.CREATOR.createCloseAction(), Constants.INAPP_CTA_SWIPE_DISMISS, null
         )
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -191,7 +191,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
     }
 
     /**
-     * Swipe-to-dismiss, raised as a click: `wzrk_c2a = swipe-dismiss`, `wzrk_action = close`,
+     * Swipe-to-dismiss, raised as a click: `wzrk_c2a = Swipe to Dismiss`, `wzrk_action = close`,
      * `wzrk_data = close`. No `wzrk_element_id` (gesture, not an element).
      */
     fun triggerSwipeDismissAction() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -83,6 +83,13 @@ internal abstract class CTInAppBaseFragment : Fragment() {
     private var listenerWeakReference: WeakReference<InAppListener>? = null
     private var didClickForHardPermissionListener: DidClickForHardPermissionListener? = null
 
+    /**
+     * Per-presentation dedup guard. Ensures at most one `Notification Clicked` is raised for a single
+     * display (e.g. repeated swipe/tap-outside gestures fired while the in-app animates out). Reset in
+     * [didShow] so a reused fragment can raise its click again on a later presentation.
+     */
+    private var actionTriggered = false
+
     protected abstract fun cleanup()
     protected abstract fun generateListener()
 
@@ -177,12 +184,44 @@ internal abstract class CTInAppBaseFragment : Fragment() {
         triggerAction(CTInAppAction.CREATOR.createOpenUrlAction(url), null, null)
     }
 
+    /**
+     * Close (X) button dismissal, raised as a click: `wzrk_element_id = closeButton`,
+     * `wzrk_c2a = Dismiss Button`, `wzrk_action = close`, `wzrk_data = close`.
+     */
+    fun triggerCloseButtonAction() {
+        val extras = Bundle().apply {
+            putString(Constants.KEY_WZRK_ELEMENT_ID, Constants.INAPP_ELEMENT_ID_CLOSE)
+        }
+        triggerAction(
+            CTInAppAction.CREATOR.createCloseAction(), Constants.INAPP_CTA_DISMISS_BUTTON, extras
+        )
+    }
+
+    /**
+     * Swipe-to-dismiss, raised as a click: `wzrk_c2a = swipe-dismiss`, `wzrk_action = close`,
+     * `wzrk_data = close`. No `wzrk_element_id` (gesture, not an element).
+     */
+    fun triggerSwipeDismissAction() {
+        triggerAction(
+            CTInAppAction.CREATOR.createCloseAction(), Constants.KEY_SWIPE_TO_DISMISS, null
+        )
+    }
+
+    /**
+     * The swipe/pan dismiss gesture is enabled only when there is no close button and the campaign
+     * allows swipe-to-dismiss. When disabled, the gesture must not be attached at all.
+     */
+    protected fun isSwipeToDismissEnabled(): Boolean =
+        !inAppNotification.isShowClose && inAppNotification.swipeToDismiss
+
     fun didDismiss(data: Bundle?) {
         cleanup()
         getListener()?.inAppNotificationDidDismiss(inAppNotification, data)
     }
 
     fun didShow(data: Bundle?) {
+        // Reset the dedup guard on every presentation so a re-shown in-app can raise its click again.
+        actionTriggered = false
         getListener()?.inAppNotificationDidShow(inAppNotification, data)
     }
 
@@ -211,7 +250,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
     fun handleButtonClickAtIndex(index: Int) {
         try {
             val button = inAppNotification.buttons[index]
-            val clickData = didClick(button)
+            val clickData = didClick(button, index)
 
             if (inAppNotification.isLocalInApp && didClickForHardPermissionListener != null) {
                 when (index) {
@@ -246,17 +285,32 @@ internal abstract class CTInAppBaseFragment : Fragment() {
         return FileResourceProvider.getInstance(requireContext(), config.logger)
     }
 
-    private fun didClick(button: CTInAppNotificationButton): Bundle? {
+    private fun didClick(button: CTInAppNotificationButton, index: Int): Bundle? {
         var action = button.action
         if (action == null) {
             action = CTInAppAction.CREATOR.createCloseAction()
         }
-        return notifyActionTriggered(action, button.text, null)
+        // Whole-image tap on image-only templates is tagged image-1; otherwise it is a 1-based CTA button.
+        val isImageTap = inAppNotification.isImageOnlyInApp()
+        val elementId = if (isImageTap) {
+            Constants.INAPP_ELEMENT_ID_IMAGE
+        } else {
+            Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX + (index + 1)
+        }
+        val extras = Bundle().apply { putString(Constants.KEY_WZRK_ELEMENT_ID, elementId) }
+        // For the image-only tap wzrk_c2a stays empty (unchanged legacy behaviour).
+        val callToAction = if (isImageTap) "" else button.text
+        return notifyActionTriggered(action, callToAction, extras)
     }
 
     private fun notifyActionTriggered(
         action: CTInAppAction, callToAction: String, additionalData: Bundle?
     ): Bundle? {
+        // Single choke point + dedup: at most one Notification Clicked per presentation.
+        if (actionTriggered) {
+            return null
+        }
+        actionTriggered = true
         return getListener()?.inAppNotificationActionTriggered(
             inAppNotification, action, callToAction, additionalData, activity
         )

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
@@ -103,7 +103,7 @@ internal abstract class CTInAppBaseFullHtmlFragment : CTInAppBaseFullFragment() 
                 val context = inflater.context
                 val closeImageView = CloseImageView(context)
                 val closeIvLp = getLayoutParamsForCloseButton(webView.id)
-                closeImageView.setOnClickListener { didDismiss(null) }
+                closeImageView.setOnClickListener { triggerCloseButtonAction() }
                 closeImageView.contentDescription = context.getString(R.string.ct_inapp_close_btn)
                 this.closeImageView = closeImageView
                 rl.addView(closeImageView, closeIvLp)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -19,7 +19,6 @@ import android.view.animation.TranslateAnimation
 import com.clevertap.android.sdk.CTWebInterface
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.Logger
-import com.clevertap.android.sdk.inapp.CTInAppAction.CREATOR.createCloseAction
 import com.clevertap.android.sdk.inapp.CTInAppWebView
 import com.clevertap.android.sdk.inapp.InAppWebViewClient
 import kotlin.math.abs
@@ -61,7 +60,7 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
             animSet.isFillEnabled = true
             animSet.setAnimationListener(object : Animation.AnimationListener {
                 override fun onAnimationEnd(animation: Animation?) {
-                    triggerAction(createCloseAction(), CTA_SWIPE_DISMISS, null)
+                    triggerSwipeDismissAction()
                 }
 
                 override fun onAnimationRepeat(animation: Animation?) {
@@ -145,7 +144,11 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
             this.webView = webView
             val webViewClient = InAppWebViewClient(this)
             webView.setWebViewClient(webViewClient)
-            webView.setOnTouchListener(this)
+            // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no close
+            // button. When swipeToDismiss == false, the gesture is not attached at all.
+            if (isSwipeToDismissEnabled()) {
+                webView.setOnTouchListener(this)
+            }
             webView.setOnLongClickListener(this)
 
             if (inAppNotification.isJsEnabled) {
@@ -185,7 +188,6 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
     }
 
     companion object {
-        private const val CTA_SWIPE_DISMISS = "swipe-dismiss"
         private const val SWIPE_MIN_DISTANCE = 120
         private const val SWIPE_THRESHOLD_VELOCITY = 200
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialNativeFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialNativeFragment.kt
@@ -63,7 +63,7 @@ internal abstract class CTInAppBasePartialNativeFragment : CTInAppBasePartialFra
             animSet.isFillEnabled = true
             animSet.setAnimationListener(object : Animation.AnimationListener {
                 override fun onAnimationEnd(animation: Animation?) {
-                    didDismiss(null)
+                    triggerSwipeDismissAction()
                 }
 
                 override fun onAnimationRepeat(animation: Animation?) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverFragment.kt
@@ -87,7 +87,7 @@ internal class CTInAppNativeCoverFragment : CTInAppBaseFullNativeFragment() {
         val closeImageView = fl.findViewById<CloseImageView>(CloseImageView.VIEW_ID)
 
         closeImageView.setOnClickListener {
-            didDismiss(null)
+            triggerCloseButtonAction()
             activity?.finish()
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverImageFragment.kt
@@ -53,7 +53,7 @@ internal class CTInAppNativeCoverImageFragment : CTInAppBaseFullFragment() {
         val closeImageView = fl.findViewById<CloseImageView>(CloseImageView.VIEW_ID)
 
         closeImageView.setOnClickListener {
-            didDismiss(null)
+            triggerCloseButtonAction()
             activity?.finish()
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeFooterFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeFooterFragment.kt
@@ -86,9 +86,12 @@ internal class CTInAppNativeFooterFragment : CTInAppBasePartialNativeFragment() 
         }
 
         @SuppressLint("ClickableViewAccessibility")
-        inAppView.setOnTouchListener { v, event ->
-            gd.onTouchEvent(event)
-            true
+        // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled.
+        if (isSwipeToDismissEnabled()) {
+            inAppView.setOnTouchListener { v, event ->
+                gd.onTouchEvent(event)
+                true
+            }
         }
         inAppView.applyInsetsWithMarginAdjustment { insets, mlp ->
             mlp.leftMargin = insets.left

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialFragment.kt
@@ -175,7 +175,7 @@ internal class CTInAppNativeHalfInterstitialFragment : CTInAppBaseFullNativeFrag
         fl.background = ColorDrawable(-0x45000000)
 
         closeImageView.setOnClickListener {
-            didDismiss(null)
+            triggerCloseButtonAction()
             activity?.finish()
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialImageFragment.kt
@@ -138,7 +138,7 @@ internal class CTInAppNativeHalfInterstitialImageFragment : CTInAppBaseFullFragm
         )
 
         closeImageView.setOnClickListener {
-            didDismiss(null)
+            triggerCloseButtonAction()
             activity?.finish()
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHeaderFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHeaderFragment.kt
@@ -87,9 +87,12 @@ internal class CTInAppNativeHeaderFragment : CTInAppBasePartialNativeFragment() 
         }
 
         @SuppressLint("ClickableViewAccessibility")
-        inAppView.setOnTouchListener { v, event ->
-            gd.onTouchEvent(event)
-            true
+        // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled.
+        if (isSwipeToDismissEnabled()) {
+            inAppView.setOnTouchListener { v, event ->
+                gd.onTouchEvent(event)
+                true
+            }
         }
         inAppView.applyInsetsWithMarginAdjustment { insets, mlp ->
             mlp.leftMargin = insets.left

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialFragment.kt
@@ -82,7 +82,7 @@ internal class CTInAppNativeInterstitialFragment : CTInAppBaseFullNativeFragment
         } else {
             closeImageView?.setVisibility(View.VISIBLE)
             closeImageView?.setOnClickListener {
-                didDismiss(null)
+                triggerCloseButtonAction()
                 activity?.finish()
             }
         }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialImageFragment.kt
@@ -121,7 +121,7 @@ internal class CTInAppNativeInterstitialImageFragment : CTInAppBaseFullFragment(
         )
 
         closeImageView.setOnClickListener {
-            didDismiss(null)
+            triggerCloseButtonAction()
             activity?.finish()
         }
 

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTInAppNotificationTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTInAppNotificationTest.kt
@@ -33,53 +33,44 @@ class CTInAppNotificationTest {
     fun `dismiss-gesture flags default to true when keys are absent`() {
         val notification = CTInAppNotification(JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL), true)
 
-        assertTrue(notification.tapOutsideDismiss)
         assertTrue(notification.swipeToDismiss)
     }
 
     @Test
     fun `dismiss-gesture flags respect explicit boolean values`() {
         val json = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
-            put(Constants.KEY_TAP_OUTSIDE_DISMISS, false)
             put(Constants.KEY_SWIPE_TO_DISMISS, false)
         }
 
         val notification = CTInAppNotification(json, true)
 
-        assertFalse(notification.tapOutsideDismiss)
         assertFalse(notification.swipeToDismiss)
     }
 
     @Test
     fun `dismiss-gesture flags respect integer 0 and 1 values`() {
         val disabled = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
-            put(Constants.KEY_TAP_OUTSIDE_DISMISS, 0)
             put(Constants.KEY_SWIPE_TO_DISMISS, 0)
         }
         val enabled = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
-            put(Constants.KEY_TAP_OUTSIDE_DISMISS, 1)
             put(Constants.KEY_SWIPE_TO_DISMISS, 1)
         }
 
         val disabledNotification = CTInAppNotification(disabled, true)
         val enabledNotification = CTInAppNotification(enabled, true)
 
-        assertFalse(disabledNotification.tapOutsideDismiss)
         assertFalse(disabledNotification.swipeToDismiss)
-        assertTrue(enabledNotification.tapOutsideDismiss)
         assertTrue(enabledNotification.swipeToDismiss)
     }
 
     @Test
     fun `dismiss-gesture flags fall back to true for explicit JSON null without crashing`() {
         val json = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
-            put(Constants.KEY_TAP_OUTSIDE_DISMISS, JSONObject.NULL)
             put(Constants.KEY_SWIPE_TO_DISMISS, JSONObject.NULL)
         }
 
         val notification = CTInAppNotification(json, true)
 
-        assertTrue(notification.tapOutsideDismiss)
         assertTrue(notification.swipeToDismiss)
     }
 

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTInAppNotificationTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTInAppNotificationTest.kt
@@ -30,6 +30,69 @@ class CTInAppNotificationTest {
     }
 
     @Test
+    fun `dismiss-gesture flags default to true when keys are absent`() {
+        val notification = CTInAppNotification(JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL), true)
+
+        assertTrue(notification.tapOutsideDismiss)
+        assertTrue(notification.swipeToDismiss)
+    }
+
+    @Test
+    fun `dismiss-gesture flags respect explicit boolean values`() {
+        val json = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
+            put(Constants.KEY_TAP_OUTSIDE_DISMISS, false)
+            put(Constants.KEY_SWIPE_TO_DISMISS, false)
+        }
+
+        val notification = CTInAppNotification(json, true)
+
+        assertFalse(notification.tapOutsideDismiss)
+        assertFalse(notification.swipeToDismiss)
+    }
+
+    @Test
+    fun `dismiss-gesture flags respect integer 0 and 1 values`() {
+        val disabled = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
+            put(Constants.KEY_TAP_OUTSIDE_DISMISS, 0)
+            put(Constants.KEY_SWIPE_TO_DISMISS, 0)
+        }
+        val enabled = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
+            put(Constants.KEY_TAP_OUTSIDE_DISMISS, 1)
+            put(Constants.KEY_SWIPE_TO_DISMISS, 1)
+        }
+
+        val disabledNotification = CTInAppNotification(disabled, true)
+        val enabledNotification = CTInAppNotification(enabled, true)
+
+        assertFalse(disabledNotification.tapOutsideDismiss)
+        assertFalse(disabledNotification.swipeToDismiss)
+        assertTrue(enabledNotification.tapOutsideDismiss)
+        assertTrue(enabledNotification.swipeToDismiss)
+    }
+
+    @Test
+    fun `dismiss-gesture flags fall back to true for explicit JSON null without crashing`() {
+        val json = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
+            put(Constants.KEY_TAP_OUTSIDE_DISMISS, JSONObject.NULL)
+            put(Constants.KEY_SWIPE_TO_DISMISS, JSONObject.NULL)
+        }
+
+        val notification = CTInAppNotification(json, true)
+
+        assertTrue(notification.tapOutsideDismiss)
+        assertTrue(notification.swipeToDismiss)
+    }
+
+    @Test
+    fun `isHtml is true for html in-apps and false for native in-apps`() {
+        val html = CTInAppNotification(JSONObject(InAppFixtures.TYPE_ADVANCED_BUILDER_HEADER), true)
+        val native = CTInAppNotification(JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL), true)
+
+        assertTrue(html.isHtml())
+        assertFalse(native.isHtml())
+    }
+
+    @Test
     fun `constructor for advanced builder custom-html should initialize correctly for html footer`() {
         // Arrange - Html in app
         val jsonObject = JSONObject(InAppFixtures.TYPE_ADVANCED_BUILDER_FOOTER)

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
@@ -432,7 +432,7 @@ class InAppControllerTest {
         """.trimIndent()
         val inApp = getInAppWithAction(actionJsonString)
         val inAppController = createInAppController()
-        inAppController.inAppNotificationDidClick(inApp, inApp.buttons[0], null)
+        inAppController.inAppNotificationDidClick(inApp, inApp.buttons[0], 0, null)
 
         verify(exactly = 1) { mockInAppActionHandler.openUrl(url, null) }
     }
@@ -441,13 +441,42 @@ class InAppControllerTest {
     fun `inAppNotificationDidClick tags the clicked button with a 1-based element id`() {
         val inApp = getInAppWithAction("""{"${Constants.KEY_TYPE}": "${InAppActionType.CLOSE}"}""")
 
-        createInAppController().inAppNotificationDidClick(inApp, inApp.buttons[0], null)
+        createInAppController().inAppNotificationDidClick(inApp, inApp.buttons[0], 0, null)
 
         verify(exactly = 1) {
             mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
                 data.getString(Constants.KEY_WZRK_ELEMENT_ID) == "${Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX}1" &&
                         data.getString(Constants.KEY_WZRK_ACTION) == InAppActionType.CLOSE.toString() &&
                         data.getString(Constants.KEY_WZRK_DATA) == Constants.INAPP_WZRK_DATA_CLOSE
+            })
+        }
+    }
+
+    @Test
+    fun `inAppNotificationDidClick uses the passed index for duplicate button payloads`() {
+        // Two identical button payloads: CTInAppNotificationButton.equals is value-based, so indexOf
+        // would resolve buttons[1] back to slot 0 and mis-tag it button-1.
+        val buttonJson = """{
+            "${Constants.KEY_TEXT}": "OK",
+            "${Constants.KEY_ACTIONS}": {"${Constants.KEY_TYPE}": "${InAppActionType.CLOSE}"}
+        }"""
+        val inApp = CTInAppNotification(
+            JSONObject(
+                """{
+            "${Constants.KEY_TYPE}": "${CTInAppType.CTInAppTypeCover}",
+            "${Constants.NOTIFICATION_ID_TAG}": "test-campaign",
+            "${Constants.KEY_BUTTONS}": [$buttonJson, $buttonJson]
+            }""".trimIndent()
+            ), false
+        )
+        // Sanity: the two buttons really are equal, so indexOf(buttons[1]) == 0 (the bug).
+        assertEquals(inApp.buttons[0], inApp.buttons[1])
+
+        createInAppController().inAppNotificationDidClick(inApp, inApp.buttons[1], 1, null)
+
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
+                data.getString(Constants.KEY_WZRK_ELEMENT_ID) == "${Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX}2"
             })
         }
     }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
@@ -26,6 +26,8 @@ import com.clevertap.android.sdk.inapp.delay.InAppScheduler
 import com.clevertap.android.sdk.inapp.evaluation.EvaluationManager
 import com.clevertap.android.sdk.inapp.fragment.CTInAppBaseFragment
 import com.clevertap.android.sdk.network.NetworkMonitor
+import com.clevertap.android.sdk.validation.ValidationResult
+import com.clevertap.android.sdk.validation.ValidationResultStack
 import com.clevertap.android.sdk.task.MockCTExecutors
 import com.clevertap.android.sdk.toList
 import com.clevertap.android.sdk.utils.FakeClock
@@ -68,6 +70,7 @@ class InAppControllerTest {
     private lateinit var fakeInAppQueue: FakeInAppQueue
 
     private lateinit var mockNetworkMonitor: NetworkMonitor
+    private lateinit var mockValidationResultStack: ValidationResultStack
     private val fakeClock = FakeClock(timeMillis = 1735686000000) // 01.01.2025
 
     @Before
@@ -90,6 +93,8 @@ class InAppControllerTest {
 
         mockNetworkMonitor = mockk(relaxed = true)
         every { mockNetworkMonitor.isNetworkOnline() } returns true
+
+        mockValidationResultStack = mockk(relaxed = true)
 
 
         mockInAppActionHandler = mockk(relaxed = true)
@@ -316,6 +321,107 @@ class InAppControllerTest {
     }
 
     @Test
+    fun `inAppActionTriggered adds url action descriptors to clicked event`() {
+        val url = "https://clevertap.com"
+        val actionJsonString = """
+        {
+            "${Constants.KEY_TYPE}": "${InAppActionType.OPEN_URL}",
+            "${Constants.KEY_ANDROID}": "$url"
+        }
+        """.trimIndent()
+        val inApp = getInAppWithAction(actionJsonString)
+
+        createInAppController().inAppNotificationActionTriggered(
+            inApp, CTInAppAction.createFromJson(JSONObject(actionJsonString))!!, "cta", null, null
+        )
+
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
+                data.getString(Constants.KEY_WZRK_ACTION) == InAppActionType.OPEN_URL.toString() &&
+                        data.getString(Constants.KEY_WZRK_DATA) == url
+            })
+        }
+    }
+
+    @Test
+    fun `inAppActionTriggered adds close action descriptors to clicked event`() {
+        val inApp = getInAppWithAction("""{"${Constants.KEY_TYPE}": "${InAppActionType.CLOSE}"}""")
+
+        createInAppController().inAppNotificationActionTriggered(
+            inApp,
+            CTInAppAction.createCloseAction(),
+            Constants.INAPP_CTA_DISMISS_BUTTON,
+            Bundle().apply { putString(Constants.KEY_WZRK_ELEMENT_ID, Constants.INAPP_ELEMENT_ID_CLOSE) },
+            null
+        )
+
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
+                data.getString(Constants.KEY_WZRK_ACTION) == InAppActionType.CLOSE.toString() &&
+                        data.getString(Constants.KEY_WZRK_DATA) == Constants.INAPP_WZRK_DATA_CLOSE &&
+                        data.getString(Constants.KEY_WZRK_ELEMENT_ID) == Constants.INAPP_ELEMENT_ID_CLOSE
+            })
+        }
+    }
+
+    @Test
+    fun `inAppActionTriggered adds kv action descriptors as a nested payload`() {
+        every { mockCallbackManager.getInAppNotificationButtonListener() } returns null
+        val keyValues = hashMapOf("key1" to "value1", "key2" to "value2")
+        val actionJsonString = """
+        {
+            "${Constants.KEY_TYPE}": "${InAppActionType.KEY_VALUES}",
+            "${Constants.KEY_KV}": ${JSONObject((keyValues as Map<*, *>?)!!)}
+        }
+        """.trimIndent()
+        val inApp = getInAppWithAction(actionJsonString)
+
+        createInAppController().inAppNotificationActionTriggered(
+            inApp, CTInAppAction.createFromJson(JSONObject(actionJsonString))!!, "cta", null, null
+        )
+
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
+                val kv = data.getBundle(Constants.KEY_WZRK_DATA)
+                data.getString(Constants.KEY_WZRK_ACTION) == InAppActionType.KEY_VALUES.toString() &&
+                        kv?.getString("key1") == "value1" && kv.getString("key2") == "value2"
+            })
+        }
+    }
+
+    @Test
+    fun `media error on html inapp reports wzrk_error and raises no clicked event`() {
+        val inApp = CTInAppNotification(JSONObject(InAppFixtures.TYPE_ADVANCED_BUILDER_HEADER), true)
+
+        createInAppController().inAppNotificationActionTriggered(
+            inApp, CTInAppAction.createCloseAction(), Constants.INAPP_CTA_IMAGE_ERROR_DISMISS, null, null
+        )
+
+        verify(exactly = 1) {
+            mockValidationResultStack.pushValidationResult(match<ValidationResult> {
+                it.errorCode == Constants.INAPP_IMAGE_LOAD_FAILED_ERROR_CODE
+            })
+        }
+        verify(exactly = 0) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `media error c2a on native inapp is treated as a normal click`() {
+        val inApp = getInAppWithAction("""{"${Constants.KEY_TYPE}": "${InAppActionType.CLOSE}"}""")
+
+        createInAppController().inAppNotificationActionTriggered(
+            inApp, CTInAppAction.createCloseAction(), Constants.INAPP_CTA_IMAGE_ERROR_DISMISS, null, null
+        )
+
+        verify(exactly = 0) { mockValidationResultStack.pushValidationResult(any<ValidationResult>()) }
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, any())
+        }
+    }
+
+    @Test
     fun `inAppNotificationDidClick should trigger the InAppButton's action`() {
         val url = "https://clevertap.com"
         val actionJsonString = """
@@ -329,6 +435,21 @@ class InAppControllerTest {
         inAppController.inAppNotificationDidClick(inApp, inApp.buttons[0], null)
 
         verify(exactly = 1) { mockInAppActionHandler.openUrl(url, null) }
+    }
+
+    @Test
+    fun `inAppNotificationDidClick tags the clicked button with a 1-based element id`() {
+        val inApp = getInAppWithAction("""{"${Constants.KEY_TYPE}": "${InAppActionType.CLOSE}"}""")
+
+        createInAppController().inAppNotificationDidClick(inApp, inApp.buttons[0], null)
+
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
+                data.getString(Constants.KEY_WZRK_ELEMENT_ID) == "${Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX}1" &&
+                        data.getString(Constants.KEY_WZRK_ACTION) == InAppActionType.CLOSE.toString() &&
+                        data.getString(Constants.KEY_WZRK_DATA) == Constants.INAPP_WZRK_DATA_CLOSE
+            })
+        }
     }
 
     @Test
@@ -820,6 +941,7 @@ class InAppControllerTest {
             networkMonitor = mockNetworkMonitor,
             clock = fakeClock,
             pipManager = mockk(relaxed = true),
+            validationResultStack = mockValidationResultStack,
         )
     }
 

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
@@ -382,9 +382,10 @@ class InAppControllerTest {
 
         verify(exactly = 1) {
             mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
-                val kv = data.getBundle(Constants.KEY_WZRK_DATA)
+                @Suppress("UNCHECKED_CAST")
+                val kv = data.getSerializable(Constants.KEY_WZRK_DATA) as? Map<String, String>
                 data.getString(Constants.KEY_WZRK_ACTION) == InAppActionType.KEY_VALUES.toString() &&
-                        kv?.getString("key1") == "value1" && kv.getString("key2") == "value2"
+                        kv?.get("key1") == "value1" && kv?.get("key2") == "value2"
             })
         }
     }


### PR DESCRIPTION
feat: SDK-5810 per-element in-app click tracking, dismiss-as-click & media-error reporting

  Bring the iOS "Split of Clicks" contract to Android for in-app notifications so
  every Notification Clicked event identifies which element was clicked and what
  action it performed, dismissals are tracked as clicks, and media preload failures
  are reported as wzrk_error instead of clicks.

  Per-element identity (wzrk_element_id):
  - Native CTA buttons -> "button-N" (1-based); whole-image tap on image-only
    templates -> "image-1" (wzrk_c2a kept empty); close (X) -> "closeButton";
    HTML JS-bridge -> the FE-supplied buttonId. Alert-template buttons are tagged
    via InAppController.inAppNotificationDidClick.

  Action descriptors (wzrk_action / wzrk_data):
  - Added at the single choke point (InAppController.inAppNotificationActionTriggered)
    for every clicked event: url -> URL, kv -> nested object, close -> "close",
    custom-code -> template name. Nested kv payload carried as a Bundle and emitted
    as a nested JSON object by AnalyticsManager.

  Dismiss tracking + gesture config:
  - Close button and swipe-to-dismiss (native & HTML header/footer) now raise
    Notification Clicked (wzrk_c2a = "Dismiss Button" / "Swipe to Dismiss").
  - Per-campaign swipe-dismiss flag parsed on CTInAppNotification, default true, null-safe, honoring 0/1 or boolean.
  - Swipe gesture attached only when !showClose && swipeToDismiss.
  - Per-presentation dedup guard (reset on didShow) -> one clicked event per display.

  Media-error reporting:
  - image-error-dismiss / video-error-dismiss on HTML in-apps push a structured
    wzrk_error (591/592, placeholders) via ValidationResultStack and raise no
    click/viewed event. Gated on isHtml() so a native CTA can never trip it.

  Breaking:
  - button_id is no longer emitted in HTML JS-bridge click extras; element identity
    flows only through wzrk_element_id.

  Tests: flag parsing (absent/true/false/null/0/1), action descriptors (url/kv/close/
  custom-code), element ids, and media-error gating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

- **New Features**
  - Added per-campaign `swipeToDismiss` configuration with safe defaults (including support for boolean and 0/1 values) and index-aware dismissal/click tracking.
  - Close and swipe-dismiss gestures now trigger consistent in-app “close” actions and include element/action descriptors in click analytics.
  - Updated in-app click callbacks to include the clicked button index.

- **Bug Fixes**
  - Corrected nested custom payload representation in in-app event data.
  - Improved HTML media-preload failure handling to report errors without firing standard click analytics.

- **Tests**
  - Expanded coverage for dismiss gestures, HTML detection, indexed tagging, and media-error analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->