### PR TITLE
fix(SDK-5897): load in-app close icon via static resource reference and ship keep rule

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
@@ -11,6 +11,7 @@ import android.util.TypedValue;
 import androidx.appcompat.widget.AppCompatImageView;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.Logger;
+import com.clevertap.android.sdk.R;
 
 /**
  * Represents the close button.
@@ -45,8 +46,8 @@ public final class CloseImageView extends AppCompatImageView {
         try {
 
             Context context = getContext();
-            int resourceID = context.getResources().getIdentifier("ct_close", "drawable", context.getPackageName());
-            Bitmap closeBitmap = BitmapFactory.decodeResource(context.getResources(), resourceID, null);
+            // Static R reference (instead of getIdentifier) so R8 resource shrinking cannot strip ct_close
+            Bitmap closeBitmap = BitmapFactory.decodeResource(context.getResources(), R.drawable.ct_close, null);
 
             if (closeBitmap != null) {
                 Bitmap scaledCloseBitmap = Bitmap.createScaledBitmap(closeBitmap,

--- a/clevertap-core/src/main/res/raw/com_clevertap_android_sdk_keep.xml
+++ b/clevertap-core/src/main/res/raw/com_clevertap_android_sdk_keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/ct_close" />


### PR DESCRIPTION
## Summary

Fixes [SDK-5897](https://wizrocket.atlassian.net/browse/SDK-5897), the in-app close button becomes invisible when the consuming app's R8 resource shrinker strips `ct_close.png` from the release APK.

- Replace the `Resources.getIdentifier("ct_close", ...)` lookup in `CloseImageView` with a static `R.drawable.ct_close` reference, so every shrinker configuration sees the usage as a real reference.
- Ship `res/raw/com_clevertap_android_sdk_keep.xml` with `tools:keep="@drawable/ct_close"` in the AAR as defense-in-depth (explicit keep rules survive even shrinker reachability bugs). Package-qualified filename per [Android keep-file guidelines](https://developer.android.com/topic/performance/app-optimization/customize-which-resources-to-keep) so it cannot collide with an app's own keep file.

## Root cause

`ct_close.png` was referenced **only** via a dynamic `getIdentifier()` string lookup — invisible to static shrinker analysis. The code was identical from 7.5.2 through 8.3.0. A controlled 10-cell experiment (minimal app, CleverTap from Maven, `minifyEnabled` + `shrinkResources`, one variable changed at a time) proved the icon's survival is decided entirely app-side:

| CT SDK | AGP / compileSdk | Shrink configuration | `ct_close` in APK |
|---|---|---|---|
| 7.5.2 and 8.3.0 | 8.6.0/35, 8.9.1/36, 8.9.3/36 | default safe mode | ✅ kept (string-pool heuristic) |
| 7.5.2 and 8.3.0 | any tested | `tools:shrinkMode="strict"` | ❌ stripped |
| 7.5.2 and 8.3.0 | 8.13.0/36 | `android.r8.optimizedResourceShrinking=true` (default in AGP 9) | ❌ stripped |

Third known trigger: AGP 8.9.0/8.9.1 shrinker regression ([Google issue 404745556](https://issuetracker.google.com/issues/404745556), fixed in AGP 8.9.2).

## Verification

- `clevertap-core:testDebugUnitTest` and `clevertap-core:lint` green.
- End-to-end: published the fixed SDK to mavenLocal and re-ran the two failing cells — compiled `CloseImageView.class` contains no `getIdentifier` call, AAR ships the keep file, and `aapt2 dump resources` confirms both previously-failing configurations now keep `ct_close`:

| Cell | Before fix | After fix |
|---|---|---|
| strict shrink mode, AGP 8.9.3 | ❌ stripped | ✅ kept |
| optimized resource shrinking, AGP 8.13 | ❌ stripped | ✅ kept |

- Manual device test: sample app built from this branch with `minifyEnabled` + `shrinkResources` + strict keep.xml renders the in-app close button correctly and dismisses on tap.

No behavior change for apps not using resource shrinking; app-side overrides of `ct_close` continue to work via resource merging.

[SDK-5897]: https://wizrocket.atlassian.net/browse/SDK-5897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the close button display by using a fixed app resource reference, making it more reliable at runtime.
  * Added a safeguard so the close icon asset is retained in builds and won’t be stripped out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->