### PR TITLE
fix(accessibility): BIS IS 17802 - InApp accessibility improvements

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -118,7 +118,7 @@ public interface Constants {
     String INAPP_KEY = "inApp";
     String INAPP_WZRK_PIVOT = "wzrk_pivot";
     String INAPP_WZRK_CGID = "wzrk_cgId";
-    int INAPP_CLOSE_IV_WIDTH = 40;
+    int INAPP_CLOSE_IV_WIDTH = 48;
     String INAPP_JS_ENABLED = "isJsEnabled";
     String NOTIFICATION_ID_TAG = "wzrk_id";
     String DEEP_LINK_KEY = "wzrk_dl";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
@@ -8,9 +8,11 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.util.AttributeSet;
 import android.util.TypedValue;
+import android.view.View;
 import androidx.appcompat.widget.AppCompatImageView;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.Logger;
+import com.clevertap.android.sdk.R;
 
 /**
  * Represents the close button.
@@ -24,18 +26,26 @@ public final class CloseImageView extends AppCompatImageView {
     public CloseImageView(Context context) {
         super(context);
         setId(VIEW_ID);
+        initAccessibility(context);
     }
 
     @SuppressLint("ResourceType")
     public CloseImageView(Context context, AttributeSet attrs) {
         super(context, attrs);
         setId(VIEW_ID);
+        initAccessibility(context);
     }
 
     @SuppressLint("ResourceType")
     public CloseImageView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         setId(VIEW_ID);
+        initAccessibility(context);
+    }
+
+    private void initAccessibility(Context context) {
+        setContentDescription(context.getString(R.string.ct_inapp_close_btn));
+        setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
     }
 
     @SuppressLint("DrawAllocation")

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -118,7 +118,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        ViewCompat.announceForAccessibility(view, "InApp message shown")
+        ViewCompat.announceForAccessibility(view, getString(R.string.ct_inapp_message_shown))
         didShow(null)
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.View
-
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 
@@ -118,6 +118,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        ViewCompat.announceForAccessibility(view, "InApp message shown")
         didShow(null)
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.View
-import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 
@@ -118,7 +117,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        ViewCompat.announceForAccessibility(view, getString(R.string.ct_inapp_message_shown))
+        view.announceForAccessibility(getString(R.string.ct_inapp_message_shown))
         didShow(null)
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppMediaHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppMediaHandler.kt
@@ -66,6 +66,9 @@ internal interface InAppMediaHandler : DefaultLifecycleObserver {
 internal fun View.setContentDescriptionIfNotBlank(contentDescription: String) {
     if (contentDescription.isNotBlank()) {
         this.contentDescription = contentDescription
+        this.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+    } else {
+        this.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
     }
 }
 

--- a/clevertap-core/src/main/res/layout/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover.xml
@@ -88,8 +88,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="10dp"
         android:layout_marginRight="10dp"

--- a/clevertap-core/src/main/res/layout/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover_image.xml
@@ -43,8 +43,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="10dp"
         android:layout_marginTop="10dp"

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
@@ -89,8 +89,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
@@ -45,8 +45,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial.xml
@@ -103,8 +103,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
@@ -48,8 +48,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="30dp"
         android:layout_marginTop="45dp"

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="ct_inbox_icon_content_description">Message Icon</string>
     <string name="ct_notification_big_picture_alt_text">Notification Big Picture</string>
     <string name="ct_inapp_close_btn">Close</string>
+    <string name="ct_inapp_message_shown">InApp message shown</string>
     <string name="ct_inapp_img">Inapp Image</string>
     <string name="ct_inapp_media">Inapp Media</string>
     <string name="ct_inapp_gif">Inapp Gif</string>


### PR DESCRIPTION
## Summary
- Increase inapp close button touch target from 30dp to 48dp (IS 17802 Clause 5.5)
- Add contentDescription and importantForAccessibility to CloseImageView
- Announce inapp message shown to screen readers
- Set importantForAccessibility on inapp images based on content description
- 
## Changes
- `Constants.java` — INAPP_CLOSE_IV_WIDTH 40 → 48
- `CloseImageView.java` — accessibility label + importantForAccessibility in all constructors
- `inapp_cover.xml`, `inapp_cover_image.xml` — close button 30dp → 48dp
- `inapp_half_interstitial.xml`, `inapp_half_interstitial_image.xml` — close button 30dp → 48dp
- `inapp_interstitial.xml`, `inapp_interstitial_image.xml` — close button 30dp → 48dp
- `CTInAppBaseFragment.kt` — screen change announcement on inapp shown
- `InAppMediaHandler.kt` — importantForAccessibility YES/NO based on content description
