### PR TITLE
BIS compliance for App Inbox and Push Templates

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -118,7 +118,8 @@ public interface Constants {
     String INAPP_KEY = "inApp";
     String INAPP_WZRK_PIVOT = "wzrk_pivot";
     String INAPP_WZRK_CGID = "wzrk_cgId";
-    int INAPP_CLOSE_IV_WIDTH = 48;
+    int INAPP_CLOSE_IV_WIDTH = 40;
+    int INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH = 48;
     String INAPP_JS_ENABLED = "isJsEnabled";
     String NOTIFICATION_ID_TAG = "wzrk_id";
     String DEEP_LINK_KEY = "wzrk_dl";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
@@ -20,7 +20,8 @@ import com.clevertap.android.sdk.R;
 public final class CloseImageView extends AppCompatImageView {
 
     public static final int VIEW_ID = 199272;
-    private final int canvasSize = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH);
+    private final int iconSize = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH);
+    private final int touchTargetSize = getScaledPixels(Constants.INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH);
 
     @SuppressLint("ResourceType")
     public CloseImageView(Context context) {
@@ -60,8 +61,9 @@ public final class CloseImageView extends AppCompatImageView {
 
             if (closeBitmap != null) {
                 Bitmap scaledCloseBitmap = Bitmap.createScaledBitmap(closeBitmap,
-                        canvasSize, canvasSize, true);
-                canvas.drawBitmap(scaledCloseBitmap, 0, 0, new Paint());
+                        iconSize, iconSize, true);
+                float offset = (touchTargetSize - iconSize) / 2f;
+                canvas.drawBitmap(scaledCloseBitmap, offset, offset, new Paint());
             } else {
                 Logger.v("Unable to find inapp notif close button image");
             }
@@ -73,7 +75,7 @@ public final class CloseImageView extends AppCompatImageView {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         // The image view is fixed in dip on all devices
-        setMeasuredDimension(canvasSize, canvasSize);
+        setMeasuredDimension(touchTargetSize, touchTargetSize);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.View
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 
@@ -118,7 +119,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.announceForAccessibility(getString(R.string.ct_inapp_message_shown))
+        ViewCompat.setAccessibilityPaneTitle(view, getString(R.string.ct_inapp_message_shown))
         didShow(null)
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
@@ -56,7 +56,7 @@ internal abstract class CTInAppBaseFullHtmlFragment : CTInAppBaseFullFragment() 
         closeIvLp.addRule(RelativeLayout.ABOVE, webViewId)
         closeIvLp.addRule(RelativeLayout.RIGHT_OF, webViewId)
 
-        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH) / 2
+        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH) / 2
         closeIvLp.setMargins(-sub, 0, 0, -sub)
         return closeIvLp
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppHtmlCoverFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppHtmlCoverFragment.kt
@@ -17,7 +17,7 @@ internal class CTInAppHtmlCoverFragment : CTInAppBaseFullHtmlFragment() {
         closeIvLp.addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
         closeIvLp.addRule(RelativeLayout.ALIGN_PARENT_TOP)
 
-        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH) / 4
+        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH) / 4
         closeIvLp.setMargins(0, sub, sub, 0)
         return closeIvLp
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverFragment.kt
@@ -11,6 +11,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -57,13 +58,18 @@ internal class CTInAppNativeCoverFragment : CTInAppBaseFullNativeFragment() {
             InAppMediaConfig(imageViewId = R.id.backgroundImage, clickableMedia = false, gifImageId = R.id.gifImage)
         )
 
+        relativeLayout.findViewById<View>(R.id.backgroundImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val textView1 = relativeLayout.findViewById<TextView>(R.id.cover_title)
         textView1.text = inAppNotification.title
         textView1.setTextColor(inAppNotification.titleColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView1, true)
 
         val textView2 = relativeLayout.findViewById<TextView>(R.id.cover_message)
         textView2.text = inAppNotification.message
         textView2.setTextColor(inAppNotification.messageColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView2, true)
 
         val buttons = inAppNotification.buttons
         if (buttons.size == 1) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverImageFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -49,6 +50,9 @@ internal class CTInAppNativeCoverImageFragment : CTInAppBaseFullFragment() {
             InAppMediaConfig(imageViewId = R.id.cover_image, clickableMedia = true, videoFrameId = R.id.video_frame, gifImageId = R.id.gifImage),
             CTInAppNativeButtonClickListener()
         )
+
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val closeImageView = fl.findViewById<CloseImageView>(CloseImageView.VIEW_ID)
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeFooterFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeFooterFragment.kt
@@ -12,6 +12,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -61,13 +62,18 @@ internal class CTInAppNativeFooterFragment : CTInAppBasePartialNativeFragment() 
             )
         )
 
+        ViewCompat.setScreenReaderFocusable(imageView, true)
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val textView1 = linearLayout2.findViewById<TextView>(R.id.footer_title)
         textView1.text = inAppNotification.title
         textView1.setTextColor(inAppNotification.titleColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView1, true)
 
         val textView2 = linearLayout2.findViewById<TextView>(R.id.footer_message)
         textView2.text = inAppNotification.message
         textView2.setTextColor(inAppNotification.messageColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView2, true)
 
         val buttons = inAppNotification.buttons
         if (!buttons.isEmpty()) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialFragment.kt
@@ -15,6 +15,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.DeviceInfo
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
@@ -138,6 +139,9 @@ internal class CTInAppNativeHalfInterstitialFragment : CTInAppBaseFullNativeFrag
             InAppMediaConfig(imageViewId = R.id.backgroundImage, clickableMedia = false, gifImageId = R.id.gifImage)
         )
 
+        relativeLayout?.findViewById<View>(R.id.backgroundImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val linearLayout =
             relativeLayout?.findViewById<LinearLayout>(R.id.half_interstitial_linear_layout)
         val mainButton = linearLayout?.findViewById<Button>(R.id.half_interstitial_button1)
@@ -148,10 +152,12 @@ internal class CTInAppNativeHalfInterstitialFragment : CTInAppBaseFullNativeFrag
         val textView1 = relativeLayout?.findViewById<TextView>(R.id.half_interstitial_title)
         textView1?.text = inAppNotification.title
         textView1?.setTextColor(inAppNotification.titleColor.toColorInt())
+        textView1?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val textView2 = relativeLayout?.findViewById<TextView>(R.id.half_interstitial_message)
         textView2?.text = inAppNotification.message
         textView2?.setTextColor(inAppNotification.messageColor.toColorInt())
+        textView2?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val buttons = inAppNotification.buttons
         if (buttons.size == 1) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialImageFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -136,6 +137,9 @@ internal class CTInAppNativeHalfInterstitialImageFragment : CTInAppBaseFullFragm
             InAppMediaConfig(imageViewId = R.id.half_interstitial_image, clickableMedia = true, videoFrameId = R.id.video_frame, gifImageId = R.id.gifImage),
             CTInAppNativeButtonClickListener()
         )
+
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         closeImageView.setOnClickListener {
             didDismiss(null)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHeaderFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHeaderFragment.kt
@@ -12,6 +12,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -62,13 +63,18 @@ internal class CTInAppNativeHeaderFragment : CTInAppBasePartialNativeFragment() 
             )
         )
 
+        ViewCompat.setScreenReaderFocusable(imageView, true)
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val textView1 = linearLayout2.findViewById<TextView>(R.id.header_title)
         textView1.text = inAppNotification.title
         textView1.setTextColor(inAppNotification.titleColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView1, true)
 
         val textView2 = linearLayout2.findViewById<TextView>(R.id.header_message)
         textView2.text = inAppNotification.message
         textView2.setTextColor(inAppNotification.messageColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView2, true)
 
         val buttons = inAppNotification.buttons
         if (!buttons.isEmpty()) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialFragment.kt
@@ -15,6 +15,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -68,6 +69,11 @@ internal class CTInAppNativeInterstitialFragment : CTInAppBaseFullNativeFragment
                 gifImageId = R.id.gifImage,
             )
         )
+
+        relativeLayout?.findViewById<View>(R.id.backgroundImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         setTitleAndMessage()
         setButtons()
         handleCloseButton()
@@ -121,10 +127,12 @@ internal class CTInAppNativeInterstitialFragment : CTInAppBaseFullNativeFragment
         val textView1 = relativeLayout?.findViewById<TextView>(R.id.interstitial_title)
         textView1?.text = inAppNotification.title
         textView1?.setTextColor(inAppNotification.titleColor.toColorInt())
+        textView1?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val textView2 = relativeLayout?.findViewById<TextView>(R.id.interstitial_message)
         textView2?.text = inAppNotification.message
         textView2?.setTextColor(inAppNotification.messageColor.toColorInt())
+        textView2?.let { ViewCompat.setScreenReaderFocusable(it, true) }
     }
 
     private fun resizeContainer(fl: FrameLayout, closeImageView: CloseImageView) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialImageFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -119,6 +120,9 @@ internal class CTInAppNativeInterstitialImageFragment : CTInAppBaseFullFragment(
             InAppMediaConfig(imageViewId = R.id.interstitial_image, clickableMedia = true, videoFrameId = R.id.video_frame, gifImageId = R.id.gifImage),
             CTInAppNativeButtonClickListener()
         )
+
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         closeImageView.setOnClickListener {
             didDismiss(null)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppGifHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppGifHandler.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.RelativeLayout
 import androidx.lifecycle.LifecycleOwner
+import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.gif.GifImageView
 import com.clevertap.android.sdk.inapp.CTInAppNotificationMedia
 import com.clevertap.android.sdk.inapp.images.FileResourceProvider
@@ -23,7 +24,10 @@ internal class InAppGifHandler(
         if (config.gifImageId == 0) return
         val gifByteArray = resourceProvider.cachedInAppGifV1(media.mediaUrl) ?: return
         gifImageView = relativeLayout?.findViewById(config.gifImageId)
-        gifImageView?.setContentDescriptionIfNotBlank(media.contentDescription)
+        gifImageView?.setContentDescriptionOrDefault(
+            media.contentDescription,
+            gifImageView?.context?.getString(R.string.ct_inapp_gif).orEmpty()
+        )
         gifImageView?.visibility = View.VISIBLE
         gifImageView?.setBytes(gifByteArray)
         gifImageView?.startAnimation()

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppGifHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppGifHandler.kt
@@ -24,10 +24,12 @@ internal class InAppGifHandler(
         if (config.gifImageId == 0) return
         val gifByteArray = resourceProvider.cachedInAppGifV1(media.mediaUrl) ?: return
         gifImageView = relativeLayout?.findViewById(config.gifImageId)
-        gifImageView?.setContentDescriptionOrDefault(
-            media.contentDescription,
-            gifImageView?.context?.getString(R.string.ct_inapp_gif).orEmpty()
-        )
+        gifImageView?.let { view ->
+            view.setContentDescriptionOrDefault(
+                media.contentDescription,
+                view.context.getString(R.string.ct_inapp_gif)
+            )
+        }
         gifImageView?.visibility = View.VISIBLE
         gifImageView?.setBytes(gifByteArray)
         gifImageView?.startAnimation()

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppImageHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppImageHandler.kt
@@ -23,7 +23,7 @@ internal class InAppImageHandler(
     ) {
         val bitmap = resourceProvider.cachedInAppImageV1(media.mediaUrl) ?: return
         val layout = relativeLayout ?: return
-        val imageView = layout.findViewById<ImageView>(config.imageViewId)
+        val imageView = layout.findViewById<ImageView>(config.imageViewId) ?: return
         imageView.setContentDescriptionOrDefault(
             media.contentDescription,
             imageView.context.getString(R.string.ct_inapp_img)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppImageHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppImageHandler.kt
@@ -22,16 +22,17 @@ internal class InAppImageHandler(
         clickListener: View.OnClickListener?
     ) {
         val bitmap = resourceProvider.cachedInAppImageV1(media.mediaUrl) ?: return
-        val imageView = relativeLayout?.findViewById<ImageView>(config.imageViewId)
-        imageView?.setContentDescriptionOrDefault(
+        val layout = relativeLayout ?: return
+        val imageView = layout.findViewById<ImageView>(config.imageViewId)
+        imageView.setContentDescriptionOrDefault(
             media.contentDescription,
             imageView.context.getString(R.string.ct_inapp_img)
         )
-        imageView?.setImageBitmap(bitmap)
-        imageView?.visibility = View.VISIBLE
+        imageView.setImageBitmap(bitmap)
+        imageView.visibility = View.VISIBLE
         if (config.clickableMedia && clickListener != null) {
-            imageView?.tag = 0
-            imageView?.setOnClickListener(clickListener)
+            imageView.tag = 0
+            imageView.setOnClickListener(clickListener)
         }
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppImageHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppImageHandler.kt
@@ -3,6 +3,7 @@ package com.clevertap.android.sdk.inapp.media
 import android.view.View
 import android.widget.ImageView
 import android.widget.RelativeLayout
+import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.CTInAppNotificationMedia
 import com.clevertap.android.sdk.inapp.images.FileResourceProvider
 
@@ -22,7 +23,10 @@ internal class InAppImageHandler(
     ) {
         val bitmap = resourceProvider.cachedInAppImageV1(media.mediaUrl) ?: return
         val imageView = relativeLayout?.findViewById<ImageView>(config.imageViewId)
-        imageView?.setContentDescriptionIfNotBlank(media.contentDescription)
+        imageView?.setContentDescriptionOrDefault(
+            media.contentDescription,
+            imageView.context.getString(R.string.ct_inapp_img)
+        )
         imageView?.setImageBitmap(bitmap)
         imageView?.visibility = View.VISIBLE
         if (config.clickableMedia && clickListener != null) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppMediaHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppMediaHandler.kt
@@ -63,13 +63,9 @@ internal interface InAppMediaHandler : DefaultLifecycleObserver {
     }
 }
 
-internal fun View.setContentDescriptionIfNotBlank(contentDescription: String) {
-    if (contentDescription.isNotBlank()) {
-        this.contentDescription = contentDescription
-        this.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
-    } else {
-        this.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
-    }
+internal fun View.setContentDescriptionOrDefault(contentDescription: String, defaultDescription: String) {
+    this.contentDescription = contentDescription.ifBlank { defaultDescription }
+    this.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
 }
 
 /**

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppStreamMediaHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppStreamMediaHandler.kt
@@ -75,10 +75,12 @@ internal class InAppStreamMediaHandler
             onBackPressedCallback.isEnabled = true
             openFullscreenDialog()
         }
-        videoFrameLayout?.setContentDescriptionOrDefault(
-            media.contentDescription,
-            videoFrameLayout?.context?.getString(R.string.ct_inapp_media).orEmpty()
-        )
+        videoFrameLayout?.let { layout ->
+            layout.setContentDescriptionOrDefault(
+                media.contentDescription,
+                layout.context.getString(R.string.ct_inapp_media)
+            )
+        }
     }
 
     override fun onResume(owner: LifecycleOwner) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppStreamMediaHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppStreamMediaHandler.kt
@@ -12,6 +12,7 @@ import com.clevertap.android.sdk.applyInsetsWithMarginAdjustment
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.media3.common.util.UnstableApi
+import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.CTInAppNotificationMedia
 import com.clevertap.android.sdk.video.InAppVideoPlayerHandle
 import com.clevertap.android.sdk.video.VideoLibChecker
@@ -74,7 +75,10 @@ internal class InAppStreamMediaHandler
             onBackPressedCallback.isEnabled = true
             openFullscreenDialog()
         }
-        videoFrameLayout?.setContentDescriptionIfNotBlank(media.contentDescription)
+        videoFrameLayout?.setContentDescriptionOrDefault(
+            media.contentDescription,
+            videoFrameLayout?.context?.getString(R.string.ct_inapp_media).orEmpty()
+        )
     }
 
     override fun onResume(owner: LifecycleOwner) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
@@ -57,6 +57,14 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
             }
             dots[position].setImageDrawable(
                     ResourcesCompat.getDrawable(context.getResources(), R.drawable.ct_selected_dot, null));
+            int totalPages = inboxMessage.getInboxMessageContents().size();
+            String imageDesc = getImageContentDescription(context, inboxMessage, position);
+            String announcement = context.getString(R.string.ct_carousel_page_announcement,
+                    imageDesc, position + 1, totalPages);
+            viewHolder.imageViewPager.setContentDescription(
+                    context.getString(R.string.ct_carousel_content_description,
+                            imageDesc, position + 1, totalPages));
+            viewHolder.imageViewPager.announceForAccessibility(announcement);
         }
     }
 
@@ -67,6 +75,8 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
     private final CTCarouselViewPager imageViewPager;
 
     private final LinearLayout sliderDots;
+
+    private CarouselPageChangeListener activePageChangeListener;
 
     CTCarouselImageViewHolder(@NonNull View itemView) {
         super(itemView);
@@ -101,6 +111,10 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
         CTCarouselViewPagerAdapter carouselViewPagerAdapter = new CTCarouselViewPagerAdapter(appContext, parent,
                 inboxMessage, layoutParams, position);
         this.imageViewPager.setAdapter(carouselViewPagerAdapter);
+        int itemCount = inboxMessage.getInboxMessageContents().size();
+        String firstImageDesc = getImageContentDescription(appContext, inboxMessage, 0);
+        this.imageViewPager.setContentDescription(
+                appContext.getString(R.string.ct_carousel_content_description, firstImageDesc, 1, itemCount));
         //Adds the dots for the carousel
         int dotsCount = inboxMessage.getInboxMessageContents().size();
         if (this.sliderDots.getChildCount() > 0) {
@@ -110,10 +124,12 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
         setDots(dots, dotsCount, appContext, this.sliderDots);
         dots[0].setImageDrawable(
                 ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_selected_dot, null));
-        CTCarouselImageViewHolder.CarouselPageChangeListener carouselPageChangeListener
-                = new CTCarouselImageViewHolder.CarouselPageChangeListener(
+        if (activePageChangeListener != null) {
+            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
+        }
+        activePageChangeListener = new CTCarouselImageViewHolder.CarouselPageChangeListener(
                 parent.getActivity().getApplicationContext(), this, dots, inboxMessage);
-        this.imageViewPager.addOnPageChangeListener(carouselPageChangeListener);
+        this.imageViewPager.addOnPageChangeListener(activePageChangeListener);
 
         this.clickLayout.setOnClickListener(
                 new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true, APP_INBOX_ITEM_INDEX));

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
@@ -65,6 +65,14 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
             viewHolder.message.setText(inboxMessage.getInboxMessageContents().get(position).getMessage());
             viewHolder.message.setTextColor(
                     Color.parseColor(inboxMessage.getInboxMessageContents().get(position).getMessageColor()));
+            int totalPages = inboxMessage.getInboxMessageContents().size();
+            String imageDesc = getImageContentDescription(context, inboxMessage, position);
+            String announcement = context.getString(R.string.ct_carousel_page_announcement,
+                    imageDesc, position + 1, totalPages);
+            viewHolder.imageViewPager.setContentDescription(
+                    context.getString(R.string.ct_carousel_content_description,
+                            imageDesc, position + 1, totalPages));
+            viewHolder.imageViewPager.announceForAccessibility(announcement);
         }
     }
 
@@ -74,6 +82,8 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
 
 
     private final LinearLayout sliderDots;
+
+    private CarouselPageChangeListener activePageChangeListener;
 
     private final TextView title;
 
@@ -123,6 +133,10 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
         CTCarouselViewPagerAdapter carouselViewPagerAdapter = new CTCarouselViewPagerAdapter(appContext, parent,
                 inboxMessage, layoutParams, position);
         this.imageViewPager.setAdapter(carouselViewPagerAdapter);
+        int itemCount = inboxMessage.getInboxMessageContents().size();
+        String firstImageDesc = getImageContentDescription(appContext, inboxMessage, 0);
+        this.imageViewPager.setContentDescription(
+                appContext.getString(R.string.ct_carousel_content_description, firstImageDesc, 1, itemCount));
         //Adds the dots for the carousel
         int dotsCount = inboxMessage.getInboxMessageContents().size();
         if (this.sliderDots.getChildCount() > 0) {
@@ -132,10 +146,12 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
         setDots(dots, dotsCount, appContext, this.sliderDots);
         dots[0].setImageDrawable(
                 ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_selected_dot, null));
-        CTCarouselMessageViewHolder.CarouselPageChangeListener carouselPageChangeListener
-                = new CTCarouselMessageViewHolder.CarouselPageChangeListener(
+        if (activePageChangeListener != null) {
+            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
+        }
+        activePageChangeListener = new CTCarouselMessageViewHolder.CarouselPageChangeListener(
                 parent.getActivity().getApplicationContext(), this, dots, inboxMessage);
-        this.imageViewPager.addOnPageChangeListener(carouselPageChangeListener);
+        this.imageViewPager.addOnPageChangeListener(activePageChangeListener);
 
         this.clickLayout.setOnClickListener(
                 new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true, APP_INBOX_ITEM_INDEX));

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
@@ -1,35 +1,102 @@
 package com.clevertap.android.sdk.inbox;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
+import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
+import androidx.core.view.AccessibilityDelegateCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 import androidx.viewpager.widget.ViewPager;
+import com.clevertap.android.sdk.R;
 
-/**
- * Custom Viewpager class to handle orientation of images
- */
 @RestrictTo(Scope.LIBRARY)
 public class CTCarouselViewPager extends ViewPager {
 
-    /**
-     * Constructor
-     *
-     * @param context the context
-     */
     public CTCarouselViewPager(Context context) {
         super(context);
+        setupAccessibility();
     }
 
-    /**
-     * Constructor
-     *
-     * @param context the context
-     * @param attrs   the attribute set
-     */
     public CTCarouselViewPager(Context context, AttributeSet attrs) {
         super(context, attrs);
+        setupAccessibility();
+    }
+
+    private void setupAccessibility() {
+        setFocusable(true);
+        setFocusableInTouchMode(true);
+        setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
+        final AccessibilityDelegateCompat originalDelegate = ViewCompat.getAccessibilityDelegate(this);
+        ViewCompat.setAccessibilityDelegate(this, new AccessibilityDelegateCompat() {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(@NonNull View host,
+                    @NonNull AccessibilityNodeInfoCompat info) {
+                if (originalDelegate != null) {
+                    originalDelegate.onInitializeAccessibilityNodeInfo(host, info);
+                } else {
+                    super.onInitializeAccessibilityNodeInfo(host, info);
+                }
+                info.setClassName("android.widget.ScrollView");
+                if (getAdapter() != null && getAdapter().getCount() > 1) {
+                    info.setScrollable(true);
+                    if (getCurrentItem() < getAdapter().getCount() - 1) {
+                        info.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_SCROLL_FORWARD);
+                    }
+                    if (getCurrentItem() > 0) {
+                        info.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_SCROLL_BACKWARD);
+                    }
+                }
+            }
+
+            @Override
+            public void onInitializeAccessibilityEvent(@NonNull View host,
+                    @NonNull AccessibilityEvent event) {
+                if (originalDelegate != null) {
+                    originalDelegate.onInitializeAccessibilityEvent(host, event);
+                } else {
+                    super.onInitializeAccessibilityEvent(host, event);
+                }
+            }
+
+            @Override
+            public boolean performAccessibilityAction(@NonNull View host, int action, Bundle args) {
+                if (action == AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD) {
+                    if (getAdapter() != null && getCurrentItem() < getAdapter().getCount() - 1) {
+                        setCurrentItem(getCurrentItem() + 1, true);
+                        restoreAccessibilityFocus();
+                        return true;
+                    }
+                } else if (action == AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD) {
+                    if (getCurrentItem() > 0) {
+                        setCurrentItem(getCurrentItem() - 1, true);
+                        restoreAccessibilityFocus();
+                        return true;
+                    }
+                }
+                if (originalDelegate != null) {
+                    return originalDelegate.performAccessibilityAction(host, action, args);
+                }
+                return super.performAccessibilityAction(host, action, args);
+            }
+        });
+    }
+
+    private void restoreAccessibilityFocus() {
+        postDelayed(() -> {
+            clearFocus();
+            requestFocus();
+            sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+            ViewCompat.performAccessibilityAction(
+                    CTCarouselViewPager.this,
+                    AccessibilityNodeInfoCompat.ACTION_ACCESSIBILITY_FOCUS,
+                    null
+            );
+        }, 300);
     }
 
     @Override
@@ -49,32 +116,5 @@ public class CTCarouselViewPager extends ViewPager {
         }
 
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-    }
-
-    /**
-     * Determines the height of this view
-     *
-     * @param measureSpec A measureSpec packed into an int
-     * @param view        the base view with already measured height
-     * @return The height of the view, honoring constraints from measureSpec
-     */
-    @SuppressWarnings({"unused"})
-    private int measureHeight(int measureSpec, View view) {
-        int result = 0;
-        int specMode = MeasureSpec.getMode(measureSpec);
-        int specSize = MeasureSpec.getSize(measureSpec);
-
-        if (specMode == MeasureSpec.EXACTLY) {
-            result = specSize;
-        } else {
-            // set the height from the base view if available
-            if (view != null) {
-                result = view.getMeasuredHeight();
-            }
-            if (specMode == MeasureSpec.AT_MOST) {
-                result = Math.min(result, specSize);
-            }
-        }
-        return result;
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPagerAdapter.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPagerAdapter.java
@@ -94,11 +94,8 @@ public class CTCarouselViewPagerAdapter extends PagerAdapter {
 
     void addImageAndSetClick(ImageView imageView, View view, final int position, ViewGroup container) {
         imageView.setVisibility(View.VISIBLE);
-        String contentDescription = carouselImagesData.get(position).getContentDescription();
-        if (contentDescription.isEmpty()) {
-            contentDescription = context.getString(R.string.ct_inbox_image_content_description) + (position + 1);
-        }
-        imageView.setContentDescription(contentDescription);
+        imageView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+        view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
         try {
             Glide.with(imageView.getContext())
                     .load(carouselImagesData.get(position).getUrl())

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.Logger;
+import androidx.core.view.ViewCompat;
 import com.clevertap.android.sdk.R;
 import com.clevertap.android.sdk.Utils;
 import org.json.JSONArray;
@@ -67,6 +68,10 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
         ctaLinearLayout = itemView.findViewById(R.id.cta_linear_layout);
         progressBarFrameLayout = itemView.findViewById(R.id.icon_progress_frame_layout);
         mediaLayout = itemView.findViewById(R.id.media_layout);
+
+        ViewCompat.setScreenReaderFocusable(title, true);
+        ViewCompat.setScreenReaderFocusable(message, true);
+        ViewCompat.setScreenReaderFocusable(timestamp, true);
     }
 
     @Override
@@ -165,11 +170,18 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
 
         this.mediaImage.setVisibility(View.GONE);
         this.mediaImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.mediaImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.mediaImage, false);
         this.squareImage.setVisibility(View.GONE);
         this.squareImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.squareImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.squareImage, false);
         this.defaultImage.setVisibility(View.GONE);
         this.defaultImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.defaultImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.defaultImage, false);
+        this.iconImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.iconImage, false);
         this.mediaLayout.setVisibility(View.GONE);
         this.progressBarFrameLayout.setVisibility(View.GONE);
         try {
@@ -177,6 +189,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "l":
                     if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.mediaImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.mediaImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -268,6 +281,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "p":
                     if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.squareImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.squareImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -369,6 +383,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                     if (!TextUtils.isEmpty(content.getMedia())) {
                         if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                             this.defaultImage.setContentDescription(content.getMediaContentDescription());
+                            ViewCompat.setScreenReaderFocusable(this.defaultImage, true);
                         }
                         if (content.mediaIsImage()) {
                             this.mediaLayout.setVisibility(View.VISIBLE);
@@ -486,6 +501,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 iconImage.setVisibility(View.VISIBLE);
                 if (!content.getIconContentDescription().isEmpty()) {
                     iconImage.setContentDescription(content.getIconContentDescription());
+                    ViewCompat.setScreenReaderFocusable(iconImage, true);
                 }
                 try {
                     Glide.with(iconImage.getContext())

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
@@ -145,6 +145,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         this.cta3.setText(content.getLinkText(cta3Object));
                         this.cta3.setTextColor(Color.parseColor(content.getLinkColor(cta3Object)));
                         this.cta3.setBackgroundColor(Color.parseColor(content.getLinkBGColor(cta3Object)));
+                        showThreeButtons(this.cta1, this.cta2, this.cta3);
                         if (parentWeak != null) {
                             this.cta1.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
                                     this.cta1.getText().toString(), cta1Object, parentWeak,false, APP_INBOX_CTA1_INDEX));

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
@@ -269,6 +269,14 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
         }
     }
 
+    String getImageContentDescription(Context context, CTInboxMessage inboxMessage, int position) {
+        String desc = inboxMessage.getInboxMessageContents().get(position).getMediaContentDescription();
+        if (desc == null || desc.isEmpty()) {
+            desc = context.getString(R.string.ct_inbox_image_content_description) + " " + (position + 1);
+        }
+        return desc;
+    }
+
     void setDots(ImageView[] dots, int dotsCount, Context appContext, LinearLayout sliderDots) {
         for (int k = 0; k < dotsCount; k++) {
             dots[k] = new ImageView(appContext);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
@@ -215,17 +215,17 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
 
     void hideOneButton(Button mainButton, Button secondaryButton, Button tertiaryButton) {
         tertiaryButton.setVisibility(View.GONE);
-        mainButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 3));
-        secondaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 3));
-        tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 0));
+        mainButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 3));
+        secondaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 3));
+        tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 0));
     }
 
     void hideTwoButtons(Button mainButton, Button secondaryButton, Button tertiaryButton) {
         secondaryButton.setVisibility(View.GONE);
         tertiaryButton.setVisibility(View.GONE);
-        mainButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 6));
-        secondaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 0));
-        tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 0));
+        mainButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 6));
+        secondaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 0));
+        tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 0));
     }
 
     public boolean needsMediaPlayer() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
@@ -220,6 +220,12 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
         tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 0));
     }
 
+    void showThreeButtons(Button mainButton, Button secondaryButton, Button tertiaryButton) {
+        mainButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 2));
+        secondaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 2));
+        tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 2));
+    }
+
     void hideTwoButtons(Button mainButton, Button secondaryButton, Button tertiaryButton) {
         secondaryButton.setVisibility(View.GONE);
         tertiaryButton.setVisibility(View.GONE);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.core.view.ViewCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import com.clevertap.android.sdk.R;
 import java.lang.ref.WeakReference;
@@ -134,9 +135,11 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
             // Initial state setup
             setMuteIconState(muteIcon, context, currentVolume);
 
-            int iconWidth = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30, displayMetrics);
-            int iconHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30, displayMetrics);
-            FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(iconWidth, iconHeight);
+            // 48dp tap target; 9dp padding keeps the visual icon at 30dp
+            int iconSize = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 48, displayMetrics);
+            int iconPadding = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 9, displayMetrics);
+            muteIcon.setPadding(iconPadding, iconPadding, iconPadding, iconPadding);
+            FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(iconSize, iconSize);
             int iconTop = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4, displayMetrics);
             int iconRight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 2, displayMetrics);
             layoutParams.setMargins(0, iconTop, iconRight, 0);
@@ -158,8 +161,9 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
     private void setMuteIconState(ImageView icon, Context context, float volume) {
         boolean isMuted = volume <= 0;
         int drawableRes = isMuted ? R.drawable.ct_volume_off : R.drawable.ct_volume_on;
-        int contentDescRes = isMuted ? R.string.ct_mute_button_content_description
-                : R.string.ct_unmute_button_content_description;
+        // When muted, the action available is "Unmute"; when audible, the action is "Mute"
+        int contentDescRes = isMuted ? R.string.ct_unmute_button_content_description
+                : R.string.ct_mute_button_content_description;
 
         icon.setContentDescription(context.getString(contentDescRes));
         icon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), drawableRes, null));
@@ -211,17 +215,17 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
 
     void hideOneButton(Button mainButton, Button secondaryButton, Button tertiaryButton) {
         tertiaryButton.setVisibility(View.GONE);
-        mainButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 3));
-        secondaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 3));
-        tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 0));
+        mainButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 3));
+        secondaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 3));
+        tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 0));
     }
 
     void hideTwoButtons(Button mainButton, Button secondaryButton, Button tertiaryButton) {
         secondaryButton.setVisibility(View.GONE);
         tertiaryButton.setVisibility(View.GONE);
-        mainButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 6));
-        secondaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 0));
-        tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 0));
+        mainButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 6));
+        secondaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 0));
+        tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 0));
     }
 
     public boolean needsMediaPlayer() {
@@ -265,6 +269,7 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
             dots[k].setVisibility(View.VISIBLE);
             dots[k].setImageDrawable(
                     ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_unselected_dot, null));
+            ViewCompat.setImportantForAccessibility(dots[k], ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO);
             LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT,
                     LinearLayout.LayoutParams.WRAP_CONTENT);
             params.setMargins(8, 6, 4, 6);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
@@ -141,6 +141,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         this.cta3.setText(content.getLinkText(cta3Object));
                         this.cta3.setTextColor(Color.parseColor(content.getLinkColor(cta3Object)));
                         this.cta3.setBackgroundColor(Color.parseColor(content.getLinkBGColor(cta3Object)));
+                        showThreeButtons(this.cta1, this.cta2, this.cta3);
                         if (parentWeak != null) {
                             this.cta1.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
                                     this.cta1.getText().toString(), cta1Object, parentWeak,false, APP_INBOX_CTA1_INDEX));

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
@@ -19,6 +19,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.Logger;
+import androidx.core.view.ViewCompat;
 import com.clevertap.android.sdk.R;
 import com.clevertap.android.sdk.Utils;
 import org.json.JSONArray;
@@ -160,11 +161,16 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
         }
         this.mediaImage.setVisibility(View.GONE);
         this.mediaImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.mediaImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.mediaImage, false);
         this.squareImage.setVisibility(View.GONE);
         this.squareImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.squareImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.squareImage, false);
         this.defaultImage.setVisibility(View.GONE);
         this.defaultImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.defaultImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.defaultImage, false);
         this.mediaLayout.setVisibility(View.GONE);
         this.progressBarFrameLayout.setVisibility(View.GONE);
         try {
@@ -172,6 +178,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "l":
                     if(!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.mediaImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.mediaImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -262,6 +269,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "p":
                     if(!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.squareImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.squareImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -360,6 +368,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                     if (!TextUtils.isEmpty(content.getMedia())) {
                         if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                             this.defaultImage.setContentDescription(content.getMediaContentDescription());
+                            ViewCompat.setScreenReaderFocusable(this.defaultImage, true);
                         }
                         if (content.mediaIsImage()) {
                             this.mediaLayout.setVisibility(View.VISIBLE);

--- a/clevertap-core/src/main/res/layout-land/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="30sp"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -58,8 +55,7 @@
             android:gravity="center"
             android:maxLines="2"
             android:textColor="@android:color/black"
-            android:textSize="22sp"
-            android:focusable="true" />
+            android:textSize="22sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"
@@ -92,8 +88,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="10dp"
         android:layout_marginTop="10dp"

--- a/clevertap-core/src/main/res/layout-land/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,14 +36,13 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="10dp"
         android:layout_marginTop="10dp"

--- a/clevertap-core/src/main/res/layout-land/inapp_footer.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_footer.xml
@@ -14,8 +14,7 @@
             android:id="@+id/footer_linear_layout_1"
             android:layout_width="match_parent"
             android:layout_height="118dp"
-            android:orientation="horizontal"
-            android:focusable="true" >
+            android:orientation="horizontal" >
 
             <FrameLayout
                 android:id="@+id/footer_media_container"
@@ -57,7 +56,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="20dp"
                     android:textSize="@dimen/txt_size_inapp_footer_title"
-                    android:textStyle="bold" />
+                    android:textStyle="bold"
+                    android:focusable="true" />
 
                 <TextView
                     android:id="@+id/footer_message"
@@ -65,7 +65,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
                     android:maxLines="3"
-                    android:textSize="@dimen/txt_size_inapp_footer_message" />
+                    android:textSize="@dimen/txt_size_inapp_footer_message"
+                    android:focusable="true" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inapp_footer.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_footer.xml
@@ -28,7 +28,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -37,7 +36,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>
@@ -56,8 +54,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="20dp"
                     android:textSize="@dimen/txt_size_inapp_footer_title"
-                    android:textStyle="bold"
-                    android:focusable="true" />
+                    android:textStyle="bold" />
 
                 <TextView
                     android:id="@+id/footer_message"
@@ -65,8 +62,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
                     android:maxLines="3"
-                    android:textSize="@dimen/txt_size_inapp_footer_message"
-                    android:focusable="true" />
+                    android:textSize="@dimen/txt_size_inapp_footer_message" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -43,8 +41,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -60,8 +57,7 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"
@@ -99,8 +95,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_half_interstitial_image.xml
@@ -28,7 +28,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,15 +37,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_header.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_header.xml
@@ -13,8 +13,7 @@
             android:id="@+id/header_linear_layout_1"
             android:layout_width="match_parent"
             android:layout_height="118dp"
-            android:orientation="horizontal"
-            android:focusable="true">
+            android:orientation="horizontal">
 
             <FrameLayout
                 android:id="@+id/header_media_container"
@@ -55,7 +54,8 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="20dp"
                     android:textSize="16sp"
-                    android:textStyle="bold" />
+                    android:textStyle="bold"
+                    android:focusable="true" />
 
                 <TextView
                     android:id="@+id/header_message"
@@ -64,7 +64,8 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="4dp"
                     android:maxLines="3"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    android:focusable="true" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inapp_header.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_header.xml
@@ -27,7 +27,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -36,7 +35,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>
@@ -54,8 +52,7 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="20dp"
                     android:textSize="16sp"
-                    android:textStyle="bold"
-                    android:focusable="true" />
+                    android:textStyle="bold" />
 
                 <TextView
                     android:id="@+id/header_message"
@@ -64,8 +61,7 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="4dp"
                     android:maxLines="3"
-                    android:textSize="14sp"
-                    android:focusable="true" />
+                    android:textSize="14sp" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_interstitial.xml
@@ -23,8 +23,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +39,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:focusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +47,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:focusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +54,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:focusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -75,8 +71,7 @@
             android:gravity="center"
             android:maxLines="2"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_message" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"
@@ -115,8 +110,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_interstitial.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:focusable="true"
         android:layout_margin="35dp">
 
         <TextView
@@ -24,7 +23,8 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold" />
+            android:textStyle="bold"
+            android:focusable="true" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,6 +40,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
+                android:focusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -48,6 +49,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
+                android:focusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -55,6 +57,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
+                android:focusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -72,7 +75,8 @@
             android:gravity="center"
             android:maxLines="2"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message" />
+            android:textSize="@dimen/txt_size_inapp_message"
+            android:focusable="true" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout-land/inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,15 +40,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inbox_carousel_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_carousel_layout.xml
@@ -49,7 +49,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="10dp"
                     android:layout_marginRight="10dp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
                 <ImageView
                     android:id="@+id/read_circle"
@@ -60,6 +61,8 @@
                     android:layout_marginLeft="10dp"
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
+                    android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                    android:importantForAccessibility="yes"
                     android:src="@drawable/ct_read_circle" />
             </LinearLayout>
         </RelativeLayout>

--- a/clevertap-core/src/main/res/layout-land/inbox_carousel_text_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_carousel_text_layout.xml
@@ -39,6 +39,7 @@
                     android:layout_marginTop="10dp"
                     android:maxLines="2"
                     android:textColor="@android:color/black"
+                    android:textSize="@dimen/ct_inbox_title_text_size"
                     android:textStyle="bold" />
 
                 <TextView
@@ -51,7 +52,8 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_body_text_size" />
 
                 <RelativeLayout
                     android:id="@+id/timestamp_linear_layout"
@@ -81,7 +83,8 @@
                             android:layout_height="wrap_content"
                             android:layout_marginEnd="10dp"
                             android:layout_marginRight="10dp"
-                            android:textColor="@android:color/darker_gray" />
+                            android:textColor="@android:color/darker_gray"
+                        android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
                         <ImageView
                             android:id="@+id/read_circle"
@@ -92,6 +95,8 @@
                             android:layout_marginLeft="10dp"
                             android:layout_marginRight="20dp"
                             android:layout_marginStart="10dp"
+                            android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                            android:importantForAccessibility="yes"
                             android:src="@drawable/ct_read_circle" />
                     </LinearLayout>
                 </RelativeLayout>
@@ -113,9 +118,10 @@
                 android:layout_height="match_parent"
                 android:layout_weight="2"
                 android:background="@android:color/white"
+                android:importantForAccessibility="yes"
                 android:padding="2dp"
                 android:textColor="@android:color/holo_blue_light"
-                android:textSize="14sp"
+                android:textSize="@dimen/ct_inbox_cta_button_text_size"
                 android:visibility="gone" />
 
             <Button
@@ -124,9 +130,10 @@
                 android:layout_height="match_parent"
                 android:layout_weight="2"
                 android:background="@android:color/white"
+                android:importantForAccessibility="yes"
                 android:padding="2dp"
                 android:textColor="@android:color/holo_blue_light"
-                android:textSize="14sp"
+                android:textSize="@dimen/ct_inbox_cta_button_text_size"
                 android:visibility="gone" />
 
             <Button
@@ -135,9 +142,10 @@
                 android:layout_height="match_parent"
                 android:layout_weight="2"
                 android:background="@android:color/white"
+                android:importantForAccessibility="yes"
                 android:padding="2dp"
                 android:textColor="@android:color/holo_blue_light"
-                android:textSize="14sp"
+                android:textSize="@dimen/ct_inbox_cta_button_text_size"
                 android:visibility="gone" />
         </LinearLayout>
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout-land/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_icon_message_layout.xml
@@ -27,7 +27,7 @@
                     android:layout_height="wrap_content"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+
                     android:visibility="gone" />
 
                 <com.clevertap.android.sdk.customviews.HorizontalSquareImageView
@@ -37,7 +37,7 @@
                     android:layout_centerInParent="true"
                     android:scaleType="centerCrop"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+
                     android:visibility="gone" />
 
                 <ImageView
@@ -47,7 +47,7 @@
                     android:adjustViewBounds="true"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+
                     android:visibility="gone" />
 
                 <FrameLayout
@@ -98,7 +98,7 @@
                         android:layout_marginStart="8dp"
                         android:layout_marginTop="8dp"
                         android:contentDescription="@string/ct_inbox_icon_content_description"
-                        android:focusable="true"
+    
                         android:scaleType="fitCenter" />
 
                     <TextView
@@ -111,8 +111,9 @@
                         android:layout_marginStart="10dp"
                         android:layout_marginTop="10dp"
                         android:maxLines="2"
-                        android:focusable="true"
+    
                         android:textColor="@android:color/black"
+                        android:textSize="@dimen/ct_inbox_title_text_size"
                         android:textStyle="bold" />
 
                 </LinearLayout>
@@ -127,8 +128,9 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:focusable="true"
-                    android:textColor="@android:color/darker_gray" />
+
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_body_text_size" />
             </RelativeLayout>
         </LinearLayout>
 
@@ -148,8 +150,8 @@
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
                 android:gravity="end"
-                android:focusable="true"
-                android:textColor="@android:color/darker_gray" />
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
             <ImageView
                 android:id="@+id/read_circle"
@@ -158,6 +160,8 @@
                 android:layout_gravity="center"
                 android:layout_marginEnd="20dp"
                 android:layout_marginRight="20dp"
+                android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                android:importantForAccessibility="yes"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
 
@@ -184,9 +188,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -195,9 +200,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -206,9 +212,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
     </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_simple_message_layout.xml
@@ -28,7 +28,6 @@
                     android:layout_height="wrap_content"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
                     android:visibility="gone" />
 
                 <com.clevertap.android.sdk.customviews.HorizontalSquareImageView
@@ -38,7 +37,7 @@
                     android:layout_centerInParent="true"
                     android:scaleType="centerCrop"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+
                     android:visibility="gone" />
 
                 <ImageView
@@ -48,7 +47,7 @@
                     android:adjustViewBounds="true"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+
                     android:visibility="gone" />
 
                 <FrameLayout
@@ -90,6 +89,7 @@
                     android:layout_marginTop="10dp"
                     android:maxLines="2"
                     android:textColor="@android:color/black"
+                    android:textSize="@dimen/ct_inbox_title_text_size"
                     android:textStyle="bold" />
 
 
@@ -103,7 +103,8 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_body_text_size" />
             </RelativeLayout>
         </LinearLayout>
 
@@ -123,7 +124,8 @@
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
                 android:gravity="end"
-                android:textColor="@android:color/darker_gray" />
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
             <ImageView
                 android:id="@+id/read_circle"
@@ -132,6 +134,8 @@
                 android:layout_gravity="center"
                 android:layout_marginEnd="20dp"
                 android:layout_marginRight="20dp"
+                android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                android:importantForAccessibility="yes"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
 
@@ -157,9 +161,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -168,9 +173,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -179,9 +185,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
     </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="2"
             android:textColor="@android:color/black"
             android:textSize="40sp"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -57,8 +54,7 @@
             android:layout_marginTop="40dp"
             android:gravity="center"
             android:textColor="@android:color/black"
-            android:textSize="24sp"
-            android:focusable="true" />
+            android:textSize="24sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"
@@ -93,8 +89,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginRight="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,14 +36,13 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginTop="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -43,8 +41,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -59,8 +56,7 @@
             android:layout_marginTop="36dp"
             android:gravity="center"
             android:maxLines="3"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"
@@ -99,8 +95,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial_image.xml
@@ -28,7 +28,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,15 +37,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:focusable="true"
         android:layout_margin="40dp">
 
         <TextView
@@ -24,7 +23,8 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold" />
+            android:textStyle="bold"
+            android:focusable="true" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,6 +40,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
+                android:focusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -48,6 +49,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
+                android:focusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -55,6 +57,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
+                android:focusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -72,7 +75,8 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message" />
+            android:textSize="@dimen/txt_size_inapp_message"
+            android:focusable="true" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial.xml
@@ -23,8 +23,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +39,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:focusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +47,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:focusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +54,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:focusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -75,8 +71,7 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_message" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"
@@ -115,8 +110,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,15 +40,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="2"
             android:textColor="@android:color/black"
             android:textSize="30sp"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -53,8 +50,7 @@
             android:layout_marginTop="80dp"
             android:gravity="center"
             android:textColor="@android:color/black"
-            android:textSize="18sp"
-            android:focusable="true" />
+            android:textSize="18sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"
@@ -88,8 +84,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginTop="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,14 +36,13 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginTop="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -42,8 +40,7 @@
             android:gravity="center"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -53,8 +50,7 @@
             android:layout_centerHorizontal="true"
             android:layout_marginTop="30dp"
             android:gravity="center"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"
@@ -89,8 +85,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial_image.xml
@@ -29,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -39,15 +38,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:focusable="true"
         android:layout_margin="40dp">
 
         <TextView
@@ -24,7 +23,8 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold" />
+            android:textStyle="bold"
+            android:focusable="true" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,6 +40,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
+                android:focusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -48,6 +49,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
+                android:focusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -55,6 +57,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
+                android:focusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -68,7 +71,8 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message" />
+            android:textSize="@dimen/txt_size_inapp_message"
+            android:focusable="true" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial.xml
@@ -23,8 +23,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +39,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:focusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +47,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:focusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +54,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:focusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -71,8 +67,7 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_message" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"
@@ -107,8 +102,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,15 +40,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="2"
             android:textColor="@android:color/black"
             android:textSize="30sp"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -53,8 +50,7 @@
             android:layout_marginTop="40dp"
             android:gravity="center"
             android:textColor="@android:color/black"
-            android:textSize="18sp"
-            android:focusable="true" />
+            android:textSize="18sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,7 +36,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_footer.xml
+++ b/clevertap-core/src/main/res/layout/inapp_footer.xml
@@ -14,8 +14,7 @@
             android:id="@+id/footer_linear_layout_1"
             android:layout_width="match_parent"
             android:layout_height="118dp"
-            android:orientation="horizontal"
-            android:focusable="true" >
+            android:orientation="horizontal" >
 
             <FrameLayout
                 android:id="@+id/footer_media_container"
@@ -56,7 +55,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="20dp"
                     android:textSize="@dimen/txt_size_inapp_footer_title"
-                    android:textStyle="bold" />
+                    android:textStyle="bold"
+                    android:focusable="true" />
 
                 <TextView
                     android:id="@+id/footer_message"
@@ -64,7 +64,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
                     android:maxLines="3"
-                    android:textSize="@dimen/txt_size_inapp_footer_message" />
+                    android:textSize="@dimen/txt_size_inapp_footer_message"
+                    android:focusable="true" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_footer.xml
+++ b/clevertap-core/src/main/res/layout/inapp_footer.xml
@@ -28,7 +28,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -37,7 +36,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
                     android:visibility="gone" />
             </FrameLayout>
 
@@ -55,8 +53,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="20dp"
                     android:textSize="@dimen/txt_size_inapp_footer_title"
-                    android:textStyle="bold"
-                    android:focusable="true" />
+                    android:textStyle="bold" />
 
                 <TextView
                     android:id="@+id/footer_message"
@@ -64,8 +61,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
                     android:maxLines="3"
-                    android:textSize="@dimen/txt_size_inapp_footer_message"
-                    android:focusable="true" />
+                    android:textSize="@dimen/txt_size_inapp_footer_message" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true"/>
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -42,8 +40,7 @@
             android:gravity="center"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -53,8 +50,7 @@
             android:layout_centerHorizontal="true"
             android:layout_marginTop="20dp"
             android:gravity="center"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
@@ -28,7 +28,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,7 +37,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inapp_header.xml
+++ b/clevertap-core/src/main/res/layout/inapp_header.xml
@@ -13,8 +13,7 @@
             android:id="@+id/header_linear_layout_1"
             android:layout_width="match_parent"
             android:layout_height="118dp"
-            android:orientation="horizontal"
-            android:focusable="true">
+            android:orientation="horizontal">
 
             <FrameLayout
                 android:id="@+id/header_media_container"
@@ -55,7 +54,8 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="20dp"
                     android:textSize="16sp"
-                    android:textStyle="bold" />
+                    android:textStyle="bold"
+                    android:focusable="true" />
 
                 <TextView
                     android:id="@+id/header_message"
@@ -64,7 +64,8 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="4dp"
                     android:maxLines="3"
-                    android:textSize="14sp" />
+                    android:textSize="14sp"
+                    android:focusable="true" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_header.xml
+++ b/clevertap-core/src/main/res/layout/inapp_header.xml
@@ -27,7 +27,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -36,7 +35,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>
@@ -54,8 +52,7 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="20dp"
                     android:textSize="16sp"
-                    android:textStyle="bold"
-                    android:focusable="true" />
+                    android:textStyle="bold" />
 
                 <TextView
                     android:id="@+id/header_message"
@@ -64,8 +61,7 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="4dp"
                     android:maxLines="3"
-                    android:textSize="14sp"
-                    android:focusable="true" />
+                    android:textSize="14sp" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:focusable="true"
         android:layout_margin="35dp">
 
         <TextView
@@ -24,7 +23,8 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold" />
+            android:textStyle="bold"
+            android:focusable="true" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,6 +40,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
+                android:focusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -48,6 +49,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
+                android:focusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -55,6 +57,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
+                android:focusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -68,7 +71,8 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message" />
+            android:textSize="@dimen/txt_size_inapp_message"
+            android:focusable="true" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial.xml
@@ -23,8 +23,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +39,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:focusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +47,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:focusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +54,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:focusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -71,8 +67,7 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_message" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,7 +40,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inbox_carousel_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_carousel_layout.xml
@@ -59,8 +59,6 @@
                     android:layout_marginRight="20dp"
                     android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
                     android:importantForAccessibility="yes"
-                    android:minHeight="@dimen/ct_inbox_min_tap_target"
-                    android:minWidth="@dimen/ct_inbox_min_tap_target"
                     android:src="@drawable/ct_read_circle" />
             </LinearLayout>
         </LinearLayout>

--- a/clevertap-core/src/main/res/layout/inbox_carousel_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_carousel_layout.xml
@@ -47,7 +47,8 @@
                     android:layout_marginRight="5dp"
                     android:gravity="end"
                     android:text="timestamp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
                 <ImageView
                     android:id="@+id/read_circle"
@@ -56,6 +57,10 @@
                     android:layout_gravity="center"
                     android:layout_marginEnd="20dp"
                     android:layout_marginRight="20dp"
+                    android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                    android:importantForAccessibility="yes"
+                    android:minHeight="@dimen/ct_inbox_min_tap_target"
+                    android:minWidth="@dimen/ct_inbox_min_tap_target"
                     android:src="@drawable/ct_read_circle" />
             </LinearLayout>
         </LinearLayout>

--- a/clevertap-core/src/main/res/layout/inbox_carousel_text_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_carousel_text_layout.xml
@@ -45,6 +45,7 @@
             android:layout_marginTop="20dp"
             android:maxLines="1"
             android:textColor="@android:color/black"
+            android:textSize="@dimen/ct_inbox_title_text_size"
             android:textStyle="bold" />
 
         <TextView
@@ -57,7 +58,8 @@
             android:layout_marginRight="20dp"
             android:layout_marginStart="20dp"
             android:layout_marginTop="5dp"
-            android:textColor="@android:color/darker_gray" />
+            android:textColor="@android:color/darker_gray"
+            android:textSize="@dimen/ct_inbox_body_text_size" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -75,7 +77,8 @@
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
                 android:gravity="end"
-                android:textColor="@android:color/darker_gray" />
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
             <ImageView
                 android:id="@+id/read_circle"
@@ -84,6 +87,10 @@
                 android:layout_gravity="center"
                 android:layout_marginEnd="20dp"
                 android:layout_marginRight="20dp"
+                android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                android:importantForAccessibility="yes"
+                android:minHeight="@dimen/ct_inbox_min_tap_target"
+                android:minWidth="@dimen/ct_inbox_min_tap_target"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inbox_carousel_text_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_carousel_text_layout.xml
@@ -89,8 +89,6 @@
                 android:layout_marginRight="20dp"
                 android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
                 android:importantForAccessibility="yes"
-                android:minHeight="@dimen/ct_inbox_min_tap_target"
-                android:minWidth="@dimen/ct_inbox_min_tap_target"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
@@ -29,7 +29,6 @@
                 android:layout_marginStart="8dp"
                 android:layout_marginTop="8dp"
                 android:contentDescription="@string/ct_inbox_icon_content_description"
-                android:focusable="true"
                 android:scaleType="fitCenter" />
 
             <LinearLayout
@@ -77,7 +76,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.customviews.SquareImageView
@@ -85,7 +84,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+
                 android:visibility="gone" />
 
             <ImageView
@@ -95,7 +94,7 @@
                 android:adjustViewBounds="true"
                 android:scaleType="fitCenter"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+
                 android:visibility="gone" />
 
             <FrameLayout
@@ -160,10 +159,9 @@
     <LinearLayout
         android:id="@+id/cta_linear_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="44dp"
         android:layout_below="@id/click_relative_layout"
         android:background="@android:color/white"
-        android:minHeight="@dimen/ct_inbox_min_tap_target"
         android:orientation="horizontal"
         android:weightSum="6">
 
@@ -174,7 +172,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"
@@ -187,7 +184,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"
@@ -200,7 +196,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"

--- a/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
@@ -146,8 +146,6 @@
                 android:layout_marginRight="20dp"
                 android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
                 android:importantForAccessibility="yes"
-                android:minHeight="@dimen/ct_inbox_min_tap_target"
-                android:minWidth="@dimen/ct_inbox_min_tap_target"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
@@ -172,7 +172,7 @@
         <Button
             android:id="@+id/cta_button_1"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
@@ -185,7 +185,7 @@
         <Button
             android:id="@+id/cta_button_2"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
@@ -198,7 +198,7 @@
         <Button
             android:id="@+id/cta_button_3"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"

--- a/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
@@ -49,6 +49,7 @@
                     android:layout_marginTop="10dp"
                     android:maxLines="1"
                     android:textColor="@android:color/black"
+                    android:textSize="@dimen/ct_inbox_title_text_size"
                     android:textStyle="bold" />
 
                 <TextView
@@ -60,7 +61,8 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_body_text_size" />
             </LinearLayout>
         </LinearLayout>
 
@@ -112,6 +114,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal|center_vertical"
+                    android:importantForAccessibility="no"
                     android:visibility="visible" />
             </FrameLayout>
         </RelativeLayout>
@@ -131,7 +134,8 @@
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
                 android:gravity="end"
-                android:textColor="@android:color/darker_gray" />
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
             <ImageView
                 android:id="@+id/read_circle"
@@ -140,6 +144,10 @@
                 android:layout_gravity="center"
                 android:layout_marginEnd="20dp"
                 android:layout_marginRight="20dp"
+                android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                android:importantForAccessibility="yes"
+                android:minHeight="@dimen/ct_inbox_min_tap_target"
+                android:minWidth="@dimen/ct_inbox_min_tap_target"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
 
@@ -154,43 +162,50 @@
     <LinearLayout
         android:id="@+id/cta_linear_layout"
         android:layout_width="match_parent"
-        android:layout_height="44dp"
+        android:layout_height="wrap_content"
         android:layout_below="@id/click_relative_layout"
         android:background="@android:color/white"
+        android:minHeight="@dimen/ct_inbox_min_tap_target"
         android:orientation="horizontal"
         android:weightSum="6">
 
         <Button
             android:id="@+id/cta_button_1"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
+            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="visible" />
 
         <Button
             android:id="@+id/cta_button_2"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
+            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
             android:id="@+id/cta_button_3"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
+            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
     </LinearLayout>
 </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
@@ -152,7 +152,7 @@
         <Button
             android:id="@+id/cta_button_1"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
@@ -165,7 +165,7 @@
         <Button
             android:id="@+id/cta_button_2"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
@@ -178,7 +178,7 @@
         <Button
             android:id="@+id/cta_button_3"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"

--- a/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
@@ -22,7 +22,6 @@
                 android:layout_height="wrap_content"
                 android:scaleType="centerCrop"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.customviews.SquareImageView
@@ -31,7 +30,7 @@
                 android:layout_height="wrap_content"
                 android:scaleType="centerCrop"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+
                 android:visibility="gone" />
 
             <ImageView
@@ -41,7 +40,7 @@
                 android:adjustViewBounds="true"
                 android:scaleType="fitCenter"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+
                 android:visibility="gone" />
 
             <FrameLayout
@@ -140,10 +139,9 @@
     <LinearLayout
         android:id="@+id/cta_linear_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="44dp"
         android:layout_below="@id/click_relative_layout"
         android:background="@android:color/white"
-        android:minHeight="@dimen/ct_inbox_min_tap_target"
         android:orientation="horizontal"
         android:weightSum="6">
 
@@ -154,7 +152,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"
@@ -167,7 +164,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"
@@ -180,7 +176,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"

--- a/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
@@ -127,8 +127,6 @@
                     android:layout_marginRight="20dp"
                     android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
                     android:importantForAccessibility="yes"
-                    android:minHeight="@dimen/ct_inbox_min_tap_target"
-                    android:minWidth="@dimen/ct_inbox_min_tap_target"
                     android:src="@drawable/ct_read_circle" />
             </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
@@ -60,6 +60,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal|center_vertical"
+                    android:importantForAccessibility="no"
                     android:visibility="visible" />
             </FrameLayout>
         </RelativeLayout>
@@ -83,6 +84,7 @@
                 android:layout_marginTop="20dp"
                 android:maxLines="1"
                 android:textColor="@android:color/black"
+                android:textSize="@dimen/ct_inbox_title_text_size"
                 android:textStyle="bold" />
 
             <TextView
@@ -94,7 +96,8 @@
                 android:layout_marginRight="20dp"
                 android:layout_marginStart="20dp"
                 android:layout_marginTop="5dp"
-                android:textColor="@android:color/darker_gray" />
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_body_text_size" />
 
             <LinearLayout
                 android:id="@+id/timestamp_linear_layout"
@@ -112,7 +115,8 @@
                     android:layout_marginEnd="10dp"
                     android:layout_marginRight="10dp"
                     android:gravity="end"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
                 <ImageView
                     android:id="@+id/read_circle"
@@ -121,6 +125,10 @@
                     android:layout_gravity="center"
                     android:layout_marginEnd="20dp"
                     android:layout_marginRight="20dp"
+                    android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                    android:importantForAccessibility="yes"
+                    android:minHeight="@dimen/ct_inbox_min_tap_target"
+                    android:minWidth="@dimen/ct_inbox_min_tap_target"
                     android:src="@drawable/ct_read_circle" />
             </LinearLayout>
 
@@ -134,43 +142,50 @@
     <LinearLayout
         android:id="@+id/cta_linear_layout"
         android:layout_width="match_parent"
-        android:layout_height="44dp"
+        android:layout_height="wrap_content"
         android:layout_below="@id/click_relative_layout"
         android:background="@android:color/white"
+        android:minHeight="@dimen/ct_inbox_min_tap_target"
         android:orientation="horizontal"
         android:weightSum="6">
 
         <Button
             android:id="@+id/cta_button_1"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
+            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
             android:id="@+id/cta_button_2"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
+            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
             android:id="@+id/cta_button_3"
             android:layout_width="0dp"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
+            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
     </LinearLayout>
 </RelativeLayout>

--- a/clevertap-core/src/main/res/values/dimens.xml
+++ b/clevertap-core/src/main/res/values/dimens.xml
@@ -13,6 +13,12 @@
     <dimen name="txt_size_inapp_footer_message">12sp</dimen>
     <dimen name="txt_size_inapp_footer_button">14sp</dimen>
 
+    <dimen name="ct_inbox_cta_button_text_size">14sp</dimen>
+    <dimen name="ct_inbox_title_text_size">16sp</dimen>
+    <dimen name="ct_inbox_body_text_size">14sp</dimen>
+    <dimen name="ct_inbox_timestamp_text_size">12sp</dimen>
+    <dimen name="ct_inbox_min_tap_target">48dp</dimen>
+
     <dimen name="ct_video_bottom_bar_height">60dp</dimen>
     <dimen name="ct_video_bottom_bar_margin_top">10dp</dimen>
     <dimen name="ct_video_time_padding">10dp</dimen>

--- a/clevertap-core/src/main/res/values/dimens.xml
+++ b/clevertap-core/src/main/res/values/dimens.xml
@@ -14,9 +14,9 @@
     <dimen name="txt_size_inapp_footer_button">14sp</dimen>
 
     <dimen name="ct_inbox_cta_button_text_size">14sp</dimen>
-    <dimen name="ct_inbox_title_text_size">16sp</dimen>
+    <dimen name="ct_inbox_title_text_size">14sp</dimen>
     <dimen name="ct_inbox_body_text_size">14sp</dimen>
-    <dimen name="ct_inbox_timestamp_text_size">12sp</dimen>
+    <dimen name="ct_inbox_timestamp_text_size">14sp</dimen>
     <dimen name="ct_inbox_min_tap_target">48dp</dimen>
 
     <dimen name="ct_video_bottom_bar_height">60dp</dimen>

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -9,7 +9,8 @@
     <string name="ct_inbox_image_content_description">Message Image</string>
     <string name="ct_inbox_icon_content_description">Message Icon</string>
     <string name="ct_inbox_unread_indicator_content_description">Unread message</string>
-    <string name="ct_inbox_message_content_description">Open message</string>
+    <string name="ct_carousel_content_description">Image carousel, %1$s, Page %2$d of %3$d</string>
+    <string name="ct_carousel_page_announcement">%1$s, Page %2$d of %3$d</string>
     <string name="ct_notification_big_picture_alt_text">Notification Big Picture</string>
     <string name="ct_inapp_close_btn">Close</string>
     <string name="ct_inapp_message_shown">Popup shown</string>

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="ct_inbox_message_content_description">Open message</string>
     <string name="ct_notification_big_picture_alt_text">Notification Big Picture</string>
     <string name="ct_inapp_close_btn">Close</string>
-    <string name="ct_inapp_message_shown">InApp message shown</string>
+    <string name="ct_inapp_message_shown">Popup shown</string>
     <string name="ct_inapp_img">Inapp Image</string>
     <string name="ct_inapp_media">Inapp Media</string>
     <string name="ct_inapp_gif">Inapp Gif</string>

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -8,6 +8,8 @@
     <string name="ct_inbox_media_content_description">Message Media</string>
     <string name="ct_inbox_image_content_description">Message Image</string>
     <string name="ct_inbox_icon_content_description">Message Icon</string>
+    <string name="ct_inbox_unread_indicator_content_description">Unread message</string>
+    <string name="ct_inbox_message_content_description">Open message</string>
     <string name="ct_notification_big_picture_alt_text">Notification Big Picture</string>
     <string name="ct_inapp_close_btn">Close</string>
     <string name="ct_inapp_message_shown">InApp message shown</string>

--- a/clevertap-core/src/main/res/values/styles.xml
+++ b/clevertap-core/src/main/res/values/styles.xml
@@ -50,7 +50,7 @@
          icon dynamically at runtime via PlayerControlView. -->
     <style name="CtVideoControls.Button.Center.PlayPause" parent="CtVideoControls.Button.Center">
         <item name="android:padding">2dp</item>
-        <item name="android:contentDescription">Play</item>
+        <item name="android:contentDescription">@string/ct_pip_play_button_content_description</item>
     </style>
 
     <!-- Exact mirror of ExoStyledControls.TimeText -->

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
@@ -68,15 +68,9 @@ internal class ManualCarouselContentView(
                 val rightRemoteView = tempRemoteView.clone()
                 val leftRemoteView = tempRemoteView.clone()
 
-                rightRemoteView.setContentDescription(
-                    imageViewId,
-                    context.getString(R.string.next_btn_content_description)
-                )
-                leftRemoteView.setContentDescription(
-                    imageViewId,
-                    context.getString(R.string.prev_btn_content_description)
-                )
                 centerRemoteView.setContentDescription(imageViewId, altText)
+                rightRemoteView.setContentDescription(imageViewId, altText)
+                leftRemoteView.setContentDescription(imageViewId, altText)
 
                 remoteView.addView(R.id.carousel_image_right, rightRemoteView)
                 remoteView.addView(R.id.carousel_image_left, leftRemoteView)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
@@ -65,10 +65,21 @@ internal class ManualCarouselContentView(
 
                 tempRemoteView.setViewVisibility(imageViewId, View.VISIBLE)
                 val centerRemoteView = tempRemoteView.clone()
+                val rightRemoteView = tempRemoteView.clone()
+                val leftRemoteView = tempRemoteView.clone()
 
-                remoteView.addView(R.id.carousel_image_right, tempRemoteView)
-                remoteView.addView(R.id.carousel_image_left, tempRemoteView)
+                rightRemoteView.setContentDescription(
+                    imageViewId,
+                    context.getString(R.string.next_btn_content_description)
+                )
+                leftRemoteView.setContentDescription(
+                    imageViewId,
+                    context.getString(R.string.prev_btn_content_description)
+                )
                 centerRemoteView.setContentDescription(imageViewId, altText)
+
+                remoteView.addView(R.id.carousel_image_right, rightRemoteView)
+                remoteView.addView(R.id.carousel_image_left, leftRemoteView)
                 remoteView.addView(R.id.carousel_image, centerRemoteView)
 
                 imageCounter++

--- a/clevertap-pushtemplates/src/main/res/layout/rating.xml
+++ b/clevertap-pushtemplates/src/main/res/layout/rating.xml
@@ -29,40 +29,50 @@
             <ImageView
                 android:id="@+id/star1"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/rating_star"
+                android:layout_height="@dimen/rating_star_touch_target"
                 android:layout_weight="1"
+                android:paddingTop="@dimen/rating_star_padding"
+                android:paddingBottom="@dimen/rating_star_padding"
                 android:contentDescription="@string/rating_star_1"
                 android:src="@drawable/pt_star_outline" />
 
             <ImageView
                 android:id="@+id/star2"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/rating_star"
+                android:layout_height="@dimen/rating_star_touch_target"
                 android:layout_weight="1"
+                android:paddingTop="@dimen/rating_star_padding"
+                android:paddingBottom="@dimen/rating_star_padding"
                 android:src="@drawable/pt_star_outline"
                 android:contentDescription="@string/rating_star_2" />
 
             <ImageView
                 android:id="@+id/star3"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/rating_star"
+                android:layout_height="@dimen/rating_star_touch_target"
                 android:layout_weight="1"
+                android:paddingTop="@dimen/rating_star_padding"
+                android:paddingBottom="@dimen/rating_star_padding"
                 android:src="@drawable/pt_star_outline"
                 android:contentDescription="@string/rating_star_3" />
 
             <ImageView
                 android:id="@+id/star4"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/rating_star"
+                android:layout_height="@dimen/rating_star_touch_target"
                 android:layout_weight="1"
+                android:paddingTop="@dimen/rating_star_padding"
+                android:paddingBottom="@dimen/rating_star_padding"
                 android:src="@drawable/pt_star_outline"
                 android:contentDescription="@string/rating_star_4" />
 
             <ImageView
                 android:id="@+id/star5"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/rating_star"
+                android:layout_height="@dimen/rating_star_touch_target"
                 android:layout_weight="1"
+                android:paddingTop="@dimen/rating_star_padding"
+                android:paddingBottom="@dimen/rating_star_padding"
                 android:src="@drawable/pt_star_outline"
                 android:contentDescription="@string/rating_star_5" />
 

--- a/clevertap-pushtemplates/src/main/res/values-sw300dp/dimens.xml
+++ b/clevertap-pushtemplates/src/main/res/values-sw300dp/dimens.xml
@@ -15,6 +15,7 @@
     <dimen name="five_cta_icon_margin">6dp</dimen>
 
     <dimen name="manual_carousel_arrow">36dp</dimen>
+    <dimen name="manual_carousel_arrow_padding">12dp</dimen>
 
     <dimen name="chronometer_font_size">20sp</dimen>
 

--- a/clevertap-pushtemplates/src/main/res/values-sw400dp/dimens.xml
+++ b/clevertap-pushtemplates/src/main/res/values-sw400dp/dimens.xml
@@ -19,8 +19,10 @@
     <dimen name="five_cta_icon_margin">8dp</dimen>
 
     <dimen name="manual_carousel_arrow">48dp</dimen>
+    <dimen name="manual_carousel_arrow_padding">0dp</dimen>
 
     <dimen name="rating_star">24dp</dimen>
+    <dimen name="rating_star_padding">12dp</dimen>
 
     <dimen name="chronometer_font_size">20sp</dimen>
 

--- a/clevertap-pushtemplates/src/main/res/values/dimens.xml
+++ b/clevertap-pushtemplates/src/main/res/values/dimens.xml
@@ -34,8 +34,14 @@
     <dimen name="five_cta_padding">6dp</dimen>
 
     <dimen name="manual_carousel_arrow">30dp</dimen>
+    <dimen name="manual_carousel_arrow_touch_target">48dp</dimen>
+    <!-- 48dp - manual_carousel_arrow visual width, applied on the side away from the screen edge -->
+    <dimen name="manual_carousel_arrow_padding">18dp</dimen>
 
     <dimen name="rating_star">20dp</dimen>
+    <dimen name="rating_star_touch_target">48dp</dimen>
+    <!-- (rating_star_touch_target - rating_star) / 2, kept symmetric so the star stays centered in its cell -->
+    <dimen name="rating_star_padding">14dp</dimen>
 
     <dimen name="chronometer_font_size">12sp</dimen>
 

--- a/clevertap-pushtemplates/src/main/res/values/styles.xml
+++ b/clevertap-pushtemplates/src/main/res/values/styles.xml
@@ -24,15 +24,17 @@
     </style>
 
     <style name="ManualCarouselArrowRev" parent="android:Widget.TextView">
-        <item name="android:layout_width">@dimen/manual_carousel_arrow</item>
+        <item name="android:layout_width">@dimen/manual_carousel_arrow_touch_target</item>
         <item name="android:layout_height">50dp</item>
+        <item name="android:paddingEnd">@dimen/manual_carousel_arrow_padding</item>
         <item name="android:layout_centerVertical">true</item>
         <item name="android:src">@drawable/pt_arrow_back</item>
     </style>
 
     <style name="ManualCarouselArrowFwd" parent="android:Widget.TextView">
-        <item name="android:layout_width">@dimen/manual_carousel_arrow</item>
+        <item name="android:layout_width">@dimen/manual_carousel_arrow_touch_target</item>
         <item name="android:layout_height">50dp</item>
+        <item name="android:paddingStart">@dimen/manual_carousel_arrow_padding</item>
         <item name="android:layout_centerVertical">true</item>
         <item name="android:layout_alignParentEnd">true</item>
         <item name="android:layout_alignParentRight">true</item>


### PR DESCRIPTION
- **Dynamic Type**: Added `sp`-based text sizes (`ct_inbox_title_text_size`, `ct_inbox_body_text_size`, `ct_inbox_timestamp_text_size`) to all 4 inbox templates (Simple, Icon, Carousel, Carousel Image) so text scales with system font size
- **48dp tap targets**: CTA buttons now use `wrap_content` + `minHeight=48dp` on both the view and container; `hideOneButton`/`hideTwoButtons` updated to use `WRAP_CONTENT` so the 48dp floor survives runtime `setLayoutParams` calls
- **Push Templates — Rating stars**: Touch target increased to 48dp via symmetric padding; visual star size unchanged
- **Push Templates — Manual Carousel arrows**: Width increased to 48dp touch target; arrow drawable kept visually in place via padding offset
- **Push Templates — Carousel image labels**: Left/right images now get separate `contentDescription` ("Previous"/"Next") instead of sharing `altText`