### PR TITLE
fix(network): defer CtApi creation off main thread (8.2.0 regression: Direct Boot crash + init ANR) [SDK-5947]

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
@@ -543,7 +543,7 @@ internal object CleverTapFactory {
         val networkScope = NetworkScope()
 
         val inboxFetchCall = InboxFetchCall(
-            ctApi = ctApiWrapper.ctApi,
+            ctApiProvider = { ctApiWrapper.ctApi },
             queueHeaderBuilder = queueHeaderBuilder,
             coreMetaData = coreMetaData,
             packageName = context.packageName,
@@ -565,7 +565,7 @@ internal object CleverTapFactory {
 
         val inboxDeleteCoordinator = InboxDeleteCoordinator(
             networkScope = networkScope,
-            ctApi = ctApiWrapper.ctApi,
+            ctApiProvider = { ctApiWrapper.ctApi },
             queueHeaderBuilder = queueHeaderBuilder,
             dbAdapterProvider = { databaseManager.loadDBAdapter(context) },
             coreMetaData = coreMetaData,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/InboxDeleteCoordinator.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/InboxDeleteCoordinator.kt
@@ -26,7 +26,9 @@ import org.json.JSONObject
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 internal class InboxDeleteCoordinator(
     private val networkScope: NetworkScope,
-    private val ctApi: CtApi,
+    // Supplier so CtApi is created on the network dispatcher, not at
+    // factory-construction time — `CtApiWrapper.ctApi` is @get:WorkerThread.
+    private val ctApiProvider: () -> CtApi,
     private val queueHeaderBuilder: QueueHeaderBuilder,
     // Supplier so the DB adapter is loaded on the network dispatcher, not at
     // factory-construction time — `DBManager.loadDBAdapter` is @WorkerThread.
@@ -74,7 +76,7 @@ internal class InboxDeleteCoordinator(
 
     private suspend fun runDelete(messages: List<CTInboxMessage>, userId: String) {
         val call = InboxDeleteCall(
-            ctApi = ctApi,
+            ctApi = ctApiProvider(),
             queueHeaderBuilder = queueHeaderBuilder,
             messages = messages,
             coreMetaData = coreMetaData,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/fetch/InboxFetchCall.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/fetch/InboxFetchCall.kt
@@ -64,7 +64,7 @@ internal class InboxFetchCall(
                     200 -> {
                         val raw = response.readBody()
                             ?: return@use CallResult.NetworkFailure(IOException("empty body"))
-                        logger.verbose("InboxV22", "fetch sent successfully (HTTP 200, ${raw.length} bytes)")
+                        logger.verbose("InboxV2", "fetch sent successfully (HTTP 200, ${raw.length} bytes)")
                         CallResult.Success(JSONObject(raw))
                     }
                     else -> {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/fetch/InboxFetchCall.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/fetch/InboxFetchCall.kt
@@ -28,7 +28,10 @@ import java.io.IOException
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 internal class InboxFetchCall(
-    private val ctApi: CtApi,
+    // Supplier so CtApi is created on the network dispatcher, not at
+    // factory-construction time — `CtApiWrapper.ctApi` is @get:WorkerThread
+    // (same pattern as `InboxDeleteCoordinator.dbAdapterProvider`).
+    private val ctApiProvider: () -> CtApi,
     private val queueHeaderBuilder: QueueHeaderBuilder,
     private val coreMetaData: CoreMetaData,
     private val packageName: String,
@@ -56,12 +59,12 @@ internal class InboxFetchCall(
         logger.debug("InboxV2", "Send fetch (t=${Constants.FETCH_TYPE_INBOX_V2}): $body")
 
         try {
-            ctApi.sendInboxFetch(body).use { response ->
+            ctApiProvider().sendInboxFetch(body).use { response ->
                 when (response.code) {
                     200 -> {
                         val raw = response.readBody()
                             ?: return@use CallResult.NetworkFailure(IOException("empty body"))
-                        logger.verbose("InboxV2", "fetch sent successfully (HTTP 200, ${raw.length} bytes)")
+                        logger.verbose("InboxV22", "fetch sent successfully (HTTP 200, ${raw.length} bytes)")
                         CallResult.Success(JSONObject(raw))
                     }
                     else -> {

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/InboxDeleteCoordinatorTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/InboxDeleteCoordinatorTest.kt
@@ -86,7 +86,7 @@ class InboxDeleteCoordinatorTest {
         dbAdapter: DBAdapter
     ): InboxDeleteCoordinator = InboxDeleteCoordinator(
         networkScope = NetworkScope(StandardTestDispatcher(testScheduler)),
-        ctApi = ctApi(code),
+        ctApiProvider = { ctApi(code) },
         queueHeaderBuilder = headerBuilder(),
         dbAdapterProvider = { dbAdapter },
         coreMetaData = mockk<CoreMetaData>(relaxed = true),
@@ -100,7 +100,7 @@ class InboxDeleteCoordinatorTest {
         dbAdapter: DBAdapter
     ): InboxDeleteCoordinator = InboxDeleteCoordinator(
         networkScope = NetworkScope(StandardTestDispatcher(testScheduler)),
-        ctApi = ctApi(http),
+        ctApiProvider = { ctApi(http) },
         queueHeaderBuilder = headerBuilder(),
         dbAdapterProvider = { dbAdapter },
         coreMetaData = mockk<CoreMetaData>(relaxed = true),
@@ -204,6 +204,31 @@ class InboxDeleteCoordinatorTest {
         assertEquals("default", msgs.getJSONObject(0).getString("wzrk_pivot"))
         assertEquals("m2", msgs.getJSONObject(1).getString("wzrk_mid"))
         assertEquals("c2", msgs.getJSONObject(1).getString("wzrk_id"))
+    }
+
+    @Test
+    fun `ctApi provider is not invoked at construction and resolves when a delete runs`() = runTest {
+        // Regression test for SDK-5947: CtApi construction reads SharedPreferences,
+        // so it must stay deferred to the network dispatcher, never construction time.
+        val dbAdapter = mockk<DBAdapter>(relaxed = true)
+        var providerCalls = 0
+        val coordinator = InboxDeleteCoordinator(
+            networkScope = NetworkScope(StandardTestDispatcher(testScheduler)),
+            ctApiProvider = { providerCalls++; ctApi(200) },
+            queueHeaderBuilder = headerBuilder(),
+            dbAdapterProvider = { dbAdapter },
+            coreMetaData = mockk<CoreMetaData>(relaxed = true),
+            packageName = "com.example.app",
+            logger = mockk<Logger>(relaxed = true),
+            httpDispatcher = UnconfinedTestDispatcher(testScheduler)
+        )
+
+        assertEquals(0, providerCalls)
+
+        coordinator.syncDelete(listOf(message("m1")), "u")
+        advanceUntilIdle()
+
+        assertEquals(1, providerCalls)
     }
 
     @Test

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/network/fetch/InboxFetchCallTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/network/fetch/InboxFetchCallTest.kt
@@ -80,7 +80,7 @@ class InboxFetchCallTest {
         packageName: String = "com.example.app"
     ): InboxFetchCall =
         InboxFetchCall(
-            ctApi = newCtApi(http),
+            ctApiProvider = { newCtApi(http) },
             queueHeaderBuilder = newHeaderBuilder(header),
             coreMetaData = coreMetaData,
             packageName = packageName,
@@ -151,6 +151,30 @@ class InboxFetchCallTest {
         val result = newCall(http, header = null).execute()
 
         assertTrue(result is CallResult.NetworkFailure)
+    }
+
+    @Test
+    fun `ctApi provider is not invoked at construction and resolves once on execute`() = runTest {
+        // Regression test for SDK-5947: CtApi construction reads SharedPreferences,
+        // so it must stay deferred to the call dispatcher, never construction time.
+        val http = MockHttpClient(responseCode = 200, responseBody = """{"inbox_notifs_v2":[]}""")
+        var providerCalls = 0
+        val call = InboxFetchCall(
+            ctApiProvider = { providerCalls++; newCtApi(http) },
+            queueHeaderBuilder = newHeaderBuilder(),
+            coreMetaData = newCoreMetaData(),
+            packageName = "com.example.app",
+            logger = noopLogger(),
+            clock = fixedClock,
+            dispatcher = UnconfinedTestDispatcher()
+        )
+
+        assertEquals(0, providerCalls)
+
+        val result = call.execute()
+
+        assertEquals(1, providerCalls)
+        assertTrue(result is CallResult.Success)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Core **8.2.0**'s Inbox-v2 wiring (#1008) eagerly dereferences the `@get:WorkerThread` lazy `CtApiWrapper.ctApi` in `CleverTapFactory` while constructing `InboxFetchCall`/`InboxDeleteCoordinator`, so `CtApi` construction runs on whatever thread builds the SDK — the **main thread** when apps call `CleverTapAPI.getDefaultInstance()` in `Application.onCreate` (the documented integration). One defect, two field signatures on Play SDK Console:

- **Startup crash in Direct Boot** ([GPSDK 9b5398f1](https://play.google.com/sdk-console/accounts/2895211467178262450/sdks/6179303647802668283/crashes/9b5398f1/details)): `CtApi` construction synchronously reads SharedPreferences (`NetworkRepo.getDomain` → `StorageHelper`). Pre-unlock (app has any `directBootAware` component) the framework's `credentialProtectedStorageCheck` throws `IllegalStateException` and kills app startup on every pre-unlock start attempt.
- **Launch ANR on API 30+** ([GPSDK 09f9ef71](https://play.google.com/sdk-console/accounts/2895211467178262450/sdks/6179303647802668283/crashes/09f9ef71/details)): `CtApi` construction reads `deviceInfo.sdkVersion`, forcing the full `DeviceCachedInfo` snapshot whose window-size measurement performs a synchronous `createWindowContext` → `IWindowManager.addWindowTokenWithOptions` binder call into system_server; contended at launch, the main thread stalls >5 s.

Pre-8.2.0 the "CtApi/DeviceCachedInfo only on worker threads" invariant held at every call site; both traces pin the reporting builds to 8.2.0/8.3.0 and the code was unchanged on develop. Affected versions: **8.2.0–8.3.0**. Jira: [SDK-5947](https://wizrocket.atlassian.net/browse/SDK-5947).

## Fix

Inject `ctApiProvider: () -> CtApi` into `InboxFetchCall` / `InboxDeleteCoordinator`; the factory passes `{ ctApiWrapper.ctApi }`. The lazy now resolves on the IO dispatcher at first inbox network use — no sync prefs read, no main-thread binder call.

[SDK-5947]: https://wizrocket.atlassian.net/browse/SDK-5947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbox fetch and delete operations by creating API clients when network requests execute, helping ensure current connection details are used.

* **Tests**
  * Added regression coverage confirming API clients are not created prematurely and are resolved at the appropriate execution time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->