### PR TITLE
ci: notify Bearded Robot (CT-Apps) on core SDK release

### DIFF
--- a/.github/workflows/on_pr_merged_in_master.yml
+++ b/.github/workflows/on_pr_merged_in_master.yml
@@ -98,3 +98,42 @@ jobs:
 
       - name: Build Release AARs
         uses: ./.github/mini_flows/build_code_release
+
+  # Notify the Bearded Robot test app (CleverTap/CT-Apps) that a new core
+  # SDK version has landed on master, so it can open a version-bump PR.
+  notify-br-app:
+    needs: [build]
+    if: ${{ github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    name: Notify Bearded Robot of core release
+    steps:
+      - name: Checkout the code from Repo
+        uses: actions/checkout@v4
+
+      - name: Resolve core SDK version
+        id: version
+        run: |
+          VERSION=$(grep -E '^[[:space:]]*clevertap_android_sdk[[:space:]]*=' gradle/libs.versions.toml \
+            | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not resolve clevertap_android_sdk version from gradle/libs.versions.toml"
+            exit 1
+          fi
+          echo "Resolved core SDK version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch core-sdk-released to CT-Apps
+        env:
+          GH_TOKEN: ${{ secrets.CT_APPS_DISPATCH_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::CT_APPS_DISPATCH_TOKEN is not set. Add a PAT with 'repo' scope on CleverTap/CT-Apps as a repo secret."
+            exit 1
+          fi
+          echo "📣 Notifying CT-Apps: android core $VERSION released"
+          PAYLOAD=$(printf '{"event_type":"core-sdk-released","client_payload":{"platform":"android","version":"%s"}}' "$VERSION")
+          echo "$PAYLOAD" | gh api repos/CleverTap/CT-Apps/dispatches --method POST --input -
+          echo "✅ Dispatch sent to CleverTap/CT-Apps."


### PR DESCRIPTION
## What
Adds a `notify-br-app` job to `on_pr_merged_in_master.yml` (the master-merge release workflow). After the release AAR `build` job succeeds, it fires a `repository_dispatch` to **CleverTap/CT-Apps** so the Bearded Robot test app can automatically open a PR bumping to the new core SDK version.

## How
- Reads the core version from `gradle/libs.versions.toml` (`clevertap_android_sdk`).
- Sends:
  ```json
  { "event_type": "core-sdk-released", "client_payload": { "platform": "android", "version": "<version>" } }
  ```

## Prerequisite (repo secret)
- **`CT_APPS_DISPATCH_TOKEN`** — a PAT with `repo` scope on `CleverTap/CT-Apps`. The job fails fast with a clear error if it's missing, so merging before the secret exists is safe (it just no-ops loudly on the next release).

## Companion work
- CT-Apps side: a new `br-sync-core-sdk.yml` workflow consumes this dispatch and opens the bump PR (separate change in CT-Apps).
- iOS SDK: matching PR in `clevertap-ios-sdk`.

## Impact
Additive only — a new job gated on `github.event.pull_request.merged`. No existing jobs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated post-merge notification to signal successful Android SDK releases.
  * Release version details are now sent automatically to the connected app repository.
  * Added validation and clear failure reporting when the release version or notification credentials are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->