### PR TITLE
ci: broaden PR check allowlist to conventional-commit branch prefixes

### DIFF
--- a/.github/workflows/on_pr_from_task_to_develop.yml
+++ b/.github/workflows/on_pr_from_task_to_develop.yml
@@ -12,7 +12,20 @@ concurrency:
 jobs:
   # Code Quality Checks (Run in Parallel)
   lint:
-    if: startsWith(github.head_ref, 'task/') || startsWith(github.head_ref, 'feat/') || startsWith(github.head_ref, 'bug/')
+    if: >-
+      startsWith(github.head_ref, 'feat/') ||
+      startsWith(github.head_ref, 'feature/') ||
+      startsWith(github.head_ref, 'fix/') ||
+      startsWith(github.head_ref, 'docs/') ||
+      startsWith(github.head_ref, 'style/') ||
+      startsWith(github.head_ref, 'refactor/') ||
+      startsWith(github.head_ref, 'perf/') ||
+      startsWith(github.head_ref, 'test/') ||
+      startsWith(github.head_ref, 'build/') ||
+      startsWith(github.head_ref, 'ci/') ||
+      startsWith(github.head_ref, 'chore/') ||
+      startsWith(github.head_ref, 'task/') ||
+      startsWith(github.head_ref, 'bug/')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -28,7 +41,20 @@ jobs:
         uses: ./.github/mini_flows/lint
 
   detekt:
-    if: startsWith(github.head_ref, 'task/') || startsWith(github.head_ref, 'feat/') || startsWith(github.head_ref, 'bug/')
+    if: >-
+      startsWith(github.head_ref, 'feat/') ||
+      startsWith(github.head_ref, 'feature/') ||
+      startsWith(github.head_ref, 'fix/') ||
+      startsWith(github.head_ref, 'docs/') ||
+      startsWith(github.head_ref, 'style/') ||
+      startsWith(github.head_ref, 'refactor/') ||
+      startsWith(github.head_ref, 'perf/') ||
+      startsWith(github.head_ref, 'test/') ||
+      startsWith(github.head_ref, 'build/') ||
+      startsWith(github.head_ref, 'ci/') ||
+      startsWith(github.head_ref, 'chore/') ||
+      startsWith(github.head_ref, 'task/') ||
+      startsWith(github.head_ref, 'bug/')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -44,7 +70,20 @@ jobs:
         uses: ./.github/mini_flows/codechecks_detekt
 
   checkstyle:
-    if: startsWith(github.head_ref, 'task/') || startsWith(github.head_ref, 'feat/') || startsWith(github.head_ref, 'bug/')
+    if: >-
+      startsWith(github.head_ref, 'feat/') ||
+      startsWith(github.head_ref, 'feature/') ||
+      startsWith(github.head_ref, 'fix/') ||
+      startsWith(github.head_ref, 'docs/') ||
+      startsWith(github.head_ref, 'style/') ||
+      startsWith(github.head_ref, 'refactor/') ||
+      startsWith(github.head_ref, 'perf/') ||
+      startsWith(github.head_ref, 'test/') ||
+      startsWith(github.head_ref, 'build/') ||
+      startsWith(github.head_ref, 'ci/') ||
+      startsWith(github.head_ref, 'chore/') ||
+      startsWith(github.head_ref, 'task/') ||
+      startsWith(github.head_ref, 'bug/')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -62,7 +101,20 @@ jobs:
   # Unit Tests and Coverage
   test:
     needs: [lint, detekt, checkstyle]
-    if: startsWith(github.head_ref, 'task/') || startsWith(github.head_ref, 'feat/') || startsWith(github.head_ref, 'bug/')
+    if: >-
+      startsWith(github.head_ref, 'feat/') ||
+      startsWith(github.head_ref, 'feature/') ||
+      startsWith(github.head_ref, 'fix/') ||
+      startsWith(github.head_ref, 'docs/') ||
+      startsWith(github.head_ref, 'style/') ||
+      startsWith(github.head_ref, 'refactor/') ||
+      startsWith(github.head_ref, 'perf/') ||
+      startsWith(github.head_ref, 'test/') ||
+      startsWith(github.head_ref, 'build/') ||
+      startsWith(github.head_ref, 'ci/') ||
+      startsWith(github.head_ref, 'chore/') ||
+      startsWith(github.head_ref, 'task/') ||
+      startsWith(github.head_ref, 'bug/')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -86,7 +138,20 @@ jobs:
   # Build (Only after tests pass)
   build:
     needs: [test]
-    if: startsWith(github.head_ref, 'task/') || startsWith(github.head_ref, 'feat/') || startsWith(github.head_ref, 'bug/')
+    if: >-
+      startsWith(github.head_ref, 'feat/') ||
+      startsWith(github.head_ref, 'feature/') ||
+      startsWith(github.head_ref, 'fix/') ||
+      startsWith(github.head_ref, 'docs/') ||
+      startsWith(github.head_ref, 'style/') ||
+      startsWith(github.head_ref, 'refactor/') ||
+      startsWith(github.head_ref, 'perf/') ||
+      startsWith(github.head_ref, 'test/') ||
+      startsWith(github.head_ref, 'build/') ||
+      startsWith(github.head_ref, 'ci/') ||
+      startsWith(github.head_ref, 'chore/') ||
+      startsWith(github.head_ref, 'task/') ||
+      startsWith(github.head_ref, 'bug/')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem
The code-quality/build/test jobs in `on_pr_from_task_to_develop.yml` gate every job on the PR head-branch prefix:

```yaml
if: startsWith(github.head_ref, 'task/') || startsWith(github.head_ref, 'feat/') || startsWith(github.head_ref, 'bug/')
```

Any branch with a different prefix (e.g. `fix/`, `feature/`) makes all five jobs **skip**. Because these are **required** status checks, a skipped job never reports success and the PR is effectively blocked — while also looking like it has "no failing checks". This hit #1020 (`feature/…`) and #1026 (`fix/…`), and the only workaround so far was renaming branches (which closes/recreates PRs and creates team churn).

## Fix
Broaden the allowlist to the Conventional Commits types plus `feature/`, keeping the existing `task/` and `bug/`:

`feat`, `feature`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `task`, `bug`.

## Effect on existing PRs
`pull_request` workflows run against the head+base merge, so once this lands on `develop`, open PRs like **#1026** just need to merge `develop` in (also required by the strict/up-to-date rule) to re-trigger — no rename, no recreate.

> Self-check: this PR's own branch is `ci/…`, one of the newly-allowed prefixes.
