### PR TITLE
BIS : Fixed PR comments for BIS changes for inapps

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -118,7 +118,8 @@ public interface Constants {
     String INAPP_KEY = "inApp";
     String INAPP_WZRK_PIVOT = "wzrk_pivot";
     String INAPP_WZRK_CGID = "wzrk_cgId";
-    int INAPP_CLOSE_IV_WIDTH = 48;
+    int INAPP_CLOSE_IV_WIDTH = 40;
+    int INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH = 48;
     String INAPP_JS_ENABLED = "isJsEnabled";
     String NOTIFICATION_ID_TAG = "wzrk_id";
     String DEEP_LINK_KEY = "wzrk_dl";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
@@ -20,7 +20,8 @@ import com.clevertap.android.sdk.R;
 public final class CloseImageView extends AppCompatImageView {
 
     public static final int VIEW_ID = 199272;
-    private final int canvasSize = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH);
+    private final int iconSize = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH);
+    private final int touchTargetSize = getScaledPixels(Constants.INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH);
 
     @SuppressLint("ResourceType")
     public CloseImageView(Context context) {
@@ -60,8 +61,9 @@ public final class CloseImageView extends AppCompatImageView {
 
             if (closeBitmap != null) {
                 Bitmap scaledCloseBitmap = Bitmap.createScaledBitmap(closeBitmap,
-                        canvasSize, canvasSize, true);
-                canvas.drawBitmap(scaledCloseBitmap, 0, 0, new Paint());
+                        iconSize, iconSize, true);
+                float offset = (touchTargetSize - iconSize) / 2f;
+                canvas.drawBitmap(scaledCloseBitmap, offset, offset, new Paint());
             } else {
                 Logger.v("Unable to find inapp notif close button image");
             }
@@ -73,7 +75,7 @@ public final class CloseImageView extends AppCompatImageView {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         // The image view is fixed in dip on all devices
-        setMeasuredDimension(canvasSize, canvasSize);
+        setMeasuredDimension(touchTargetSize, touchTargetSize);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.View
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 
@@ -118,7 +119,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.accessibilityPaneTitle = getString(R.string.ct_inapp_message_shown)
+        ViewCompat.setAccessibilityPaneTitle(view, getString(R.string.ct_inapp_message_shown))
         didShow(null)
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -118,7 +118,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.announceForAccessibility(getString(R.string.ct_inapp_message_shown))
+        view.accessibilityPaneTitle = getString(R.string.ct_inapp_message_shown)
         didShow(null)
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
@@ -56,7 +56,7 @@ internal abstract class CTInAppBaseFullHtmlFragment : CTInAppBaseFullFragment() 
         closeIvLp.addRule(RelativeLayout.ABOVE, webViewId)
         closeIvLp.addRule(RelativeLayout.RIGHT_OF, webViewId)
 
-        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH) / 2
+        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH) / 2
         closeIvLp.setMargins(-sub, 0, 0, -sub)
         return closeIvLp
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppHtmlCoverFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppHtmlCoverFragment.kt
@@ -17,7 +17,7 @@ internal class CTInAppHtmlCoverFragment : CTInAppBaseFullHtmlFragment() {
         closeIvLp.addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
         closeIvLp.addRule(RelativeLayout.ALIGN_PARENT_TOP)
 
-        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH) / 4
+        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH) / 4
         closeIvLp.setMargins(0, sub, sub, 0)
         return closeIvLp
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverFragment.kt
@@ -11,6 +11,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -57,13 +58,18 @@ internal class CTInAppNativeCoverFragment : CTInAppBaseFullNativeFragment() {
             InAppMediaConfig(imageViewId = R.id.backgroundImage, clickableMedia = false, gifImageId = R.id.gifImage)
         )
 
+        relativeLayout.findViewById<View>(R.id.backgroundImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val textView1 = relativeLayout.findViewById<TextView>(R.id.cover_title)
         textView1.text = inAppNotification.title
         textView1.setTextColor(inAppNotification.titleColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView1, true)
 
         val textView2 = relativeLayout.findViewById<TextView>(R.id.cover_message)
         textView2.text = inAppNotification.message
         textView2.setTextColor(inAppNotification.messageColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView2, true)
 
         val buttons = inAppNotification.buttons
         if (buttons.size == 1) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverImageFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -49,6 +50,9 @@ internal class CTInAppNativeCoverImageFragment : CTInAppBaseFullFragment() {
             InAppMediaConfig(imageViewId = R.id.cover_image, clickableMedia = true, videoFrameId = R.id.video_frame, gifImageId = R.id.gifImage),
             CTInAppNativeButtonClickListener()
         )
+
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val closeImageView = fl.findViewById<CloseImageView>(CloseImageView.VIEW_ID)
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeFooterFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeFooterFragment.kt
@@ -12,6 +12,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -61,13 +62,18 @@ internal class CTInAppNativeFooterFragment : CTInAppBasePartialNativeFragment() 
             )
         )
 
+        ViewCompat.setScreenReaderFocusable(imageView, true)
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val textView1 = linearLayout2.findViewById<TextView>(R.id.footer_title)
         textView1.text = inAppNotification.title
         textView1.setTextColor(inAppNotification.titleColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView1, true)
 
         val textView2 = linearLayout2.findViewById<TextView>(R.id.footer_message)
         textView2.text = inAppNotification.message
         textView2.setTextColor(inAppNotification.messageColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView2, true)
 
         val buttons = inAppNotification.buttons
         if (!buttons.isEmpty()) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialFragment.kt
@@ -15,6 +15,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.DeviceInfo
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
@@ -138,6 +139,9 @@ internal class CTInAppNativeHalfInterstitialFragment : CTInAppBaseFullNativeFrag
             InAppMediaConfig(imageViewId = R.id.backgroundImage, clickableMedia = false, gifImageId = R.id.gifImage)
         )
 
+        relativeLayout?.findViewById<View>(R.id.backgroundImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val linearLayout =
             relativeLayout?.findViewById<LinearLayout>(R.id.half_interstitial_linear_layout)
         val mainButton = linearLayout?.findViewById<Button>(R.id.half_interstitial_button1)
@@ -148,10 +152,12 @@ internal class CTInAppNativeHalfInterstitialFragment : CTInAppBaseFullNativeFrag
         val textView1 = relativeLayout?.findViewById<TextView>(R.id.half_interstitial_title)
         textView1?.text = inAppNotification.title
         textView1?.setTextColor(inAppNotification.titleColor.toColorInt())
+        textView1?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val textView2 = relativeLayout?.findViewById<TextView>(R.id.half_interstitial_message)
         textView2?.text = inAppNotification.message
         textView2?.setTextColor(inAppNotification.messageColor.toColorInt())
+        textView2?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val buttons = inAppNotification.buttons
         if (buttons.size == 1) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialImageFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -136,6 +137,9 @@ internal class CTInAppNativeHalfInterstitialImageFragment : CTInAppBaseFullFragm
             InAppMediaConfig(imageViewId = R.id.half_interstitial_image, clickableMedia = true, videoFrameId = R.id.video_frame, gifImageId = R.id.gifImage),
             CTInAppNativeButtonClickListener()
         )
+
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         closeImageView.setOnClickListener {
             didDismiss(null)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHeaderFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHeaderFragment.kt
@@ -12,6 +12,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -62,13 +63,18 @@ internal class CTInAppNativeHeaderFragment : CTInAppBasePartialNativeFragment() 
             )
         )
 
+        ViewCompat.setScreenReaderFocusable(imageView, true)
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val textView1 = linearLayout2.findViewById<TextView>(R.id.header_title)
         textView1.text = inAppNotification.title
         textView1.setTextColor(inAppNotification.titleColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView1, true)
 
         val textView2 = linearLayout2.findViewById<TextView>(R.id.header_message)
         textView2.text = inAppNotification.message
         textView2.setTextColor(inAppNotification.messageColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView2, true)
 
         val buttons = inAppNotification.buttons
         if (!buttons.isEmpty()) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialFragment.kt
@@ -15,6 +15,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -68,6 +69,11 @@ internal class CTInAppNativeInterstitialFragment : CTInAppBaseFullNativeFragment
                 gifImageId = R.id.gifImage,
             )
         )
+
+        relativeLayout?.findViewById<View>(R.id.backgroundImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         setTitleAndMessage()
         setButtons()
         handleCloseButton()
@@ -121,10 +127,12 @@ internal class CTInAppNativeInterstitialFragment : CTInAppBaseFullNativeFragment
         val textView1 = relativeLayout?.findViewById<TextView>(R.id.interstitial_title)
         textView1?.text = inAppNotification.title
         textView1?.setTextColor(inAppNotification.titleColor.toColorInt())
+        textView1?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val textView2 = relativeLayout?.findViewById<TextView>(R.id.interstitial_message)
         textView2?.text = inAppNotification.message
         textView2?.setTextColor(inAppNotification.messageColor.toColorInt())
+        textView2?.let { ViewCompat.setScreenReaderFocusable(it, true) }
     }
 
     private fun resizeContainer(fl: FrameLayout, closeImageView: CloseImageView) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialImageFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -119,6 +120,9 @@ internal class CTInAppNativeInterstitialImageFragment : CTInAppBaseFullFragment(
             InAppMediaConfig(imageViewId = R.id.interstitial_image, clickableMedia = true, videoFrameId = R.id.video_frame, gifImageId = R.id.gifImage),
             CTInAppNativeButtonClickListener()
         )
+
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         closeImageView.setOnClickListener {
             didDismiss(null)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
@@ -57,6 +57,14 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
             }
             dots[position].setImageDrawable(
                     ResourcesCompat.getDrawable(context.getResources(), R.drawable.ct_selected_dot, null));
+            int totalPages = inboxMessage.getInboxMessageContents().size();
+            String imageDesc = getImageContentDescription(context, inboxMessage, position);
+            String announcement = context.getString(R.string.ct_carousel_page_announcement,
+                    imageDesc, position + 1, totalPages);
+            viewHolder.imageViewPager.setContentDescription(
+                    context.getString(R.string.ct_carousel_content_description,
+                            imageDesc, position + 1, totalPages));
+            viewHolder.imageViewPager.announceForAccessibility(announcement);
         }
     }
 
@@ -101,6 +109,10 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
         CTCarouselViewPagerAdapter carouselViewPagerAdapter = new CTCarouselViewPagerAdapter(appContext, parent,
                 inboxMessage, layoutParams, position);
         this.imageViewPager.setAdapter(carouselViewPagerAdapter);
+        int itemCount = inboxMessage.getInboxMessageContents().size();
+        String firstImageDesc = getImageContentDescription(appContext, inboxMessage, 0);
+        this.imageViewPager.setContentDescription(
+                appContext.getString(R.string.ct_carousel_content_description, firstImageDesc, 1, itemCount));
         //Adds the dots for the carousel
         int dotsCount = inboxMessage.getInboxMessageContents().size();
         if (this.sliderDots.getChildCount() > 0) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
@@ -76,6 +76,8 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
 
     private final LinearLayout sliderDots;
 
+    private CarouselPageChangeListener activePageChangeListener;
+
     CTCarouselImageViewHolder(@NonNull View itemView) {
         super(itemView);
         imageViewPager = itemView.findViewById(R.id.image_carousel_viewpager);
@@ -122,10 +124,12 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
         setDots(dots, dotsCount, appContext, this.sliderDots);
         dots[0].setImageDrawable(
                 ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_selected_dot, null));
-        CTCarouselImageViewHolder.CarouselPageChangeListener carouselPageChangeListener
-                = new CTCarouselImageViewHolder.CarouselPageChangeListener(
+        if (activePageChangeListener != null) {
+            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
+        }
+        activePageChangeListener = new CTCarouselImageViewHolder.CarouselPageChangeListener(
                 parent.getActivity().getApplicationContext(), this, dots, inboxMessage);
-        this.imageViewPager.addOnPageChangeListener(carouselPageChangeListener);
+        this.imageViewPager.addOnPageChangeListener(activePageChangeListener);
 
         this.clickLayout.setOnClickListener(
                 new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true, APP_INBOX_ITEM_INDEX));

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
@@ -65,6 +65,14 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
             viewHolder.message.setText(inboxMessage.getInboxMessageContents().get(position).getMessage());
             viewHolder.message.setTextColor(
                     Color.parseColor(inboxMessage.getInboxMessageContents().get(position).getMessageColor()));
+            int totalPages = inboxMessage.getInboxMessageContents().size();
+            String imageDesc = getImageContentDescription(context, inboxMessage, position);
+            String announcement = context.getString(R.string.ct_carousel_page_announcement,
+                    imageDesc, position + 1, totalPages);
+            viewHolder.imageViewPager.setContentDescription(
+                    context.getString(R.string.ct_carousel_content_description,
+                            imageDesc, position + 1, totalPages));
+            viewHolder.imageViewPager.announceForAccessibility(announcement);
         }
     }
 
@@ -123,6 +131,10 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
         CTCarouselViewPagerAdapter carouselViewPagerAdapter = new CTCarouselViewPagerAdapter(appContext, parent,
                 inboxMessage, layoutParams, position);
         this.imageViewPager.setAdapter(carouselViewPagerAdapter);
+        int itemCount = inboxMessage.getInboxMessageContents().size();
+        String firstImageDesc = getImageContentDescription(appContext, inboxMessage, 0);
+        this.imageViewPager.setContentDescription(
+                appContext.getString(R.string.ct_carousel_content_description, firstImageDesc, 1, itemCount));
         //Adds the dots for the carousel
         int dotsCount = inboxMessage.getInboxMessageContents().size();
         if (this.sliderDots.getChildCount() > 0) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
@@ -83,6 +83,8 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
 
     private final LinearLayout sliderDots;
 
+    private CarouselPageChangeListener activePageChangeListener;
+
     private final TextView title;
 
     private final TextView message;
@@ -144,10 +146,12 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
         setDots(dots, dotsCount, appContext, this.sliderDots);
         dots[0].setImageDrawable(
                 ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_selected_dot, null));
-        CTCarouselMessageViewHolder.CarouselPageChangeListener carouselPageChangeListener
-                = new CTCarouselMessageViewHolder.CarouselPageChangeListener(
+        if (activePageChangeListener != null) {
+            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
+        }
+        activePageChangeListener = new CTCarouselMessageViewHolder.CarouselPageChangeListener(
                 parent.getActivity().getApplicationContext(), this, dots, inboxMessage);
-        this.imageViewPager.addOnPageChangeListener(carouselPageChangeListener);
+        this.imageViewPager.addOnPageChangeListener(activePageChangeListener);
 
         this.clickLayout.setOnClickListener(
                 new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true, APP_INBOX_ITEM_INDEX));

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
@@ -31,11 +31,16 @@ public class CTCarouselViewPager extends ViewPager {
         setFocusable(true);
         setFocusableInTouchMode(true);
         setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
+        final AccessibilityDelegateCompat originalDelegate = ViewCompat.getAccessibilityDelegate(this);
         ViewCompat.setAccessibilityDelegate(this, new AccessibilityDelegateCompat() {
             @Override
             public void onInitializeAccessibilityNodeInfo(@NonNull View host,
                     @NonNull AccessibilityNodeInfoCompat info) {
-                super.onInitializeAccessibilityNodeInfo(host, info);
+                if (originalDelegate != null) {
+                    originalDelegate.onInitializeAccessibilityNodeInfo(host, info);
+                } else {
+                    super.onInitializeAccessibilityNodeInfo(host, info);
+                }
                 info.setClassName("android.widget.ScrollView");
                 if (getAdapter() != null && getAdapter().getCount() > 1) {
                     info.setScrollable(true);
@@ -45,6 +50,16 @@ public class CTCarouselViewPager extends ViewPager {
                     if (getCurrentItem() > 0) {
                         info.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_SCROLL_BACKWARD);
                     }
+                }
+            }
+
+            @Override
+            public void onInitializeAccessibilityEvent(@NonNull View host,
+                    @NonNull AccessibilityEvent event) {
+                if (originalDelegate != null) {
+                    originalDelegate.onInitializeAccessibilityEvent(host, event);
+                } else {
+                    super.onInitializeAccessibilityEvent(host, event);
                 }
             }
 
@@ -62,6 +77,9 @@ public class CTCarouselViewPager extends ViewPager {
                         restoreAccessibilityFocus();
                         return true;
                     }
+                }
+                if (originalDelegate != null) {
+                    return originalDelegate.performAccessibilityAction(host, action, args);
                 }
                 return super.performAccessibilityAction(host, action, args);
             }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
@@ -1,35 +1,84 @@
 package com.clevertap.android.sdk.inbox;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
+import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
+import androidx.core.view.AccessibilityDelegateCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 import androidx.viewpager.widget.ViewPager;
+import com.clevertap.android.sdk.R;
 
-/**
- * Custom Viewpager class to handle orientation of images
- */
 @RestrictTo(Scope.LIBRARY)
 public class CTCarouselViewPager extends ViewPager {
 
-    /**
-     * Constructor
-     *
-     * @param context the context
-     */
     public CTCarouselViewPager(Context context) {
         super(context);
+        setupAccessibility();
     }
 
-    /**
-     * Constructor
-     *
-     * @param context the context
-     * @param attrs   the attribute set
-     */
     public CTCarouselViewPager(Context context, AttributeSet attrs) {
         super(context, attrs);
+        setupAccessibility();
+    }
+
+    private void setupAccessibility() {
+        setFocusable(true);
+        setFocusableInTouchMode(true);
+        setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
+        ViewCompat.setAccessibilityDelegate(this, new AccessibilityDelegateCompat() {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(@NonNull View host,
+                    @NonNull AccessibilityNodeInfoCompat info) {
+                super.onInitializeAccessibilityNodeInfo(host, info);
+                info.setClassName("android.widget.ScrollView");
+                if (getAdapter() != null && getAdapter().getCount() > 1) {
+                    info.setScrollable(true);
+                    if (getCurrentItem() < getAdapter().getCount() - 1) {
+                        info.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_SCROLL_FORWARD);
+                    }
+                    if (getCurrentItem() > 0) {
+                        info.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_SCROLL_BACKWARD);
+                    }
+                }
+            }
+
+            @Override
+            public boolean performAccessibilityAction(@NonNull View host, int action, Bundle args) {
+                if (action == AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD) {
+                    if (getAdapter() != null && getCurrentItem() < getAdapter().getCount() - 1) {
+                        setCurrentItem(getCurrentItem() + 1, true);
+                        restoreAccessibilityFocus();
+                        return true;
+                    }
+                } else if (action == AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD) {
+                    if (getCurrentItem() > 0) {
+                        setCurrentItem(getCurrentItem() - 1, true);
+                        restoreAccessibilityFocus();
+                        return true;
+                    }
+                }
+                return super.performAccessibilityAction(host, action, args);
+            }
+        });
+    }
+
+    private void restoreAccessibilityFocus() {
+        postDelayed(() -> {
+            clearFocus();
+            requestFocus();
+            sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+            ViewCompat.performAccessibilityAction(
+                    CTCarouselViewPager.this,
+                    AccessibilityNodeInfoCompat.ACTION_ACCESSIBILITY_FOCUS,
+                    null
+            );
+        }, 300);
     }
 
     @Override
@@ -49,32 +98,5 @@ public class CTCarouselViewPager extends ViewPager {
         }
 
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-    }
-
-    /**
-     * Determines the height of this view
-     *
-     * @param measureSpec A measureSpec packed into an int
-     * @param view        the base view with already measured height
-     * @return The height of the view, honoring constraints from measureSpec
-     */
-    @SuppressWarnings({"unused"})
-    private int measureHeight(int measureSpec, View view) {
-        int result = 0;
-        int specMode = MeasureSpec.getMode(measureSpec);
-        int specSize = MeasureSpec.getSize(measureSpec);
-
-        if (specMode == MeasureSpec.EXACTLY) {
-            result = specSize;
-        } else {
-            // set the height from the base view if available
-            if (view != null) {
-                result = view.getMeasuredHeight();
-            }
-            if (specMode == MeasureSpec.AT_MOST) {
-                result = Math.min(result, specSize);
-            }
-        }
-        return result;
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPagerAdapter.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPagerAdapter.java
@@ -94,11 +94,8 @@ public class CTCarouselViewPagerAdapter extends PagerAdapter {
 
     void addImageAndSetClick(ImageView imageView, View view, final int position, ViewGroup container) {
         imageView.setVisibility(View.VISIBLE);
-        String contentDescription = carouselImagesData.get(position).getContentDescription();
-        if (contentDescription.isEmpty()) {
-            contentDescription = context.getString(R.string.ct_inbox_image_content_description) + (position + 1);
-        }
-        imageView.setContentDescription(contentDescription);
+        imageView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+        view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
         try {
             Glide.with(imageView.getContext())
                     .load(carouselImagesData.get(position).getUrl())

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.Logger;
+import androidx.core.view.ViewCompat;
 import com.clevertap.android.sdk.R;
 import com.clevertap.android.sdk.Utils;
 import org.json.JSONArray;
@@ -67,6 +68,14 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
         ctaLinearLayout = itemView.findViewById(R.id.cta_linear_layout);
         progressBarFrameLayout = itemView.findViewById(R.id.icon_progress_frame_layout);
         mediaLayout = itemView.findViewById(R.id.media_layout);
+
+        ViewCompat.setScreenReaderFocusable(iconImage, true);
+        ViewCompat.setScreenReaderFocusable(mediaImage, true);
+        ViewCompat.setScreenReaderFocusable(squareImage, true);
+        ViewCompat.setScreenReaderFocusable(defaultImage, true);
+        ViewCompat.setScreenReaderFocusable(title, true);
+        ViewCompat.setScreenReaderFocusable(message, true);
+        ViewCompat.setScreenReaderFocusable(timestamp, true);
     }
 
     @Override

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
@@ -69,10 +69,6 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
         progressBarFrameLayout = itemView.findViewById(R.id.icon_progress_frame_layout);
         mediaLayout = itemView.findViewById(R.id.media_layout);
 
-        ViewCompat.setScreenReaderFocusable(iconImage, true);
-        ViewCompat.setScreenReaderFocusable(mediaImage, true);
-        ViewCompat.setScreenReaderFocusable(squareImage, true);
-        ViewCompat.setScreenReaderFocusable(defaultImage, true);
         ViewCompat.setScreenReaderFocusable(title, true);
         ViewCompat.setScreenReaderFocusable(message, true);
         ViewCompat.setScreenReaderFocusable(timestamp, true);
@@ -174,11 +170,18 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
 
         this.mediaImage.setVisibility(View.GONE);
         this.mediaImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.mediaImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.mediaImage, false);
         this.squareImage.setVisibility(View.GONE);
         this.squareImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.squareImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.squareImage, false);
         this.defaultImage.setVisibility(View.GONE);
         this.defaultImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.defaultImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.defaultImage, false);
+        this.iconImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.iconImage, false);
         this.mediaLayout.setVisibility(View.GONE);
         this.progressBarFrameLayout.setVisibility(View.GONE);
         try {
@@ -186,6 +189,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "l":
                     if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.mediaImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.mediaImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -277,6 +281,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "p":
                     if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.squareImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.squareImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -378,6 +383,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                     if (!TextUtils.isEmpty(content.getMedia())) {
                         if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                             this.defaultImage.setContentDescription(content.getMediaContentDescription());
+                            ViewCompat.setScreenReaderFocusable(this.defaultImage, true);
                         }
                         if (content.mediaIsImage()) {
                             this.mediaLayout.setVisibility(View.VISIBLE);
@@ -495,6 +501,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 iconImage.setVisibility(View.VISIBLE);
                 if (!content.getIconContentDescription().isEmpty()) {
                     iconImage.setContentDescription(content.getIconContentDescription());
+                    ViewCompat.setScreenReaderFocusable(iconImage, true);
                 }
                 try {
                     Glide.with(iconImage.getContext())

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
@@ -269,6 +269,14 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
         }
     }
 
+    String getImageContentDescription(Context context, CTInboxMessage inboxMessage, int position) {
+        String desc = inboxMessage.getInboxMessageContents().get(position).getMediaContentDescription();
+        if (desc == null || desc.isEmpty()) {
+            desc = context.getString(R.string.ct_inbox_image_content_description) + " " + (position + 1);
+        }
+        return desc;
+    }
+
     void setDots(ImageView[] dots, int dotsCount, Context appContext, LinearLayout sliderDots) {
         for (int k = 0; k < dotsCount; k++) {
             dots[k] = new ImageView(appContext);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
@@ -64,9 +64,6 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
         progressBarFrameLayout = itemView.findViewById(R.id.simple_progress_frame_layout);
         mediaLayout = itemView.findViewById(R.id.media_layout);
 
-        ViewCompat.setScreenReaderFocusable(mediaImage, true);
-        ViewCompat.setScreenReaderFocusable(squareImage, true);
-        ViewCompat.setScreenReaderFocusable(defaultImage, true);
     }
 
     @Override
@@ -164,11 +161,16 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
         }
         this.mediaImage.setVisibility(View.GONE);
         this.mediaImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.mediaImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.mediaImage, false);
         this.squareImage.setVisibility(View.GONE);
         this.squareImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.squareImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.squareImage, false);
         this.defaultImage.setVisibility(View.GONE);
         this.defaultImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.defaultImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.defaultImage, false);
         this.mediaLayout.setVisibility(View.GONE);
         this.progressBarFrameLayout.setVisibility(View.GONE);
         try {
@@ -176,6 +178,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "l":
                     if(!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.mediaImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.mediaImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -266,6 +269,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "p":
                     if(!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.squareImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.squareImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -364,6 +368,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                     if (!TextUtils.isEmpty(content.getMedia())) {
                         if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                             this.defaultImage.setContentDescription(content.getMediaContentDescription());
+                            ViewCompat.setScreenReaderFocusable(this.defaultImage, true);
                         }
                         if (content.mediaIsImage()) {
                             this.mediaLayout.setVisibility(View.VISIBLE);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
@@ -19,6 +19,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.Logger;
+import androidx.core.view.ViewCompat;
 import com.clevertap.android.sdk.R;
 import com.clevertap.android.sdk.Utils;
 import org.json.JSONArray;
@@ -63,6 +64,9 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
         progressBarFrameLayout = itemView.findViewById(R.id.simple_progress_frame_layout);
         mediaLayout = itemView.findViewById(R.id.media_layout);
 
+        ViewCompat.setScreenReaderFocusable(mediaImage, true);
+        ViewCompat.setScreenReaderFocusable(squareImage, true);
+        ViewCompat.setScreenReaderFocusable(defaultImage, true);
     }
 
     @Override

--- a/clevertap-core/src/main/res/layout-land/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_cover.xml
@@ -18,7 +18,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +28,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -42,7 +42,7 @@
             android:textColor="@android:color/black"
             android:textSize="30sp"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -59,7 +59,7 @@
             android:maxLines="2"
             android:textColor="@android:color/black"
             android:textSize="22sp"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"
@@ -92,8 +92,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="10dp"
         android:layout_marginTop="10dp"

--- a/clevertap-core/src/main/res/layout-land/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:screenReaderFocusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="30sp"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -58,8 +55,7 @@
             android:gravity="center"
             android:maxLines="2"
             android:textColor="@android:color/black"
-            android:textSize="22sp"
-            android:screenReaderFocusable="true" />
+            android:textSize="22sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"

--- a/clevertap-core/src/main/res/layout-land/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_cover_image.xml
@@ -27,7 +27,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,14 +37,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="10dp"
         android:layout_marginTop="10dp"

--- a/clevertap-core/src/main/res/layout-land/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,7 +36,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inapp_footer.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_footer.xml
@@ -28,7 +28,7 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -37,7 +37,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>
@@ -57,7 +57,7 @@
                     android:layout_marginTop="20dp"
                     android:textSize="@dimen/txt_size_inapp_footer_title"
                     android:textStyle="bold"
-                    android:focusable="true" />
+                    android:screenReaderFocusable="true" />
 
                 <TextView
                     android:id="@+id/footer_message"
@@ -66,7 +66,7 @@
                     android:layout_marginTop="10dp"
                     android:maxLines="3"
                     android:textSize="@dimen/txt_size_inapp_footer_message"
-                    android:focusable="true" />
+                    android:screenReaderFocusable="true" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inapp_footer.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_footer.xml
@@ -28,7 +28,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:screenReaderFocusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -37,7 +36,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>
@@ -56,8 +54,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="20dp"
                     android:textSize="@dimen/txt_size_inapp_footer_title"
-                    android:textStyle="bold"
-                    android:screenReaderFocusable="true" />
+                    android:textStyle="bold" />
 
                 <TextView
                     android:id="@+id/footer_message"
@@ -65,8 +62,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
                     android:maxLines="3"
-                    android:textSize="@dimen/txt_size_inapp_footer_message"
-                    android:screenReaderFocusable="true" />
+                    android:textSize="@dimen/txt_size_inapp_footer_message" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:screenReaderFocusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -43,8 +41,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -60,8 +57,7 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:screenReaderFocusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout-land/inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_half_interstitial.xml
@@ -20,7 +20,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +30,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -44,7 +44,7 @@
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -61,7 +61,7 @@
             android:maxLines="3"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"
@@ -99,8 +99,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_half_interstitial_image.xml
@@ -28,7 +28,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,7 +37,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_half_interstitial_image.xml
@@ -28,7 +28,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,15 +38,15 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_header.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_header.xml
@@ -27,7 +27,7 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -36,7 +36,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>
@@ -55,7 +55,7 @@
                     android:layout_marginTop="20dp"
                     android:textSize="16sp"
                     android:textStyle="bold"
-                    android:focusable="true" />
+                    android:screenReaderFocusable="true" />
 
                 <TextView
                     android:id="@+id/header_message"
@@ -65,7 +65,7 @@
                     android:layout_marginTop="4dp"
                     android:maxLines="3"
                     android:textSize="14sp"
-                    android:focusable="true" />
+                    android:screenReaderFocusable="true" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inapp_header.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_header.xml
@@ -27,7 +27,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:screenReaderFocusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -36,7 +35,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>
@@ -54,8 +52,7 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="20dp"
                     android:textSize="16sp"
-                    android:textStyle="bold"
-                    android:screenReaderFocusable="true" />
+                    android:textStyle="bold" />
 
                 <TextView
                     android:id="@+id/header_message"
@@ -64,8 +61,7 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="4dp"
                     android:maxLines="3"
-                    android:textSize="14sp"
-                    android:screenReaderFocusable="true" />
+                    android:textSize="14sp" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_interstitial.xml
@@ -23,8 +23,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +39,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +47,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +54,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:screenReaderFocusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -75,8 +71,7 @@
             android:gravity="center"
             android:maxLines="2"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message"
-            android:screenReaderFocusable="true" />
+            android:textSize="@dimen/txt_size_inapp_message" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout-land/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_interstitial.xml
@@ -24,7 +24,7 @@
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +40,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +49,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +57,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -76,7 +76,7 @@
             android:maxLines="2"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_message"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"
@@ -115,8 +115,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_interstitial_image.xml
@@ -31,7 +31,7 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,15 +41,15 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,7 +40,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout-land/inbox_carousel_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_carousel_layout.xml
@@ -49,7 +49,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="10dp"
                     android:layout_marginRight="10dp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
                 <ImageView
                     android:id="@+id/read_circle"
@@ -60,6 +61,8 @@
                     android:layout_marginLeft="10dp"
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
+                    android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                    android:importantForAccessibility="yes"
                     android:src="@drawable/ct_read_circle" />
             </LinearLayout>
         </RelativeLayout>

--- a/clevertap-core/src/main/res/layout-land/inbox_carousel_text_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_carousel_text_layout.xml
@@ -39,6 +39,7 @@
                     android:layout_marginTop="10dp"
                     android:maxLines="2"
                     android:textColor="@android:color/black"
+                    android:textSize="@dimen/ct_inbox_title_text_size"
                     android:textStyle="bold" />
 
                 <TextView
@@ -51,7 +52,8 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_body_text_size" />
 
                 <RelativeLayout
                     android:id="@+id/timestamp_linear_layout"
@@ -81,7 +83,8 @@
                             android:layout_height="wrap_content"
                             android:layout_marginEnd="10dp"
                             android:layout_marginRight="10dp"
-                            android:textColor="@android:color/darker_gray" />
+                            android:textColor="@android:color/darker_gray"
+                        android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
                         <ImageView
                             android:id="@+id/read_circle"
@@ -92,6 +95,8 @@
                             android:layout_marginLeft="10dp"
                             android:layout_marginRight="20dp"
                             android:layout_marginStart="10dp"
+                            android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                            android:importantForAccessibility="yes"
                             android:src="@drawable/ct_read_circle" />
                     </LinearLayout>
                 </RelativeLayout>
@@ -113,9 +118,10 @@
                 android:layout_height="match_parent"
                 android:layout_weight="2"
                 android:background="@android:color/white"
+                android:importantForAccessibility="yes"
                 android:padding="2dp"
                 android:textColor="@android:color/holo_blue_light"
-                android:textSize="14sp"
+                android:textSize="@dimen/ct_inbox_cta_button_text_size"
                 android:visibility="gone" />
 
             <Button
@@ -124,9 +130,10 @@
                 android:layout_height="match_parent"
                 android:layout_weight="2"
                 android:background="@android:color/white"
+                android:importantForAccessibility="yes"
                 android:padding="2dp"
                 android:textColor="@android:color/holo_blue_light"
-                android:textSize="14sp"
+                android:textSize="@dimen/ct_inbox_cta_button_text_size"
                 android:visibility="gone" />
 
             <Button
@@ -135,9 +142,10 @@
                 android:layout_height="match_parent"
                 android:layout_weight="2"
                 android:background="@android:color/white"
+                android:importantForAccessibility="yes"
                 android:padding="2dp"
                 android:textColor="@android:color/holo_blue_light"
-                android:textSize="14sp"
+                android:textSize="@dimen/ct_inbox_cta_button_text_size"
                 android:visibility="gone" />
         </LinearLayout>
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout-land/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_icon_message_layout.xml
@@ -27,7 +27,7 @@
                     android:layout_height="wrap_content"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:screenReaderFocusable="true"
+
                     android:visibility="gone" />
 
                 <com.clevertap.android.sdk.customviews.HorizontalSquareImageView
@@ -37,7 +37,7 @@
                     android:layout_centerInParent="true"
                     android:scaleType="centerCrop"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:screenReaderFocusable="true"
+
                     android:visibility="gone" />
 
                 <ImageView
@@ -47,7 +47,7 @@
                     android:adjustViewBounds="true"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:screenReaderFocusable="true"
+
                     android:visibility="gone" />
 
                 <FrameLayout
@@ -98,7 +98,7 @@
                         android:layout_marginStart="8dp"
                         android:layout_marginTop="8dp"
                         android:contentDescription="@string/ct_inbox_icon_content_description"
-                        android:screenReaderFocusable="true"
+    
                         android:scaleType="fitCenter" />
 
                     <TextView
@@ -111,7 +111,7 @@
                         android:layout_marginStart="10dp"
                         android:layout_marginTop="10dp"
                         android:maxLines="2"
-                        android:screenReaderFocusable="true"
+    
                         android:textColor="@android:color/black"
                         android:textSize="@dimen/ct_inbox_title_text_size"
                         android:textStyle="bold" />
@@ -128,7 +128,7 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:screenReaderFocusable="true"
+
                     android:textColor="@android:color/darker_gray"
                     android:textSize="@dimen/ct_inbox_body_text_size" />
             </RelativeLayout>
@@ -150,7 +150,6 @@
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
                 android:gravity="end"
-                android:screenReaderFocusable="true"
                 android:textColor="@android:color/darker_gray"
                 android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 

--- a/clevertap-core/src/main/res/layout-land/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_icon_message_layout.xml
@@ -27,7 +27,7 @@
                     android:layout_height="wrap_content"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
                 <com.clevertap.android.sdk.customviews.HorizontalSquareImageView
@@ -37,7 +37,7 @@
                     android:layout_centerInParent="true"
                     android:scaleType="centerCrop"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
                 <ImageView
@@ -47,7 +47,7 @@
                     android:adjustViewBounds="true"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
                 <FrameLayout
@@ -98,7 +98,7 @@
                         android:layout_marginStart="8dp"
                         android:layout_marginTop="8dp"
                         android:contentDescription="@string/ct_inbox_icon_content_description"
-                        android:focusable="true"
+                        android:screenReaderFocusable="true"
                         android:scaleType="fitCenter" />
 
                     <TextView
@@ -111,8 +111,9 @@
                         android:layout_marginStart="10dp"
                         android:layout_marginTop="10dp"
                         android:maxLines="2"
-                        android:focusable="true"
+                        android:screenReaderFocusable="true"
                         android:textColor="@android:color/black"
+                        android:textSize="@dimen/ct_inbox_title_text_size"
                         android:textStyle="bold" />
 
                 </LinearLayout>
@@ -127,8 +128,9 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:focusable="true"
-                    android:textColor="@android:color/darker_gray" />
+                    android:screenReaderFocusable="true"
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_body_text_size" />
             </RelativeLayout>
         </LinearLayout>
 
@@ -148,8 +150,9 @@
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
                 android:gravity="end"
-                android:focusable="true"
-                android:textColor="@android:color/darker_gray" />
+                android:screenReaderFocusable="true"
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
             <ImageView
                 android:id="@+id/read_circle"
@@ -158,6 +161,8 @@
                 android:layout_gravity="center"
                 android:layout_marginEnd="20dp"
                 android:layout_marginRight="20dp"
+                android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                android:importantForAccessibility="yes"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
 
@@ -184,9 +189,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -195,9 +201,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -206,9 +213,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
     </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_simple_message_layout.xml
@@ -28,7 +28,6 @@
                     android:layout_height="wrap_content"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
                 <com.clevertap.android.sdk.customviews.HorizontalSquareImageView
@@ -38,7 +37,7 @@
                     android:layout_centerInParent="true"
                     android:scaleType="centerCrop"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:screenReaderFocusable="true"
+
                     android:visibility="gone" />
 
                 <ImageView
@@ -48,7 +47,7 @@
                     android:adjustViewBounds="true"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:screenReaderFocusable="true"
+
                     android:visibility="gone" />
 
                 <FrameLayout

--- a/clevertap-core/src/main/res/layout-land/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_simple_message_layout.xml
@@ -28,7 +28,7 @@
                     android:layout_height="wrap_content"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
                 <com.clevertap.android.sdk.customviews.HorizontalSquareImageView
@@ -38,7 +38,7 @@
                     android:layout_centerInParent="true"
                     android:scaleType="centerCrop"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
                 <ImageView
@@ -48,7 +48,7 @@
                     android:adjustViewBounds="true"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
                 <FrameLayout
@@ -90,6 +90,7 @@
                     android:layout_marginTop="10dp"
                     android:maxLines="2"
                     android:textColor="@android:color/black"
+                    android:textSize="@dimen/ct_inbox_title_text_size"
                     android:textStyle="bold" />
 
 
@@ -103,7 +104,8 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_body_text_size" />
             </RelativeLayout>
         </LinearLayout>
 
@@ -123,7 +125,8 @@
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
                 android:gravity="end"
-                android:textColor="@android:color/darker_gray" />
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
             <ImageView
                 android:id="@+id/read_circle"
@@ -132,6 +135,8 @@
                 android:layout_gravity="center"
                 android:layout_marginEnd="20dp"
                 android:layout_marginRight="20dp"
+                android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                android:importantForAccessibility="yes"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
 
@@ -157,9 +162,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -168,9 +174,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -179,9 +186,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
     </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover.xml
@@ -18,7 +18,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +28,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -42,7 +42,7 @@
             android:textColor="@android:color/black"
             android:textSize="40sp"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -58,7 +58,7 @@
             android:gravity="center"
             android:textColor="@android:color/black"
             android:textSize="24sp"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"
@@ -93,8 +93,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginRight="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:screenReaderFocusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="2"
             android:textColor="@android:color/black"
             android:textSize="40sp"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -57,8 +54,7 @@
             android:layout_marginTop="40dp"
             android:gravity="center"
             android:textColor="@android:color/black"
-            android:textSize="24sp"
-            android:screenReaderFocusable="true" />
+            android:textSize="24sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"

--- a/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover_image.xml
@@ -27,7 +27,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,14 +37,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginTop="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,7 +36,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:screenReaderFocusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -43,8 +41,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -59,8 +56,7 @@
             android:layout_marginTop="36dp"
             android:gravity="center"
             android:maxLines="3"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:screenReaderFocusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial.xml
@@ -20,7 +20,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +30,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -44,7 +44,7 @@
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -60,7 +60,7 @@
             android:gravity="center"
             android:maxLines="3"
             android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"
@@ -99,8 +99,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial_image.xml
@@ -28,7 +28,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,7 +37,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial_image.xml
@@ -28,7 +28,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,15 +38,15 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial.xml
@@ -23,8 +23,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +39,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +47,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +54,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:screenReaderFocusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -75,8 +71,7 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message"
-            android:screenReaderFocusable="true" />
+            android:textSize="@dimen/txt_size_inapp_message" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial.xml
@@ -24,7 +24,7 @@
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +40,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +49,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +57,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -76,7 +76,7 @@
             android:maxLines="3"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_message"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"
@@ -115,8 +115,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial_image.xml
@@ -31,7 +31,7 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,15 +41,15 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,7 +40,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/inapp_cover.xml
@@ -18,7 +18,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +28,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -42,7 +42,7 @@
             android:textColor="@android:color/black"
             android:textSize="30sp"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -54,7 +54,7 @@
             android:gravity="center"
             android:textColor="@android:color/black"
             android:textSize="18sp"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"
@@ -88,8 +88,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginTop="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:screenReaderFocusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="2"
             android:textColor="@android:color/black"
             android:textSize="30sp"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -53,8 +50,7 @@
             android:layout_marginTop="80dp"
             android:gravity="center"
             android:textColor="@android:color/black"
-            android:textSize="18sp"
-            android:screenReaderFocusable="true" />
+            android:textSize="18sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"

--- a/clevertap-core/src/main/res/layout-sw600dp/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/inapp_cover_image.xml
@@ -27,7 +27,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,14 +37,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginTop="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,7 +36,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:screenReaderFocusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -42,8 +40,7 @@
             android:gravity="center"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -53,8 +50,7 @@
             android:layout_centerHorizontal="true"
             android:layout_marginTop="30dp"
             android:gravity="center"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:screenReaderFocusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial.xml
@@ -20,7 +20,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +30,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -43,7 +43,7 @@
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -54,7 +54,7 @@
             android:layout_marginTop="30dp"
             android:gravity="center"
             android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"
@@ -89,8 +89,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial_image.xml
@@ -29,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -39,7 +38,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial_image.xml
@@ -29,7 +29,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -39,15 +39,15 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial.xml
@@ -23,8 +23,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +39,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +47,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +54,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:screenReaderFocusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -71,8 +67,7 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message"
-            android:screenReaderFocusable="true" />
+            android:textSize="@dimen/txt_size_inapp_message" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial.xml
@@ -24,7 +24,7 @@
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +40,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +49,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +57,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -72,7 +72,7 @@
             android:maxLines="3"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_message"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"
@@ -107,8 +107,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial_image.xml
@@ -31,7 +31,7 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,15 +41,15 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,7 +40,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover.xml
@@ -18,7 +18,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +28,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -42,7 +42,7 @@
             android:textColor="@android:color/black"
             android:textSize="30sp"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -54,7 +54,7 @@
             android:gravity="center"
             android:textColor="@android:color/black"
             android:textSize="18sp"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:screenReaderFocusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="2"
             android:textColor="@android:color/black"
             android:textSize="30sp"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -53,8 +50,7 @@
             android:layout_marginTop="40dp"
             android:gravity="center"
             android:textColor="@android:color/black"
-            android:textSize="18sp"
-            android:screenReaderFocusable="true" />
+            android:textSize="18sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,7 +36,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover_image.xml
@@ -27,7 +27,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,7 +37,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_footer.xml
+++ b/clevertap-core/src/main/res/layout/inapp_footer.xml
@@ -28,7 +28,7 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -37,7 +37,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
             </FrameLayout>
 
@@ -56,7 +56,7 @@
                     android:layout_marginTop="20dp"
                     android:textSize="@dimen/txt_size_inapp_footer_title"
                     android:textStyle="bold"
-                    android:focusable="true" />
+                    android:screenReaderFocusable="true" />
 
                 <TextView
                     android:id="@+id/footer_message"
@@ -65,7 +65,7 @@
                     android:layout_marginTop="10dp"
                     android:maxLines="3"
                     android:textSize="@dimen/txt_size_inapp_footer_message"
-                    android:focusable="true" />
+                    android:screenReaderFocusable="true" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_footer.xml
+++ b/clevertap-core/src/main/res/layout/inapp_footer.xml
@@ -28,7 +28,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:screenReaderFocusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -37,7 +36,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
             </FrameLayout>
 
@@ -55,8 +53,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="20dp"
                     android:textSize="@dimen/txt_size_inapp_footer_title"
-                    android:textStyle="bold"
-                    android:screenReaderFocusable="true" />
+                    android:textStyle="bold" />
 
                 <TextView
                     android:id="@+id/footer_message"
@@ -64,8 +61,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginTop="10dp"
                     android:maxLines="3"
-                    android:textSize="@dimen/txt_size_inapp_footer_message"
-                    android:screenReaderFocusable="true" />
+                    android:textSize="@dimen/txt_size_inapp_footer_message" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
@@ -20,7 +20,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"/>
+            android:screenReaderFocusable="true"/>
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +30,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -43,7 +43,7 @@
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -54,7 +54,7 @@
             android:layout_marginTop="20dp"
             android:gravity="center"
             android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"/>
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -42,8 +40,7 @@
             android:gravity="center"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -53,8 +50,7 @@
             android:layout_centerHorizontal="true"
             android:layout_marginTop="20dp"
             android:gravity="center"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:screenReaderFocusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
@@ -28,7 +28,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,7 +37,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
@@ -28,7 +28,7 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,7 +38,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inapp_header.xml
+++ b/clevertap-core/src/main/res/layout/inapp_header.xml
@@ -27,7 +27,7 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -36,7 +36,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
+                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>
@@ -55,7 +55,7 @@
                     android:layout_marginTop="20dp"
                     android:textSize="16sp"
                     android:textStyle="bold"
-                    android:focusable="true" />
+                    android:screenReaderFocusable="true" />
 
                 <TextView
                     android:id="@+id/header_message"
@@ -65,7 +65,7 @@
                     android:layout_marginTop="4dp"
                     android:maxLines="3"
                     android:textSize="14sp"
-                    android:focusable="true" />
+                    android:screenReaderFocusable="true" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_header.xml
+++ b/clevertap-core/src/main/res/layout/inapp_header.xml
@@ -27,7 +27,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:screenReaderFocusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -36,7 +35,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:screenReaderFocusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>
@@ -54,8 +52,7 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="20dp"
                     android:textSize="16sp"
-                    android:textStyle="bold"
-                    android:screenReaderFocusable="true" />
+                    android:textStyle="bold" />
 
                 <TextView
                     android:id="@+id/header_message"
@@ -64,8 +61,7 @@
                     android:layout_marginStart="20dp"
                     android:layout_marginTop="4dp"
                     android:maxLines="3"
-                    android:textSize="14sp"
-                    android:screenReaderFocusable="true" />
+                    android:textSize="14sp" />
             </LinearLayout>
         </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial.xml
@@ -23,8 +23,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
-            android:textStyle="bold"
-            android:screenReaderFocusable="true" />
+            android:textStyle="bold" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +39,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +47,6 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +54,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:screenReaderFocusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -71,8 +67,7 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_message"
-            android:screenReaderFocusable="true" />
+            android:textSize="@dimen/txt_size_inapp_message" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial.xml
@@ -24,7 +24,7 @@
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_title"
             android:textStyle="bold"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <FrameLayout
             android:id="@+id/media_container"
@@ -40,7 +40,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_img"
                 android:scaleType="centerCrop"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.gif.GifImageView
@@ -49,7 +49,7 @@
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_gif"
                 android:scaleType="centerCrop"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -57,7 +57,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:contentDescription="@string/ct_inapp_media"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone"/>
         </FrameLayout>
 
@@ -72,7 +72,7 @@
             android:maxLines="3"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_message"
-            android:focusable="true" />
+            android:screenReaderFocusable="true" />
 
         <LinearLayout
             android:id="@+id/interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
@@ -31,7 +31,7 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,7 +41,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
+            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,7 +40,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:screenReaderFocusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
@@ -29,7 +29,7 @@
                 android:layout_marginStart="8dp"
                 android:layout_marginTop="8dp"
                 android:contentDescription="@string/ct_inbox_icon_content_description"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:scaleType="fitCenter" />
 
             <LinearLayout
@@ -77,7 +77,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.customviews.SquareImageView
@@ -85,7 +85,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <ImageView
@@ -95,7 +95,7 @@
                 android:adjustViewBounds="true"
                 android:scaleType="fitCenter"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -160,10 +160,9 @@
     <LinearLayout
         android:id="@+id/cta_linear_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="44dp"
         android:layout_below="@id/click_relative_layout"
         android:background="@android:color/white"
-        android:minHeight="@dimen/ct_inbox_min_tap_target"
         android:orientation="horizontal"
         android:weightSum="6">
 
@@ -174,7 +173,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"
@@ -187,7 +185,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"
@@ -200,7 +197,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"

--- a/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
@@ -29,7 +29,6 @@
                 android:layout_marginStart="8dp"
                 android:layout_marginTop="8dp"
                 android:contentDescription="@string/ct_inbox_icon_content_description"
-                android:screenReaderFocusable="true"
                 android:scaleType="fitCenter" />
 
             <LinearLayout
@@ -77,7 +76,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:screenReaderFocusable="true"
+
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.customviews.SquareImageView
@@ -85,7 +84,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:screenReaderFocusable="true"
+
                 android:visibility="gone" />
 
             <ImageView
@@ -95,7 +94,7 @@
                 android:adjustViewBounds="true"
                 android:scaleType="fitCenter"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:screenReaderFocusable="true"
+
                 android:visibility="gone" />
 
             <FrameLayout

--- a/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
@@ -22,7 +22,6 @@
                 android:layout_height="wrap_content"
                 android:scaleType="centerCrop"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.customviews.SquareImageView
@@ -31,7 +30,7 @@
                 android:layout_height="wrap_content"
                 android:scaleType="centerCrop"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:screenReaderFocusable="true"
+
                 android:visibility="gone" />
 
             <ImageView
@@ -41,7 +40,7 @@
                 android:adjustViewBounds="true"
                 android:scaleType="fitCenter"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:screenReaderFocusable="true"
+
                 android:visibility="gone" />
 
             <FrameLayout

--- a/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
@@ -22,7 +22,7 @@
                 android:layout_height="wrap_content"
                 android:scaleType="centerCrop"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.customviews.SquareImageView
@@ -31,7 +31,7 @@
                 android:layout_height="wrap_content"
                 android:scaleType="centerCrop"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <ImageView
@@ -41,7 +41,7 @@
                 android:adjustViewBounds="true"
                 android:scaleType="fitCenter"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+                android:screenReaderFocusable="true"
                 android:visibility="gone" />
 
             <FrameLayout
@@ -140,10 +140,9 @@
     <LinearLayout
         android:id="@+id/cta_linear_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="44dp"
         android:layout_below="@id/click_relative_layout"
         android:background="@android:color/white"
-        android:minHeight="@dimen/ct_inbox_min_tap_target"
         android:orientation="horizontal"
         android:weightSum="6">
 
@@ -154,7 +153,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"
@@ -167,7 +165,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"
@@ -180,7 +177,6 @@
             android:layout_weight="2"
             android:background="@android:color/white"
             android:importantForAccessibility="yes"
-            android:minHeight="@dimen/ct_inbox_min_tap_target"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
             android:textSize="@dimen/ct_inbox_cta_button_text_size"

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -9,7 +9,6 @@
     <string name="ct_inbox_image_content_description">Message Image</string>
     <string name="ct_inbox_icon_content_description">Message Icon</string>
     <string name="ct_inbox_unread_indicator_content_description">Unread message</string>
-    <string name="ct_inbox_message_content_description">Open message</string>
     <string name="ct_notification_big_picture_alt_text">Notification Big Picture</string>
     <string name="ct_inapp_close_btn">Close</string>
     <string name="ct_inapp_message_shown">Popup shown</string>

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -9,6 +9,8 @@
     <string name="ct_inbox_image_content_description">Message Image</string>
     <string name="ct_inbox_icon_content_description">Message Icon</string>
     <string name="ct_inbox_unread_indicator_content_description">Unread message</string>
+    <string name="ct_carousel_content_description">Image carousel, %1$s, Page %2$d of %3$d</string>
+    <string name="ct_carousel_page_announcement">%1$s, Page %2$d of %3$d</string>
     <string name="ct_notification_big_picture_alt_text">Notification Big Picture</string>
     <string name="ct_inapp_close_btn">Close</string>
     <string name="ct_inapp_message_shown">Popup shown</string>


### PR DESCRIPTION
**1. `screenReaderFocusable` replacement** — Replaced `android:focusable="true"` with `android:screenReaderFocusable="true"` on all non-interactive views (TextViews, ImageViews, media containers) across all layout qualifiers:
- 8 portrait in-app layouts
- 8 landscape in-app layouts
- 12 tablet in-app layouts (sw600dp + sw600dp-land)
- 4 inbox layouts (portrait + landscape simple/icon)

**2. CloseImageView touch target** — Separated icon size from touch target:
- `Constants.java`: reverted `INAPP_CLOSE_IV_WIDTH` to 40dp, added `INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH = 48dp`
- `CloseImageView.java`: view measures at 48dp, icon drawn at 40dp centered (4dp padding)
- Updated HTML fragment margin calculations to use touch target width
- Updated all 24 CloseImageView XML declarations to 48dp

**3. `accessibilityPaneTitle`** — Replaced deprecated `announceForAccessibility` with `accessibilityPaneTitle` in `CTInAppBaseFragment.kt`

**4. Inbox landscape sync** — Applied missing changes to landscape inbox layouts:
- Added text size dimens (`ct_inbox_title/body/timestamp_text_size`)
- Added unread indicator `contentDescription` + `importantForAccessibility`
- Added `importantForAccessibility` on CTA buttons

**5. Removed unused string** — Deleted `ct_inbox_message_content_description` from `strings.xml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen-reader support across in-app messages and inbox content.
  * Added clearer carousel descriptions, page announcements, and accessible next/previous navigation.
  * Improved announcements when in-app messages appear.
* **UI Improvements**
  * Enlarged in-app close-button touch targets while keeping the icon visually compact.
  * Standardized inbox text sizing and improved unread-indicator and CTA accessibility.
  * Updated CTA areas for consistent tap sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->