### PR TITLE
[SDK-5955] App Inbox: repaint the built-in inbox list after pull-to-refresh

### DIFF
--- a/clevertap-core/build.gradle
+++ b/clevertap-core/build.gradle
@@ -61,6 +61,8 @@ dependencies {
 
     // Unit testing dependencies
     testImplementation(project(":test_shared"))
+    // material is compileOnly for consumers; tests inflating inbox_activity.xml (TabLayout) need it at runtime
+    testImplementation(libs.android.material)
     testImplementation(libs.firebase.messaging)
     testImplementation(libs.test.coroutines)
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/MediaPlayerRecyclerView.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/MediaPlayerRecyclerView.kt
@@ -155,6 +155,20 @@ class MediaPlayerRecyclerView : RecyclerView {
         playingHolder = null
     }
 
+    /**
+     * Detaches the shared player surface from its current holder and forgets it.
+     *
+     * Must be called before mutating the adapter data and calling notifyDataSetChanged(),
+     * otherwise the surface view stays parented inside a holder that gets rebound to a
+     * different message. [stop] is not enough for that: it forgets [playingHolder] without
+     * clearing the holder's video container, leaving an orphaned surface behind.
+     * [removeVideoView] must run first — it needs [playingHolder] to locate the container.
+     */
+    fun prepareForListRebind() {
+        removeVideoView()
+        playingHolder = null
+    }
+
     private fun findBestVisibleMediaHolder(): CTInboxBaseMessageViewHolder? {
         var bestHolder: CTInboxBaseMessageViewHolder? = null
         val startPosition = (layoutManager as LinearLayoutManager?)?.findFirstVisibleItemPosition() ?: 0

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/MediaPlayerRecyclerView.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/MediaPlayerRecyclerView.kt
@@ -11,6 +11,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.media3.common.util.UnstableApi
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.clevertap.android.sdk.Logger
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inbox.CTInboxBaseMessageViewHolder
 import com.clevertap.android.sdk.video.InboxVideoPlayerHandle
@@ -165,6 +166,13 @@ class MediaPlayerRecyclerView : RecyclerView {
      * [removeVideoView] must run first — it needs [playingHolder] to locate the container.
      */
     fun prepareForListRebind() {
+        Logger.v(
+            if (playingHolder != null) {
+                "prepareForListRebind: detaching video surface from playing holder"
+            } else {
+                "prepareForListRebind: no active video — nothing to detach"
+            }
+        )
         removeVideoView()
         playingHolder = null
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
@@ -19,7 +19,6 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.viewpager.widget.ViewPager;
 
-import com.clevertap.android.sdk.CTInboxListener;
 import com.clevertap.android.sdk.CTInboxStyleConfig;
 import com.clevertap.android.sdk.CleverTapAPI;
 import com.clevertap.android.sdk.CleverTapInstanceConfig;
@@ -65,8 +64,6 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
     private WeakReference<InboxActivityListener> listenerWeakReference;
 
     private CleverTapAPI cleverTapAPI;
-
-    private CTInboxListener inboxContentUpdatedListener = null;
 
     private PushPermissionHandler pushPermissionHandler;
 
@@ -238,6 +235,20 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
         super.onDestroy();
     }
 
+
+    /**
+     * Repaints every resident inbox list fragment from the already-committed message
+     * store, so tabs never show contradicting data after a refresh. Called only from
+     * the pull-to-refresh success path (explicit user action) — never from background
+     * updates, so an on-screen list never changes without a user gesture.
+     */
+    void refreshAllInboxListFragments() {
+        for (Fragment fragment : getSupportFragmentManager().getFragments()) {
+            if (fragment instanceof CTInboxListViewFragment && fragment.isAdded()) {
+                ((CTInboxListViewFragment) fragment).refreshList();
+            }
+        }
+    }
 
     @Override
     public void messageDidClick(Context baseContext, int contentPageIndex, CTInboxMessage inboxMessage, Bundle data,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
@@ -130,13 +130,10 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
             // otherwise pull-to-refresh has no surface on an empty inbox.
             final FrameLayout listViewFragmentLayout = findViewById(R.id.list_view_fragment);
             listViewFragmentLayout.setVisibility(View.VISIBLE);
-            boolean fragmentExists = false;
-            for (Fragment fragment : getSupportFragmentManager().getFragments()) {
-                if (fragment.getTag() != null && !fragment.getTag().equalsIgnoreCase(getFragmentTag())) {
-                    fragmentExists = true;
-                }
-            }
-            if (!fragmentExists) {
+            // On recreation (rotation, process restore) the FragmentManager restores the
+            // previously added fragment before this code runs — adding again would stack
+            // a duplicate list (and a duplicate video player) into the same container.
+            if (getSupportFragmentManager().findFragmentByTag(getFragmentTag()) == null) {
                 CTInboxListViewFragment listView = new CTInboxListViewFragment();
                 listView.setArguments(bundle);
                 getSupportFragmentManager().beginTransaction()

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
@@ -1,6 +1,5 @@
 package com.clevertap.android.sdk.inbox;
 
-import android.content.Context;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
@@ -244,13 +243,13 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
     }
 
     @Override
-    public void messageDidClick(Context baseContext, int contentPageIndex, CTInboxMessage inboxMessage, Bundle data,
+    public void messageDidClick(int contentPageIndex, CTInboxMessage inboxMessage, Bundle data,
                                 HashMap<String, String> keyValue, int buttonIndex) {
         didClick(data, contentPageIndex, inboxMessage, keyValue, buttonIndex);
     }
 
     @Override
-    public void messageDidShow(Context baseContext, CTInboxMessage inboxMessage, Bundle data) {
+    public void messageDidShow(CTInboxMessage inboxMessage, Bundle data) {
         Logger.v("CTInboxActivity:messageDidShow() called with: data = [" + data + "], inboxMessage = [" + inboxMessage .getMessageId()+ "]");
         didShow(data, inboxMessage);
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
@@ -243,11 +243,14 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
      * updates, so an on-screen list never changes without a user gesture.
      */
     void refreshAllInboxListFragments() {
+        int refreshed = 0;
         for (Fragment fragment : getSupportFragmentManager().getFragments()) {
             if (fragment instanceof CTInboxListViewFragment && fragment.isAdded()) {
                 ((CTInboxListViewFragment) fragment).refreshList();
+                refreshed++;
             }
         }
+        Logger.v("refreshAllInboxListFragments: refreshed " + refreshed + " inbox fragment(s)");
     }
 
     @Override

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxActivity.java
@@ -8,7 +8,6 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
@@ -119,7 +118,6 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
         linearLayout.setBackgroundColor(Color.parseColor(styleConfig.getInboxBackgroundColor()));
         tabLayout = linearLayout.findViewById(R.id.tab_layout);
         viewPager = linearLayout.findViewById(R.id.view_pager);
-        TextView noMessageView = findViewById(R.id.no_message_view);
         Bundle bundle = new Bundle();
         bundle.putParcelable("config", config);
         bundle.putParcelable("styleConfig", styleConfig);
@@ -127,28 +125,23 @@ public class CTInboxActivity extends FragmentActivity implements CTInboxListView
         if (!styleConfig.isUsingTabs()) {
             viewPager.setVisibility(View.GONE);
             tabLayout.setVisibility(View.GONE);
-            if (cleverTapAPI != null && cleverTapAPI.getInboxMessageCount() == 0) {
-                noMessageView.setBackgroundColor(Color.parseColor(styleConfig.getInboxBackgroundColor()));
-                noMessageView.setVisibility(View.VISIBLE);
-                noMessageView.setText(styleConfig.getNoMessageViewText());
-                noMessageView.setTextColor(Color.parseColor(styleConfig.getNoMessageViewTextColor()));
-            } else {
-                final FrameLayout listViewFragmentLayout = findViewById(R.id.list_view_fragment);
-                listViewFragmentLayout.setVisibility(View.VISIBLE);
-                boolean fragmentExists = false;
-                noMessageView.setVisibility(View.GONE);
-                for (Fragment fragment : getSupportFragmentManager().getFragments()) {
-                    if (fragment.getTag() != null && !fragment.getTag().equalsIgnoreCase(getFragmentTag())) {
-                        fragmentExists = true;
-                    }
+            // The fragment owns the empty state (its "no messages" view sits inside the
+            // SwipeRefreshLayout), so it is created even when the inbox is empty —
+            // otherwise pull-to-refresh has no surface on an empty inbox.
+            final FrameLayout listViewFragmentLayout = findViewById(R.id.list_view_fragment);
+            listViewFragmentLayout.setVisibility(View.VISIBLE);
+            boolean fragmentExists = false;
+            for (Fragment fragment : getSupportFragmentManager().getFragments()) {
+                if (fragment.getTag() != null && !fragment.getTag().equalsIgnoreCase(getFragmentTag())) {
+                    fragmentExists = true;
                 }
-                if (!fragmentExists) {
-                    CTInboxListViewFragment listView = new CTInboxListViewFragment();
-                    listView.setArguments(bundle);
-                    getSupportFragmentManager().beginTransaction()
-                            .add(R.id.list_view_fragment, listView, getFragmentTag())
-                            .commit();
-                }
+            }
+            if (!fragmentExists) {
+                CTInboxListViewFragment listView = new CTInboxListViewFragment();
+                listView.setArguments(bundle);
+                getSupportFragmentManager().beginTransaction()
+                        .add(R.id.list_view_fragment, listView, getFragmentTag())
+                        .commit();
             }
         } else {
             viewPager.setVisibility(View.VISIBLE);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
@@ -23,6 +23,7 @@ import androidx.annotation.RestrictTo.Scope;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.core.view.ViewCompat;
 import androidx.recyclerview.widget.RecyclerView;
+import com.clevertap.android.sdk.Logger;
 import com.clevertap.android.sdk.R;
 import java.lang.ref.WeakReference;
 import java.text.SimpleDateFormat;
@@ -320,6 +321,9 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
                             // timer was pending (list refresh or recycling); the rebind schedules
                             // its own timer, so this stale one must do nothing.
                             if (message != inboxMessage) {
+                                Logger.v("markItemAsRead: holder rebound (timer for [" + inboxMessage.getMessageId()
+                                        + "], now showing [" + (message != null ? message.getMessageId() : "null")
+                                        + "]) — skipping stale mark-read");
                                 return;
                             }
                             if (readDot.getVisibility() == View.VISIBLE) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
@@ -316,8 +316,14 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
                     activity.runOnUiThread(new Runnable() {
                         @Override
                         public void run() {
+                            // The holder may have been rebound to a different message while this
+                            // timer was pending (list refresh or recycling); the rebind schedules
+                            // its own timer, so this stale one must do nothing.
+                            if (message != inboxMessage) {
+                                return;
+                            }
                             if (readDot.getVisibility() == View.VISIBLE) {
-                                parent.didShow(null, position);
+                                parent.didShow(null, inboxMessage);
                             }
                             readDot.setVisibility(View.GONE);
                             inboxMessage.setRead(true);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
@@ -259,18 +259,26 @@ public class CTInboxListViewFragment extends Fragment {
 
         // The view holders mark the on-screen copies read instantly, but the store's
         // write is async — never let a refresh flip a just-read message back to unread.
-        mergeReadStateForward(inboxMessages, freshMessages);
+        int preservedReads = mergeReadStateForward(inboxMessages, freshMessages);
+        if (preservedReads > 0) {
+            Logger.v("refreshList: preserved read state for " + preservedReads + " just-read message(s)");
+        }
 
         if (isContentIdentical(inboxMessages, freshMessages)) {
+            Logger.v("refreshList: content identical (" + freshMessages.size()
+                    + " messages) — skipping repaint, video untouched");
             return; // nothing changed — keep any playing video untouched
         }
 
         if (getView() == null || noMessageView == null) {
             // View not created (or already destroyed) — refresh the data only.
+            Logger.v("refreshList: view not available — data-only refresh ("
+                    + freshMessages.size() + " messages)");
             replaceMessagesInPlace(freshMessages);
             return;
         }
 
+        int oldCount = inboxMessages.size();
         if (mediaRecyclerView != null) {
             // Detach the shared video surface while its holder is still known;
             // rebinding with the surface attached is the SDK-2330 video regression.
@@ -280,6 +288,7 @@ public class CTInboxListViewFragment extends Fragment {
         replaceMessagesInPlace(freshMessages);
 
         if (inboxMessages.isEmpty()) {
+            Logger.v("refreshList: list now empty — showing no-message view");
             if (mediaRecyclerView != null) {
                 mediaRecyclerView.setVisibility(View.GONE);
             }
@@ -295,9 +304,12 @@ public class CTInboxListViewFragment extends Fragment {
 
         noMessageView.setVisibility(View.GONE);
         if (inboxMessageAdapter == null) {
+            Logger.v("refreshList: first messages arrived (" + inboxMessages.size()
+                    + ") — building list UI");
             buildListView(); // tab was opened empty — the list UI is built lazily now
             return;
         }
+        Logger.v("refreshList: repainting list, " + oldCount + " -> " + inboxMessages.size() + " messages");
         RecyclerView activeRecyclerView = mediaRecyclerView != null ? mediaRecyclerView : recyclerView;
         if (activeRecyclerView != null) {
             activeRecyclerView.setVisibility(View.VISIBLE);
@@ -318,7 +330,8 @@ public class CTInboxListViewFragment extends Fragment {
         inboxMessages.addAll(freshMessages);
     }
 
-    static void mergeReadStateForward(List<CTInboxMessage> currentMessages, List<CTInboxMessage> freshMessages) {
+    /** @return how many fresh copies were upgraded to read. */
+    static int mergeReadStateForward(List<CTInboxMessage> currentMessages, List<CTInboxMessage> freshMessages) {
         HashSet<String> readIds = new HashSet<>();
         for (CTInboxMessage message : currentMessages) {
             if (message.isRead()) {
@@ -326,13 +339,16 @@ public class CTInboxListViewFragment extends Fragment {
             }
         }
         if (readIds.isEmpty()) {
-            return;
+            return 0;
         }
+        int upgraded = 0;
         for (CTInboxMessage message : freshMessages) {
             if (!message.isRead() && readIds.contains(message.getMessageId())) {
                 message.setRead(true);
+                upgraded++;
             }
         }
+        return upgraded;
     }
 
     static boolean isContentIdentical(List<CTInboxMessage> currentMessages, List<CTInboxMessage> freshMessages) {
@@ -397,6 +413,7 @@ public class CTInboxListViewFragment extends Fragment {
                 activity.runOnUiThread(() -> {
                     swipeRefreshLayout.setRefreshing(false);
                     if (!success) {
+                        Logger.v("pull-to-refresh: fetch failed or throttled — list unchanged");
                         // First fetch that hit a 403 — hide the widget now that the spinner is done.
                         if (refreshApi.isInboxFetchDisabledForSession()) {
                             swipeRefreshLayout.setEnabled(false);
@@ -409,8 +426,10 @@ public class CTInboxListViewFragment extends Fragment {
                     if (currentActivity instanceof CTInboxActivity && !currentActivity.isFinishing()) {
                         // All resident tab fragments repaint from the same committed
                         // snapshot, so no tab keeps showing a server-deleted message.
+                        Logger.v("pull-to-refresh success: refreshing all inbox tabs");
                         ((CTInboxActivity) currentActivity).refreshAllInboxListFragments();
                     } else {
+                        Logger.v("pull-to-refresh success: host is not CTInboxActivity — refreshing this list only");
                         refreshList();
                     }
                 });

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
@@ -40,7 +40,9 @@ import com.clevertap.android.sdk.video.VideoLibChecker;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import org.json.JSONObject;
 
 @RestrictTo(Scope.LIBRARY)
@@ -65,7 +67,10 @@ public class CTInboxListViewFragment extends Fragment {
     MediaPlayerRecyclerView mediaRecyclerView;
 
     RecyclerView recyclerView;
-    private  CTInboxMessageAdapter inboxMessageAdapter;
+
+    TextView noMessageView;
+
+    private CTInboxMessageAdapter inboxMessageAdapter;
 
 
     CTInboxStyleConfig styleConfig;
@@ -98,15 +103,22 @@ public class CTInboxListViewFragment extends Fragment {
         }
     }
     private void updateInboxMessages(){
+        ArrayList<CTInboxMessage> freshMessages = fetchFreshMessages();
+        if (freshMessages != null) {
+            inboxMessages = freshMessages;
+        }
+    }
+
+    @Nullable
+    ArrayList<CTInboxMessage> fetchFreshMessages() {
         Bundle bundle = getArguments();
-        if(bundle==null) return;
+        if (bundle == null) return null;
         final String filter = bundle.getString("filter", null);
         CleverTapAPI cleverTapAPI = CleverTapAPI.instanceWithConfig(getActivity(), config);
-        if (cleverTapAPI != null) {
-            Logger.v( "CTInboxListViewFragment:onAttach() called with: tabPosition = [" + tabPosition + "], filter = [" + filter + "]");
-            ArrayList<CTInboxMessage> allMessages = cleverTapAPI.getAllInboxMessages();
-            inboxMessages = filter != null ? filterMessages(allMessages, filter) : allMessages;
-        }
+        if (cleverTapAPI == null) return null;
+        Logger.v("CTInboxListViewFragment: fetching messages with: tabPosition = [" + tabPosition + "], filter = [" + filter + "]");
+        ArrayList<CTInboxMessage> allMessages = cleverTapAPI.getAllInboxMessages();
+        return filter != null ? filterMessages(allMessages, filter) : allMessages;
     }
 
     @Nullable
@@ -118,19 +130,27 @@ public class CTInboxListViewFragment extends Fragment {
         wireSwipeToRefresh(swipeRefreshLayout);
         linearLayout = allView.findViewById(R.id.list_view_linear_layout);
         linearLayout.setBackgroundColor(Color.parseColor(styleConfig.getInboxBackgroundColor()));
-        TextView noMessageView = allView.findViewById(R.id.list_view_no_message_view);
+        noMessageView = allView.findViewById(R.id.list_view_no_message_view);
 
         if (inboxMessages.size() <= 0) {
-            noMessageView.setVisibility(View.VISIBLE);
-            noMessageView.setText(styleConfig.getNoMessageViewText());
-            noMessageView.setTextColor(Color.parseColor(styleConfig.getNoMessageViewTextColor()));
+            showNoMessageView();
             return allView;
         }
 
         noMessageView.setVisibility(View.GONE);
+        buildListView();
+        return allView;
+    }
 
+    private void showNoMessageView() {
+        noMessageView.setText(styleConfig.getNoMessageViewText());
+        noMessageView.setTextColor(Color.parseColor(styleConfig.getNoMessageViewTextColor()));
+        noMessageView.setVisibility(View.VISIBLE);
+    }
+
+    private void buildListView() {
         final LinearLayoutManager linearLayoutManager = new LinearLayoutManager(getActivity());
-        inboxMessageAdapter= new CTInboxMessageAdapter(inboxMessages, this);
+        inboxMessageAdapter = new CTInboxMessageAdapter(inboxMessages, this);
         if (haveVideoPlayerSupport) {
             mediaRecyclerView = new MediaPlayerRecyclerView(getActivity());
             mediaRecyclerView.setVisibility(View.VISIBLE);
@@ -153,7 +173,7 @@ public class CTInboxListViewFragment extends Fragment {
             }
 
         } else {
-            recyclerView = allView.findViewById(R.id.list_view_recycler_view);
+            recyclerView = linearLayout.findViewById(R.id.list_view_recycler_view);
             recyclerView.setVisibility(View.VISIBLE);
             recyclerView.setLayoutManager(linearLayoutManager);
             recyclerView.addItemDecoration(new VerticalSpaceItemDecoration(18));
@@ -161,7 +181,6 @@ public class CTInboxListViewFragment extends Fragment {
             recyclerView.setAdapter(inboxMessageAdapter);
             inboxMessageAdapter.notifyDataSetChanged();
         }
-        return allView;
     }
 
     @Override
@@ -224,6 +243,129 @@ public class CTInboxListViewFragment extends Fragment {
         }
     }
 
+    /**
+     * Repaints this fragment's list from the already-committed message store.
+     * Main thread only. Called from the pull-to-refresh success path — never from
+     * background updates, so an on-screen list never changes without a user action.
+     */
+    void refreshList() {
+        if (getActivity() == null) {
+            return;
+        }
+        ArrayList<CTInboxMessage> freshMessages = fetchFreshMessages();
+        if (freshMessages == null) {
+            return;
+        }
+
+        // The view holders mark the on-screen copies read instantly, but the store's
+        // write is async — never let a refresh flip a just-read message back to unread.
+        mergeReadStateForward(inboxMessages, freshMessages);
+
+        if (isContentIdentical(inboxMessages, freshMessages)) {
+            return; // nothing changed — keep any playing video untouched
+        }
+
+        if (getView() == null || noMessageView == null) {
+            // View not created (or already destroyed) — refresh the data only.
+            replaceMessagesInPlace(freshMessages);
+            return;
+        }
+
+        if (mediaRecyclerView != null) {
+            // Detach the shared video surface while its holder is still known;
+            // rebinding with the surface attached is the SDK-2330 video regression.
+            mediaRecyclerView.prepareForListRebind();
+        }
+
+        replaceMessagesInPlace(freshMessages);
+
+        if (inboxMessages.isEmpty()) {
+            if (mediaRecyclerView != null) {
+                mediaRecyclerView.setVisibility(View.GONE);
+            }
+            if (recyclerView != null) {
+                recyclerView.setVisibility(View.GONE);
+            }
+            if (inboxMessageAdapter != null) {
+                inboxMessageAdapter.notifyDataSetChanged();
+            }
+            showNoMessageView();
+            return;
+        }
+
+        noMessageView.setVisibility(View.GONE);
+        if (inboxMessageAdapter == null) {
+            buildListView(); // tab was opened empty — the list UI is built lazily now
+            return;
+        }
+        RecyclerView activeRecyclerView = mediaRecyclerView != null ? mediaRecyclerView : recyclerView;
+        if (activeRecyclerView != null) {
+            activeRecyclerView.setVisibility(View.VISIBLE);
+        }
+        inboxMessageAdapter.notifyDataSetChanged();
+        if (mediaRecyclerView != null) {
+            // Post so findBestVisibleMediaHolder() sees the re-laid-out children.
+            mediaRecyclerView.post(mediaRecyclerView::playVideo);
+        }
+    }
+
+    /**
+     * The adapter aliases {@link #inboxMessages}; the field must never be reassigned
+     * after the adapter exists, or click positions resolve against the wrong list.
+     */
+    private void replaceMessagesInPlace(ArrayList<CTInboxMessage> freshMessages) {
+        inboxMessages.clear();
+        inboxMessages.addAll(freshMessages);
+    }
+
+    static void mergeReadStateForward(List<CTInboxMessage> currentMessages, List<CTInboxMessage> freshMessages) {
+        HashSet<String> readIds = new HashSet<>();
+        for (CTInboxMessage message : currentMessages) {
+            if (message.isRead()) {
+                readIds.add(message.getMessageId());
+            }
+        }
+        if (readIds.isEmpty()) {
+            return;
+        }
+        for (CTInboxMessage message : freshMessages) {
+            if (!message.isRead() && readIds.contains(message.getMessageId())) {
+                message.setRead(true);
+            }
+        }
+    }
+
+    static boolean isContentIdentical(List<CTInboxMessage> currentMessages, List<CTInboxMessage> freshMessages) {
+        if (currentMessages.size() != freshMessages.size()) {
+            return false;
+        }
+        for (int i = 0; i < currentMessages.size(); i++) {
+            CTInboxMessage current = currentMessages.get(i);
+            CTInboxMessage fresh = freshMessages.get(i);
+            if (!current.getMessageId().equals(fresh.getMessageId())
+                    || current.isRead() != fresh.isRead()
+                    || current.getDate() != fresh.getDate()
+                    || !contentJson(current).equals(contentJson(fresh))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * The "msg" sub-object only: the top-level read-state key must stay out of this
+     * comparison because the on-screen copies' backing JSON is fetch-time stale
+     * relative to their in-place-mutated read flag.
+     */
+    private static String contentJson(CTInboxMessage message) {
+        JSONObject data = message.getData();
+        if (data == null) {
+            return "";
+        }
+        JSONObject msg = data.optJSONObject(Constants.KEY_MSG);
+        return msg != null ? msg.toString() : "";
+    }
+
     void wireSwipeToRefresh(@NonNull final SwipeRefreshLayout swipeRefreshLayout) {
         // Direct child is a LinearLayout, whose canScrollVertically(-1) is always false.
         // Delegate to whichever RecyclerView is actually on screen so mid-scroll pulls
@@ -254,10 +396,16 @@ public class CTInboxListViewFragment extends Fragment {
                 if (activity == null) return;
                 activity.runOnUiThread(() -> {
                     swipeRefreshLayout.setRefreshing(false);
-                    // First fetch that hit a 403 — hide the widget now that the spinner is done.
-                    if (!success && refreshApi.isInboxFetchDisabledForSession()) {
-                        swipeRefreshLayout.setEnabled(false);
+                    if (!success) {
+                        // First fetch that hit a 403 — hide the widget now that the spinner is done.
+                        if (refreshApi.isInboxFetchDisabledForSession()) {
+                            swipeRefreshLayout.setEnabled(false);
+                        }
+                        return; // fetch failed or throttled — the stored data is unchanged
                     }
+                    // Re-check inside the runnable: state can change between post and run.
+                    if (!isAdded()) return;
+                    refreshList();
                 });
             });
         });

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
@@ -405,7 +405,14 @@ public class CTInboxListViewFragment extends Fragment {
                     }
                     // Re-check inside the runnable: state can change between post and run.
                     if (!isAdded()) return;
-                    refreshList();
+                    Activity currentActivity = getActivity();
+                    if (currentActivity instanceof CTInboxActivity && !currentActivity.isFinishing()) {
+                        // All resident tab fragments repaint from the same committed
+                        // snapshot, so no tab keeps showing a server-deleted message.
+                        ((CTInboxActivity) currentActivity).refreshAllInboxListFragments();
+                    } else {
+                        refreshList();
+                    }
                 });
             });
         });

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
@@ -264,6 +264,10 @@ public class CTInboxListViewFragment extends Fragment {
     }
 
     void didClick(Bundle data, int position, int contentPageIndex, HashMap<String, String> keyValuePayload, int buttonIndex) {
+        if (position < 0 || position >= inboxMessages.size()) {
+            Logger.v("didClick: stale position " + position + ", ignoring click");
+            return;
+        }
         CTInboxListViewFragment.InboxListener listener = getListener();
         if (listener != null) {
             //noinspection ConstantConditions
@@ -272,12 +276,12 @@ public class CTInboxListViewFragment extends Fragment {
     }
 
     @SuppressWarnings("SameParameterValue")
-    void didShow(Bundle data, int position) {
+    void didShow(Bundle data, CTInboxMessage inboxMessage) {
         CTInboxListViewFragment.InboxListener listener = getListener();
         if (listener != null) {
-            Logger.v("CTInboxListViewFragment:didShow() called with: data = [" + data + "], position = [" + position + "]");
+            Logger.v("CTInboxListViewFragment:didShow() called with: data = [" + data + "], messageId = [" + inboxMessage.getMessageId() + "]");
             //noinspection ConstantConditions
-            listener.messageDidShow(getActivity().getBaseContext(), inboxMessages.get(position), data);
+            listener.messageDidShow(getActivity().getBaseContext(), inboxMessage, data);
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
@@ -419,6 +419,11 @@ public class CTInboxListViewFragment extends Fragment {
     }
 
     void didClick(Bundle data, int position, int contentPageIndex, HashMap<String, String> keyValuePayload, int buttonIndex) {
+        // A row's click listener remembers its position from the moment the row was
+        // drawn. Touch events are queued, and after a refresh shrinks the list the
+        // rows are redrawn only on the NEXT frame — so a tap can arrive carrying a
+        // position from the old, longer list. Indexing with it would go out of
+        // bounds, so such a tap is ignored instead of acted on.
         if (position < 0 || position >= inboxMessages.size()) {
             Logger.v("didClick: stale position " + position + ", ignoring click");
             return;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragment.java
@@ -50,10 +50,10 @@ public class CTInboxListViewFragment extends Fragment {
 
     interface InboxListener {
 
-        void messageDidClick(Context baseContext, int contentPageIndex, CTInboxMessage inboxMessage, Bundle data,
+        void messageDidClick(int contentPageIndex, CTInboxMessage inboxMessage, Bundle data,
                 HashMap<String, String> keyValue, int buttonIndex);
 
-        void messageDidShow(Context baseContext, CTInboxMessage inboxMessage, Bundle data);
+        void messageDidShow(CTInboxMessage inboxMessage, Bundle data);
     }
 
     CleverTapInstanceConfig config;
@@ -449,8 +449,7 @@ public class CTInboxListViewFragment extends Fragment {
         }
         CTInboxListViewFragment.InboxListener listener = getListener();
         if (listener != null) {
-            //noinspection ConstantConditions
-            listener.messageDidClick(getActivity().getBaseContext(), contentPageIndex, inboxMessages.get(position), data, keyValuePayload, buttonIndex);
+            listener.messageDidClick(contentPageIndex, inboxMessages.get(position), data, keyValuePayload, buttonIndex);
         }
     }
 
@@ -459,8 +458,7 @@ public class CTInboxListViewFragment extends Fragment {
         CTInboxListViewFragment.InboxListener listener = getListener();
         if (listener != null) {
             Logger.v("CTInboxListViewFragment:didShow() called with: data = [" + data + "], messageId = [" + inboxMessage.getMessageId() + "]");
-            //noinspection ConstantConditions
-            listener.messageDidShow(getActivity().getBaseContext(), inboxMessage, data);
+            listener.messageDidShow(inboxMessage, data);
         }
     }
 

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxActivityTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxActivityTest.kt
@@ -1,0 +1,60 @@
+package com.clevertap.android.sdk.inbox
+
+import androidx.fragment.app.Fragment
+import com.clevertap.android.shared.test.BaseTestCase
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CTInboxActivityTest : BaseTestCase() {
+
+    private fun activityWithFragments(vararg fragments: Fragment): CTInboxActivity {
+        // Without inbox intent extras onCreate returns early, leaving a headless
+        // activity whose FragmentManager is fully usable.
+        val activity = Robolectric.buildActivity(CTInboxActivity::class.java).setup().get()
+        val transaction = activity.supportFragmentManager.beginTransaction()
+        fragments.forEachIndexed { index, fragment -> transaction.add(fragment, "tab$index") }
+        transaction.commitNow()
+        return activity
+    }
+
+    @Test
+    fun `refreshAllInboxListFragments refreshes every attached inbox list fragment`() {
+        val tabOne = RecordingInboxListFragment()
+        val tabTwo = RecordingInboxListFragment()
+
+        val activity = activityWithFragments(tabOne, tabTwo)
+        activity.refreshAllInboxListFragments()
+
+        assertEquals(1, tabOne.refreshListCalls)
+        assertEquals(1, tabTwo.refreshListCalls)
+    }
+
+    @Test
+    fun `refreshAllInboxListFragments skips non-inbox fragments without crashing`() {
+        val inboxFragment = RecordingInboxListFragment()
+        val unrelatedFragment = Fragment()
+
+        val activity = activityWithFragments(unrelatedFragment, inboxFragment)
+        activity.refreshAllInboxListFragments()
+
+        assertEquals(1, inboxFragment.refreshListCalls)
+    }
+
+    @Test
+    fun `refreshAllInboxListFragments skips detached inbox fragments`() {
+        val attached = RecordingInboxListFragment()
+        val detached = RecordingInboxListFragment()
+
+        val activity = activityWithFragments(attached)
+        activity.supportFragmentManager.beginTransaction().add(detached, "detached").commitNow()
+        activity.supportFragmentManager.beginTransaction().detach(detached).commitNow()
+        activity.refreshAllInboxListFragments()
+
+        assertEquals(1, attached.refreshListCalls)
+        assertEquals(0, detached.refreshListCalls)
+    }
+}

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxActivityTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxActivityTest.kt
@@ -1,8 +1,19 @@
 package com.clevertap.android.sdk.inbox
 
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.TextView
 import androidx.fragment.app.Fragment
+import com.clevertap.android.sdk.CTInboxStyleConfig
+import com.clevertap.android.sdk.CleverTapAPI
+import com.clevertap.android.sdk.R
 import com.clevertap.android.shared.test.BaseTestCase
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -42,6 +53,50 @@ class CTInboxActivityTest : BaseTestCase() {
         activity.refreshAllInboxListFragments()
 
         assertEquals(1, inboxFragment.refreshListCalls)
+    }
+
+    /** Launches CTInboxActivity with real inbox extras (no-tabs style config). */
+    private fun launchNoTabsInboxActivity(messageCount: Int): CTInboxActivity {
+        every { CleverTapAPI.instanceWithConfig(any(), any()) } returns cleverTapAPI
+        every { cleverTapAPI.inboxMessageCount } returns messageCount
+        every { cleverTapAPI.allInboxMessages } returns arrayListOf()
+
+        val intent = Intent(appCtx, CTInboxActivity::class.java).apply {
+            putExtra("styleConfig", CTInboxStyleConfig())
+            putExtra("configBundle", Bundle().apply { putParcelable("config", cleverTapInstanceConfig) })
+        }
+        val controller = Robolectric.buildActivity(CTInboxActivity::class.java, intent)
+        controller.get().setTheme(androidx.appcompat.R.style.Theme_AppCompat)
+        val activity = controller.setup().get()
+        activity.supportFragmentManager.executePendingTransactions()
+        return activity
+    }
+
+    @Test
+    fun `no-tabs empty inbox creates the list fragment so pull-to-refresh exists`() {
+        mockkStatic(CleverTapAPI::class)
+        try {
+            val activity = launchNoTabsInboxActivity(messageCount = 0)
+
+            val fragment = activity.supportFragmentManager.fragments.firstOrNull { it is CTInboxListViewFragment }
+            assertTrue(fragment != null)
+            assertEquals(View.GONE, activity.findViewById<TextView>(R.id.no_message_view).visibility)
+        } finally {
+            unmockkStatic(CleverTapAPI::class)
+        }
+    }
+
+    @Test
+    fun `no-tabs non-empty inbox still creates the list fragment`() {
+        mockkStatic(CleverTapAPI::class)
+        try {
+            val activity = launchNoTabsInboxActivity(messageCount = 3)
+
+            val fragment = activity.supportFragmentManager.fragments.firstOrNull { it is CTInboxListViewFragment }
+            assertTrue(fragment != null)
+        } finally {
+            unmockkStatic(CleverTapAPI::class)
+        }
     }
 
     @Test

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxActivityTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxActivityTest.kt
@@ -87,6 +87,40 @@ class CTInboxActivityTest : BaseTestCase() {
     }
 
     @Test
+    fun `activity recreation does not duplicate the list fragment`() {
+        mockkStatic(CleverTapAPI::class)
+        try {
+            every { CleverTapAPI.instanceWithConfig(any(), any()) } returns cleverTapAPI
+            every { cleverTapAPI.inboxMessageCount } returns 1
+            every { cleverTapAPI.allInboxMessages } returns arrayListOf()
+            // Theme must survive recreation: applicationInfo.theme is what the recreated
+            // instance resolves (per-instance setTheme would be lost on recreate()).
+            application.applicationInfo.theme = androidx.appcompat.R.style.Theme_AppCompat
+
+            val intent = Intent(appCtx, CTInboxActivity::class.java).apply {
+                putExtra("styleConfig", CTInboxStyleConfig())
+                putExtra("configBundle", Bundle().apply { putParcelable("config", cleverTapInstanceConfig) })
+            }
+            val controller = Robolectric.buildActivity(CTInboxActivity::class.java, intent).setup()
+            controller.get().supportFragmentManager.executePendingTransactions()
+            assertEquals(1, inboxFragmentCount(controller.get()))
+
+            // Rotation / process-restore path: FragmentManager restores the tagged
+            // fragment, then onCreate runs again and must NOT add a second one.
+            controller.recreate()
+
+            val recreated = controller.get()
+            recreated.supportFragmentManager.executePendingTransactions()
+            assertEquals(1, inboxFragmentCount(recreated))
+        } finally {
+            unmockkStatic(CleverTapAPI::class)
+        }
+    }
+
+    private fun inboxFragmentCount(activity: CTInboxActivity): Int =
+        activity.supportFragmentManager.fragments.count { it is CTInboxListViewFragment }
+
+    @Test
     fun `no-tabs non-empty inbox still creates the list fragment`() {
         mockkStatic(CleverTapAPI::class)
         try {

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolderTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolderTest.kt
@@ -1,0 +1,120 @@
+package com.clevertap.android.sdk.inbox
+
+import android.os.Looper
+import android.view.View
+import android.widget.ImageView
+import android.widget.LinearLayout
+import androidx.fragment.app.FragmentActivity
+import com.clevertap.android.sdk.R
+import com.clevertap.android.shared.test.BaseTestCase
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import java.time.Duration
+
+@RunWith(RobolectricTestRunner::class)
+class CTInboxBaseMessageViewHolderTest : BaseTestCase() {
+
+    private class TestViewHolder(itemView: View) : CTInboxBaseMessageViewHolder(itemView) {
+
+        fun invokeMarkItemAsRead(message: CTInboxMessage, position: Int) {
+            markItemAsRead(message, position)
+        }
+    }
+
+    private lateinit var holder: TestViewHolder
+    private lateinit var readDotView: ImageView
+    private lateinit var fragmentSpy: CTInboxListViewFragment
+
+    @Before
+    @Throws(Exception::class)
+    override fun setUp() {
+        super.setUp()
+        readDotView = ImageView(appCtx).apply {
+            id = R.id.read_circle
+            visibility = View.VISIBLE
+        }
+        val itemView = LinearLayout(appCtx).apply { addView(readDotView) }
+        holder = TestViewHolder(itemView)
+
+        val activity = mockk<FragmentActivity>(relaxed = true)
+        every { activity.runOnUiThread(any()) } answers { firstArg<Runnable>().run() }
+        fragmentSpy = spyk(CTInboxListViewFragment())
+        every { fragmentSpy.activity } returns activity
+        justRun { fragmentSpy.didShow(any(), any()) }
+    }
+
+    private fun unreadMessage(id: String): CTInboxMessage {
+        val json = JSONObject(MESSAGE_JSON).put("id", id).put("isRead", false)
+        return CTInboxMessage(json)
+    }
+
+    @Test
+    fun `delayed markItemAsRead fires didShow with the exact bound message when holder is not rebound`() {
+        val messageA = unreadMessage("msg_A")
+        holder.configureWithMessage(messageA, fragmentSpy, 0)
+
+        holder.invokeMarkItemAsRead(messageA, 0)
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(2000))
+
+        verify(exactly = 1) { fragmentSpy.didShow(null, messageA) }
+        assertEquals(View.GONE, readDotView.visibility)
+        assertTrue(messageA.isRead)
+    }
+
+    @Test
+    fun `delayed markItemAsRead does nothing when holder was rebound to another message`() {
+        val messageA = unreadMessage("msg_A")
+        val messageB = unreadMessage("msg_B")
+        holder.configureWithMessage(messageA, fragmentSpy, 0)
+        holder.invokeMarkItemAsRead(messageA, 0)
+
+        // Simulate a list refresh recycling this holder to a different message
+        // before the 2s timer fires.
+        holder.configureWithMessage(messageB, fragmentSpy, 0)
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(2000))
+
+        verify(exactly = 0) { fragmentSpy.didShow(any(), any()) }
+        assertEquals(View.VISIBLE, readDotView.visibility)
+        assertFalse(messageA.isRead)
+        assertFalse(messageB.isRead)
+    }
+
+    @Test
+    fun `stale timer does not crash when the message list shrank in the meantime`() {
+        val messageA = unreadMessage("msg_A")
+        val messageB = unreadMessage("msg_B")
+        holder.configureWithMessage(messageA, fragmentSpy, 5)
+        holder.invokeMarkItemAsRead(messageA, 5)
+
+        holder.configureWithMessage(messageB, fragmentSpy, 0)
+        fragmentSpy.inboxMessages.clear()
+
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(2000))
+
+        verify(exactly = 0) { fragmentSpy.didShow(any(), any()) }
+    }
+
+    companion object {
+
+        private val MESSAGE_JSON = """{"id":"1674122920_1674457409","msg":{"bg":"#ECEDF2","orientation":"l",
+            |"content":[{"key":5385896764,
+            |"message":{"replacements":"SampleMessage","text":"SampleMessage","color":"#434761"},
+            |"title":{"replacements":"SampleTitle","text":"SampleTitle","color":"#434761"},
+            |"action":{"hasUrl":false,"hasLinks":false,"url":{},"links":[]},"media":{},"icon":{}}],
+            |"type":"simple","tags":[],"enableTags":false},"isRead":false,"date":1674457409,
+            |"wzrk_ttl":1675062209,"tags":[""],"wzrk_id":"1674122920_20230123",
+            |"wzrkParams":{"wzrk_ttl":1675062209,"wzrk_id":"1674122920_20230123","wzrk_pivot":"wzrk_default"}}""".trimMargin()
+    }
+}

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragmentTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragmentTest.kt
@@ -1,7 +1,10 @@
 package com.clevertap.android.sdk.inbox
 
+import androidx.fragment.app.FragmentActivity
 import com.clevertap.android.sdk.Constants
 import com.clevertap.android.shared.test.BaseTestCase
+import io.mockk.every
+import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import org.json.JSONObject
@@ -193,6 +196,42 @@ class CTInboxListViewFragmentTest : BaseTestCase() {
         verify(atLeast = 1) {
             ctInboxListViewFragmentSpy.fireUrlThroughIntent("ctdemo://com.clevertap.demo/WebViewActivity")
         }
+    }
+
+    @Test
+    fun test_didClick_with_out_of_range_position_is_a_silent_noop() {
+        val listener = mockk<CTInboxListViewFragment.InboxListener>(relaxed = true)
+        ctInboxListViewFragmentSpy.setListener(listener)
+        ctInboxListViewFragmentSpy.inboxMessages.add(CTInboxMessage(jsonObj))
+
+        // Positions that a stale click could deliver after a list refresh
+        ctInboxListViewFragmentSpy.didClick(null, 5, 0, null, Constants.APP_INBOX_ITEM_INDEX)
+        ctInboxListViewFragmentSpy.didClick(null, -1, 0, null, Constants.APP_INBOX_ITEM_INDEX)
+
+        verify(exactly = 0) { listener.messageDidClick(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun test_didClick_with_empty_list_does_not_throw() {
+        val listener = mockk<CTInboxListViewFragment.InboxListener>(relaxed = true)
+        ctInboxListViewFragmentSpy.setListener(listener)
+
+        ctInboxListViewFragmentSpy.didClick(null, 0, 0, null, Constants.APP_INBOX_ITEM_INDEX)
+
+        verify(exactly = 0) { listener.messageDidClick(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun test_didShow_forwards_the_exact_message_to_the_listener() {
+        val listener = mockk<CTInboxListViewFragment.InboxListener>(relaxed = true)
+        val activity = mockk<FragmentActivity>(relaxed = true)
+        every { ctInboxListViewFragmentSpy.activity } returns activity
+        ctInboxListViewFragmentSpy.setListener(listener)
+        val message = CTInboxMessage(jsonObj)
+
+        ctInboxListViewFragmentSpy.didShow(null, message)
+
+        verify(exactly = 1) { listener.messageDidShow(any(), message, null) }
     }
 
     @Test

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragmentTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragmentTest.kt
@@ -226,7 +226,7 @@ class CTInboxListViewFragmentTest : BaseTestCase() {
         ctInboxListViewFragmentSpy.didClick(null, 5, 0, null, Constants.APP_INBOX_ITEM_INDEX)
         ctInboxListViewFragmentSpy.didClick(null, -1, 0, null, Constants.APP_INBOX_ITEM_INDEX)
 
-        verify(exactly = 0) { listener.messageDidClick(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { listener.messageDidClick(any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -236,20 +236,18 @@ class CTInboxListViewFragmentTest : BaseTestCase() {
 
         ctInboxListViewFragmentSpy.didClick(null, 0, 0, null, Constants.APP_INBOX_ITEM_INDEX)
 
-        verify(exactly = 0) { listener.messageDidClick(any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 0) { listener.messageDidClick(any(), any(), any(), any(), any()) }
     }
 
     @Test
     fun test_didShow_forwards_the_exact_message_to_the_listener() {
         val listener = mockk<CTInboxListViewFragment.InboxListener>(relaxed = true)
-        val activity = mockk<FragmentActivity>(relaxed = true)
-        every { ctInboxListViewFragmentSpy.activity } returns activity
         ctInboxListViewFragmentSpy.setListener(listener)
         val message = CTInboxMessage(jsonObj)
 
         ctInboxListViewFragmentSpy.didShow(null, message)
 
-        verify(exactly = 1) { listener.messageDidShow(any(), message, null) }
+        verify(exactly = 1) { listener.messageDidShow(message, null) }
     }
 
     // ---------------------------------------------------------------------

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragmentTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragmentTest.kt
@@ -1,12 +1,30 @@
 package com.clevertap.android.sdk.inbox
 
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.fragment.app.FragmentActivity
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+import com.clevertap.android.sdk.CTInboxStyleConfig
+import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.FetchInboxCallback
+import com.clevertap.android.sdk.R
 import com.clevertap.android.shared.test.BaseTestCase
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.spyk
+import io.mockk.unmockkStatic
 import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.robolectric.Robolectric
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
@@ -232,6 +250,200 @@ class CTInboxListViewFragmentTest : BaseTestCase() {
         ctInboxListViewFragmentSpy.didShow(null, message)
 
         verify(exactly = 1) { listener.messageDidShow(any(), message, null) }
+    }
+
+    // ---------------------------------------------------------------------
+    // refreshList() and helpers
+    // ---------------------------------------------------------------------
+
+    private fun message(id: String, text: String = "SampleMessage", read: Boolean = false): CTInboxMessage {
+        val json = JSONObject(jsonObj.toString())
+        json.put("id", id).put("isRead", read)
+        json.getJSONObject("msg").getJSONArray("content").getJSONObject(0)
+            .getJSONObject("message").put("text", text)
+        return CTInboxMessage(json)
+    }
+
+    /** Fragment spy whose view hierarchy exists (non-video path) and whose data
+     *  query is stubbed, mirroring an attached fragment without a FragmentManager. */
+    private fun viewReadyFragment(initial: List<CTInboxMessage> = emptyList()): CTInboxListViewFragment {
+        val fragment = spyk(CTInboxListViewFragment())
+        val fragmentActivity = Robolectric.buildActivity(FragmentActivity::class.java).setup().get()
+        every { fragment.activity } returns fragmentActivity
+        fragment.styleConfig = CTInboxStyleConfig()
+        fragment.haveVideoPlayerSupport = false
+        fragment.linearLayout = LinearLayout(fragmentActivity).apply {
+            addView(RecyclerView(fragmentActivity).apply {
+                id = R.id.list_view_recycler_view
+                visibility = View.GONE
+            })
+        }
+        fragment.noMessageView = TextView(fragmentActivity)
+        every { fragment.view } returns fragment.linearLayout
+        fragment.inboxMessages.addAll(initial)
+        return fragment
+    }
+
+    @Test
+    fun test_mergeReadStateForward_upgrades_unread_to_read_but_never_downgrades() {
+        val oldRead = message("A", read = true)
+        val freshUnreadA = message("A", read = false)
+        val freshReadB = message("B", read = true)
+
+        CTInboxListViewFragment.mergeReadStateForward(listOf(oldRead), listOf(freshUnreadA, freshReadB))
+
+        assertTrue(freshUnreadA.isRead)
+        assertTrue(freshReadB.isRead)
+    }
+
+    @Test
+    fun test_isContentIdentical_matrix() {
+        val a = message("A")
+        assertTrue(CTInboxListViewFragment.isContentIdentical(listOf(a), listOf(message("A"))))
+        assertFalse(CTInboxListViewFragment.isContentIdentical(listOf(a), listOf(message("B"))))
+        assertFalse(CTInboxListViewFragment.isContentIdentical(listOf(a), listOf(message("A", read = true))))
+        assertFalse(CTInboxListViewFragment.isContentIdentical(listOf(a), listOf(message("A", text = "Edited"))))
+        assertFalse(CTInboxListViewFragment.isContentIdentical(listOf(a), listOf(a, message("B"))))
+    }
+
+    @Test
+    fun test_refreshList_builds_list_lazily_and_never_reassigns_the_shared_list() {
+        val fragment = viewReadyFragment()
+        val originalListInstance = fragment.inboxMessages
+        every { fragment.fetchFreshMessages() } returns arrayListOf(message("A"), message("B"))
+
+        fragment.refreshList()
+
+        assertSame(originalListInstance, fragment.inboxMessages)
+        assertEquals(2, fragment.inboxMessages.size)
+        val recycler = fragment.linearLayout.findViewById<RecyclerView>(R.id.list_view_recycler_view)
+        assertEquals(View.VISIBLE, recycler.visibility)
+        assertEquals(2, recycler.adapter?.itemCount)
+        assertEquals(View.GONE, fragment.noMessageView.visibility)
+    }
+
+    @Test
+    fun test_refreshList_with_identical_content_touches_nothing() {
+        val fragment = viewReadyFragment()
+        every { fragment.fetchFreshMessages() } returns arrayListOf(message("A"))
+        fragment.refreshList()
+        val boundMessage = fragment.inboxMessages[0]
+
+        // Identical copy (fresh object, same id/read/content) => no-op, original object kept
+        every { fragment.fetchFreshMessages() } returns arrayListOf(message("A"))
+        fragment.refreshList()
+
+        assertSame(boundMessage, fragment.inboxMessages[0])
+    }
+
+    @Test
+    fun test_refreshList_treats_read_state_only_difference_as_noop() {
+        val fragment = viewReadyFragment()
+        every { fragment.fetchFreshMessages() } returns arrayListOf(message("A"))
+        fragment.refreshList()
+        val boundMessage = fragment.inboxMessages[0]
+        boundMessage.setRead(true) // what the view holder does after 2s on screen
+
+        // Store still says unread (async write hasn't landed) — must not repaint or downgrade
+        every { fragment.fetchFreshMessages() } returns arrayListOf(message("A", read = false))
+        fragment.refreshList()
+
+        assertSame(boundMessage, fragment.inboxMessages[0])
+        assertTrue(fragment.inboxMessages[0].isRead)
+    }
+
+    @Test
+    fun test_refreshList_from_non_empty_to_empty_shows_no_message_view() {
+        val fragment = viewReadyFragment()
+        every { fragment.fetchFreshMessages() } returns arrayListOf(message("A"))
+        fragment.refreshList()
+
+        every { fragment.fetchFreshMessages() } returns arrayListOf()
+        fragment.refreshList()
+
+        assertTrue(fragment.inboxMessages.isEmpty())
+        val recycler = fragment.linearLayout.findViewById<RecyclerView>(R.id.list_view_recycler_view)
+        assertEquals(View.GONE, recycler.visibility)
+        assertEquals(0, recycler.adapter?.itemCount)
+        assertEquals(View.VISIBLE, fragment.noMessageView.visibility)
+    }
+
+    @Test
+    fun test_refreshList_without_view_refreshes_data_only() {
+        val fragment = spyk(CTInboxListViewFragment())
+        every { fragment.activity } returns mockk<FragmentActivity>(relaxed = true)
+        val originalListInstance = fragment.inboxMessages
+        every { fragment.fetchFreshMessages() } returns arrayListOf(message("A"))
+
+        fragment.refreshList() // getView() == null -> data-only branch
+
+        assertSame(originalListInstance, fragment.inboxMessages)
+        assertEquals(1, fragment.inboxMessages.size)
+    }
+
+    @Test
+    fun test_swipe_refresh_success_triggers_refreshList_and_stops_spinner() {
+        mockkStatic(CleverTapAPI::class)
+        try {
+            val api = mockk<CleverTapAPI>(relaxed = true)
+            every { CleverTapAPI.instanceWithConfig(any(), any()) } returns api
+            every { api.isInboxFetchDisabledForSession } returns false
+            val callbackSlot = slot<FetchInboxCallback>()
+            justRun { api.fetchInbox(capture(callbackSlot)) }
+
+            val fragment = viewReadyFragment()
+            every { fragment.requireContext() } returns appCtx
+            every { fragment.isAdded } returns true
+            justRun { fragment.refreshList() }
+
+            val swipeRefreshLayout = SwipeRefreshLayout(appCtx)
+            fragment.wireSwipeToRefresh(swipeRefreshLayout)
+            swipeRefreshLayout.isRefreshing = true
+            onRefreshListenerOf(swipeRefreshLayout).onRefresh()
+
+            callbackSlot.captured.onInboxFetched(true)
+
+            assertFalse(swipeRefreshLayout.isRefreshing)
+            verify(exactly = 1) { fragment.refreshList() }
+        } finally {
+            unmockkStatic(CleverTapAPI::class)
+        }
+    }
+
+    @Test
+    fun test_swipe_refresh_failure_stops_spinner_without_refreshing() {
+        mockkStatic(CleverTapAPI::class)
+        try {
+            val api = mockk<CleverTapAPI>(relaxed = true)
+            every { CleverTapAPI.instanceWithConfig(any(), any()) } returns api
+            every { api.isInboxFetchDisabledForSession } returns false
+            val callbackSlot = slot<FetchInboxCallback>()
+            justRun { api.fetchInbox(capture(callbackSlot)) }
+
+            val fragment = viewReadyFragment()
+            every { fragment.requireContext() } returns appCtx
+            every { fragment.isAdded } returns true
+            justRun { fragment.refreshList() }
+
+            val swipeRefreshLayout = SwipeRefreshLayout(appCtx)
+            fragment.wireSwipeToRefresh(swipeRefreshLayout)
+            swipeRefreshLayout.isRefreshing = true
+            onRefreshListenerOf(swipeRefreshLayout).onRefresh()
+
+            callbackSlot.captured.onInboxFetched(false)
+
+            assertFalse(swipeRefreshLayout.isRefreshing)
+            assertTrue(swipeRefreshLayout.isEnabled)
+            verify(exactly = 0) { fragment.refreshList() }
+        } finally {
+            unmockkStatic(CleverTapAPI::class)
+        }
+    }
+
+    private fun onRefreshListenerOf(layout: SwipeRefreshLayout): SwipeRefreshLayout.OnRefreshListener {
+        val field = SwipeRefreshLayout::class.java.getDeclaredField("mListener")
+        field.isAccessible = true
+        return field.get(layout) as SwipeRefreshLayout.OnRefreshListener
     }
 
     @Test

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragmentTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/CTInboxListViewFragmentTest.kt
@@ -290,8 +290,9 @@ class CTInboxListViewFragmentTest : BaseTestCase() {
         val freshUnreadA = message("A", read = false)
         val freshReadB = message("B", read = true)
 
-        CTInboxListViewFragment.mergeReadStateForward(listOf(oldRead), listOf(freshUnreadA, freshReadB))
+        val upgraded = CTInboxListViewFragment.mergeReadStateForward(listOf(oldRead), listOf(freshUnreadA, freshReadB))
 
+        assertEquals(1, upgraded)
         assertTrue(freshUnreadA.isRead)
         assertTrue(freshReadB.isRead)
     }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/RecordingInboxListFragment.java
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inbox/RecordingInboxListFragment.java
@@ -1,0 +1,30 @@
+package com.clevertap.android.sdk.inbox;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Real fragment (safe to attach through a FragmentManager, unlike a MockK spy)
+ * that records {@link #refreshList()} invocations instead of executing them.
+ */
+public class RecordingInboxListFragment extends CTInboxListViewFragment {
+
+    public int refreshListCalls = 0;
+
+    @Override
+    void refreshList() {
+        refreshListCalls++;
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container,
+            @Nullable Bundle savedInstanceState) {
+        // Headless: the real onCreateView needs styleConfig/config intent extras.
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Pull-to-refresh in the built-in App Inbox fetched and stored new messages correctly, but the visible list never updated — the spinner stopped and the stale list stayed on screen. The auto-refresh wiring was removed in v4.6.6 (SDK-2330) because adapter rebinds broke video playback, and was never replaced. This PR implements the UI refresh explicitly and safely, scoped strictly to the user's pull gesture.

## Changes (one commit per step, each independently shippable)

1. **Stale-position hardening** (`0d9c33a`) — the 2s mark-read timer now skips if its holder was rebound to a different message (crash + wrong-message-attribution vector, reachable even before this feature); `didShow` carries the `CTInboxMessage` instead of a bind-time row index; `didClick` ignores out-of-range positions.
2. **`MediaPlayerRecyclerView.prepareForListRebind()`** (`1826668`) — detaches the shared video surface from its holder *before* an adapter rebind. `stop()` alone leaves an orphaned player view inside a recycled row — the exact SDK-2330 regression class.
3. **`CTInboxListViewFragment.refreshList()`** (`2f9e272`) — on pull success: re-queries the committed store, swaps the shared message list **in place** (the adapter aliases it), forward-merges read state (a just-read message never flips back to unread while its async store write is in flight), skips the repaint entirely when id/read/content are identical (a playing video is never interrupted by a no-change pull), and lazily builds the list UI when a tab that opened empty gets its first messages.
4. **Cross-tab consistency** (`ae56590`) — `CTInboxActivity.refreshAllInboxListFragments()` repaints every resident tab from the same snapshot, so a server-deleted message can't stay tappable in a sibling tab. No listener registration — the customer's `CTInboxListener` slot is untouched, and nothing refreshes without an explicit user pull. Dead `inboxContentUpdatedListener` field (unused since v4.6.6) removed.
5. **QA logs** (`fa1de50`, `e40d182`) — verbose-only logs on every decision point (stale-timer skip, no-op guard, read-merge count, video detach, fan-out count, failure path) so manual testing can verify which path ran from logcat; ids and counts only, no message content.
6. **Empty no-tabs inbox fix** (`c113284`) — no-tabs mode with 0 messages never created the fragment, so an empty inbox had no pull surface at all. The activity now always hosts the fragment, which owns the empty state inside the SwipeRefreshLayout (matches the tabs branch, which never gated on count).

## API / dependency impact

- **Zero public API changes** — every touched class is `@RestrictTo(LIBRARY)`.
- **Zero production dependency changes.** `material` added as `testImplementation` only, so tests can inflate `inbox_activity.xml` (TabLayout).
- No ProGuard/consumer-rules impact.

## Deliberately rejected designs

- **DiffUtil** — holders capture bind-time positions; not rebinding "unchanged" holders makes stale-position bugs worse, and in-place `isRead` mutation corrupts content comparison in both directions.
- **Global `inboxMessagesDidUpdate` listener** (the pre-v4.6.6 design) — mark-read fires it per message → refresh storms and a refresh→rebind→mark-read→refresh feedback loop; background fetches would yank the list while the user reads.

## Testing

- 3,424 unit tests green (`clevertap-core:testDebugUnitTest`), including 21 new tests: in-place-swap invariant, read forward-merge, no-op guard matrix, empty↔non-empty transitions, stale-timer identity guard, swipe callback matrix, tab fan-out, and full-activity launch tests for the empty no-tabs case.
- Manual device checklist (video paths are not unit-testable — please gate on this, both ExoPlayer and Media3 flavors): pull with video playing → list updates and video resumes in the best visible row; pull with nothing new → video keeps playing untouched; pull on an empty inbox/tab → messages appear; server-side delete-all → back to the no-message view; rotation mid-fetch; throttled second pull within 5 min → spinner stops, list unchanged.
- Note: `./gradlew detekt` currently fails on JDK 21 (`Invalid value (21) passed to --jvm-target`) — pre-existing on develop, unrelated to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbox refresh behavior, including empty-state handling and pull-to-refresh updates.
  * Refreshing inbox content now preserves read status and avoids unnecessary UI updates.
  * Updated multi-tab inboxes so all visible lists can refresh together.
  * Prevented delayed read indicators from affecting messages after list items are rebound.
  * Improved video playback stability while inbox content refreshes.
  * Improved inbox handling for empty lists and invalid item selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->