### PR TITLE
feat(accessibility): correct carousel TalkBack behaviour, simplify pa…

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
@@ -57,14 +57,10 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
             }
             dots[position].setImageDrawable(
                     ResourcesCompat.getDrawable(context.getResources(), R.drawable.ct_selected_dot, null));
-            int totalPages = inboxMessage.getInboxMessageContents().size();
-            String imageDesc = getImageContentDescription(context, inboxMessage, position);
-            String announcement = context.getString(R.string.ct_carousel_page_announcement,
-                    imageDesc, position + 1, totalPages);
-            viewHolder.imageViewPager.setContentDescription(
-                    context.getString(R.string.ct_carousel_content_description,
-                            imageDesc, position + 1, totalPages));
-            viewHolder.imageViewPager.announceForAccessibility(announcement);
+            viewHolder.imageViewPager.setAccessibilityState(
+                    getImageContentDescription(context, inboxMessage, position),
+                    position,
+                    inboxMessage.getInboxMessageContents().size());
         }
     }
 
@@ -110,11 +106,14 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
         LinearLayout.LayoutParams layoutParams = (LinearLayout.LayoutParams) this.imageViewPager.getLayoutParams();
         CTCarouselViewPagerAdapter carouselViewPagerAdapter = new CTCarouselViewPagerAdapter(appContext, parent,
                 inboxMessage, layoutParams, position);
+        // Detach the recycled holder's listener BEFORE swapping the adapter. setAdapter() resets
+        // the current item to 0, and that dispatch would otherwise reach a listener still holding
+        // the previous message's data and dots array.
+        if (activePageChangeListener != null) {
+            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
+            activePageChangeListener = null;
+        }
         this.imageViewPager.setAdapter(carouselViewPagerAdapter);
-        int itemCount = inboxMessage.getInboxMessageContents().size();
-        String firstImageDesc = getImageContentDescription(appContext, inboxMessage, 0);
-        this.imageViewPager.setContentDescription(
-                appContext.getString(R.string.ct_carousel_content_description, firstImageDesc, 1, itemCount));
         //Adds the dots for the carousel
         int dotsCount = inboxMessage.getInboxMessageContents().size();
         if (this.sliderDots.getChildCount() > 0) {
@@ -124,15 +123,22 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
         setDots(dots, dotsCount, appContext, this.sliderDots);
         dots[0].setImageDrawable(
                 ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_selected_dot, null));
-        if (activePageChangeListener != null) {
-            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
-        }
         activePageChangeListener = new CTCarouselImageViewHolder.CarouselPageChangeListener(
                 parent.getActivity().getApplicationContext(), this, dots, inboxMessage);
         this.imageViewPager.addOnPageChangeListener(activePageChangeListener);
+        // onPageSelected() never fires for the initial page - ViewPager only dispatches on a
+        // change - so page 0's state must be set explicitly, and last, so nothing triggered by
+        // the adapter swap can overwrite it.
+        this.imageViewPager.setAccessibilityState(
+                getImageContentDescription(appContext, inboxMessage, 0), 0, dotsCount);
 
-        this.clickLayout.setOnClickListener(
-                new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true, APP_INBOX_ITEM_INDEX));
+        CTInboxButtonClickListener bodyClickListener = new CTInboxButtonClickListener(position, inboxMessage, null,
+                parentWeak, this.imageViewPager, true, APP_INBOX_ITEM_INDEX);
+        this.clickLayout.setOnClickListener(bodyClickListener);
+        // The adapter hides each page from the accessibility tree, which also hides the page's
+        // own click listener. Without this a TalkBack user can page through the carousel but
+        // has no way to open the message.
+        this.imageViewPager.setAccessibilityClickAction(bodyClickListener);
 
         markItemAsRead(inboxMessage, position);
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
@@ -65,14 +65,10 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
             viewHolder.message.setText(inboxMessage.getInboxMessageContents().get(position).getMessage());
             viewHolder.message.setTextColor(
                     Color.parseColor(inboxMessage.getInboxMessageContents().get(position).getMessageColor()));
-            int totalPages = inboxMessage.getInboxMessageContents().size();
-            String imageDesc = getImageContentDescription(context, inboxMessage, position);
-            String announcement = context.getString(R.string.ct_carousel_page_announcement,
-                    imageDesc, position + 1, totalPages);
-            viewHolder.imageViewPager.setContentDescription(
-                    context.getString(R.string.ct_carousel_content_description,
-                            imageDesc, position + 1, totalPages));
-            viewHolder.imageViewPager.announceForAccessibility(announcement);
+            viewHolder.imageViewPager.setAccessibilityState(
+                    getImageContentDescription(context, inboxMessage, position),
+                    position,
+                    inboxMessage.getInboxMessageContents().size());
         }
     }
 
@@ -132,11 +128,14 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
         LinearLayout.LayoutParams layoutParams = (LinearLayout.LayoutParams) this.imageViewPager.getLayoutParams();
         CTCarouselViewPagerAdapter carouselViewPagerAdapter = new CTCarouselViewPagerAdapter(appContext, parent,
                 inboxMessage, layoutParams, position);
+        // Detach the recycled holder's listener BEFORE swapping the adapter. setAdapter() resets
+        // the current item to 0, and that dispatch would otherwise reach a listener still holding
+        // the previous message's data and dots array.
+        if (activePageChangeListener != null) {
+            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
+            activePageChangeListener = null;
+        }
         this.imageViewPager.setAdapter(carouselViewPagerAdapter);
-        int itemCount = inboxMessage.getInboxMessageContents().size();
-        String firstImageDesc = getImageContentDescription(appContext, inboxMessage, 0);
-        this.imageViewPager.setContentDescription(
-                appContext.getString(R.string.ct_carousel_content_description, firstImageDesc, 1, itemCount));
         //Adds the dots for the carousel
         int dotsCount = inboxMessage.getInboxMessageContents().size();
         if (this.sliderDots.getChildCount() > 0) {
@@ -146,15 +145,22 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
         setDots(dots, dotsCount, appContext, this.sliderDots);
         dots[0].setImageDrawable(
                 ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_selected_dot, null));
-        if (activePageChangeListener != null) {
-            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
-        }
         activePageChangeListener = new CTCarouselMessageViewHolder.CarouselPageChangeListener(
                 parent.getActivity().getApplicationContext(), this, dots, inboxMessage);
         this.imageViewPager.addOnPageChangeListener(activePageChangeListener);
+        // onPageSelected() never fires for the initial page - ViewPager only dispatches on a
+        // change - so page 0's state must be set explicitly, and last, so nothing triggered by
+        // the adapter swap can overwrite it.
+        this.imageViewPager.setAccessibilityState(
+                getImageContentDescription(appContext, inboxMessage, 0), 0, dotsCount);
 
-        this.clickLayout.setOnClickListener(
-                new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true, APP_INBOX_ITEM_INDEX));
+        CTInboxButtonClickListener bodyClickListener = new CTInboxButtonClickListener(position, inboxMessage, null,
+                parentWeak, this.imageViewPager, true, APP_INBOX_ITEM_INDEX);
+        this.clickLayout.setOnClickListener(bodyClickListener);
+        // The adapter hides each page from the accessibility tree, which also hides the page's
+        // own click listener. Without this a TalkBack user can page through the carousel but
+        // has no way to open the message.
+        this.imageViewPager.setAccessibilityClickAction(bodyClickListener);
 
         markItemAsRead(inboxMessage, position);
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
@@ -1,17 +1,16 @@
 package com.clevertap.android.sdk.inbox;
 
 import android.content.Context;
-import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.View;
-import android.view.accessibility.AccessibilityEvent;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
-import androidx.core.view.AccessibilityDelegateCompat;
 import androidx.core.view.ViewCompat;
-import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat;
 import androidx.viewpager.widget.ViewPager;
+
 import com.clevertap.android.sdk.R;
 
 @RestrictTo(Scope.LIBRARY)
@@ -28,75 +27,69 @@ public class CTCarouselViewPager extends ViewPager {
     }
 
     private void setupAccessibility() {
-        setFocusable(true);
-        setFocusableInTouchMode(true);
+        // YES is load-bearing, not defensive. Under the default AUTO,
+        // View.includeForAccessibility() keeps a view only if it is actionable, has
+        // touch/hover listeners, exposes a node provider, or is a live region. A ViewPager is
+        // none of those - it consumes touch inside onTouchEvent() rather than through a
+        // listener - and contentDescription is NOT part of that test. So under AUTO the pager
+        // is dropped from the tree entirely and TalkBack skips the carousel even when a
+        // contentDescription has been set. This line is what fixes that.
         setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
-        final AccessibilityDelegateCompat originalDelegate = ViewCompat.getAccessibilityDelegate(this);
-        ViewCompat.setAccessibilityDelegate(this, new AccessibilityDelegateCompat() {
-            @Override
-            public void onInitializeAccessibilityNodeInfo(@NonNull View host,
-                    @NonNull AccessibilityNodeInfoCompat info) {
-                if (originalDelegate != null) {
-                    originalDelegate.onInitializeAccessibilityNodeInfo(host, info);
-                } else {
-                    super.onInitializeAccessibilityNodeInfo(host, info);
-                }
-                info.setClassName("android.widget.ScrollView");
-                if (getAdapter() != null && getAdapter().getCount() > 1) {
-                    info.setScrollable(true);
-                    if (getCurrentItem() < getAdapter().getCount() - 1) {
-                        info.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_SCROLL_FORWARD);
-                    }
-                    if (getCurrentItem() > 0) {
-                        info.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_SCROLL_BACKWARD);
-                    }
-                }
-            }
 
-            @Override
-            public void onInitializeAccessibilityEvent(@NonNull View host,
-                    @NonNull AccessibilityEvent event) {
-                if (originalDelegate != null) {
-                    originalDelegate.onInitializeAccessibilityEvent(host, event);
-                } else {
-                    super.onInitializeAccessibilityEvent(host, event);
-                }
-            }
+        // Present the pager as one atomic node instead of letting the reader dive into it.
+        // This is the ViewCompat equivalent of the old setFocusable() pair - and unlike them
+        // it describes screen-reader intent rather than input focus.
+        ViewCompat.setScreenReaderFocusable(this, true);
 
-            @Override
-            public boolean performAccessibilityAction(@NonNull View host, int action, Bundle args) {
-                if (action == AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD) {
-                    if (getAdapter() != null && getCurrentItem() < getAdapter().getCount() - 1) {
-                        setCurrentItem(getCurrentItem() + 1, true);
-                        restoreAccessibilityFocus();
-                        return true;
-                    }
-                } else if (action == AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD) {
-                    if (getCurrentItem() > 0) {
-                        setCurrentItem(getCurrentItem() - 1, true);
-                        restoreAccessibilityFocus();
-                        return true;
-                    }
-                }
-                if (originalDelegate != null) {
-                    return originalDelegate.performAccessibilityAction(host, action, args);
-                }
-                return super.performAccessibilityAction(host, action, args);
-            }
-        });
+        // Stable identity only. The part that changes per page (image alt text + "page x of y")
+        // is published as stateDescription by setAccessibilityState(), which TalkBack announces
+        // on its own - no interruptive announceForAccessibility() needed.
+        setContentDescription(getContext().getString(R.string.ct_carousel_label));
+
+        // Makes the node report isClickable() so TalkBack offers "double-tap to activate" for
+        // the ACTION_CLICK installed by setAccessibilityClickAction(). This does not change
+        // touch behaviour: ViewPager overrides onTouchEvent() without delegating to
+        // View.onTouchEvent(), so performClick() is never reached from a real touch.
+        setClickable(true);
     }
 
-    private void restoreAccessibilityFocus() {
-        postDelayed(() -> {
-            clearFocus();
-            requestFocus();
-            sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
-            ViewCompat.performAccessibilityAction(
-                    CTCarouselViewPager.this,
-                    AccessibilityNodeInfoCompat.ACTION_ACCESSIBILITY_FOCUS,
-                    null
-            );
-        }, 300);
+    /**
+     * Publishes the currently visible page to screen readers as a state change.
+     * <p>
+     * Call this on bind and from {@code OnPageChangeListener.onPageSelected}. Uses
+     * stateDescription rather than contentDescription so TalkBack announces the change itself
+     * and the carousel is not announced twice.
+     *
+     * @param pageDescription description of the current page's content
+     * @param position        zero-based index of the current page
+     * @param total           total number of pages
+     */
+    void setAccessibilityState(@NonNull CharSequence pageDescription, int position, int total) {
+        ViewCompat.setStateDescription(this, getContext().getString(
+                R.string.ct_carousel_position, pageDescription, position + 1, total));
+    }
+
+    /**
+     * Installs an accessibility-only {@code ACTION_CLICK} so a screen-reader user can open the
+     * carousel message.
+     * <p>
+     * Needed because the adapter hides each page from the accessibility tree, which also hides
+     * the per-page {@code OnClickListener}; without this the carousel can be paged through but
+     * never opened. Registered as an accessibility action rather than via
+     * {@code setOnClickListener} because ViewPager consumes the touch stream in
+     * {@code onTouchEvent()} and never calls {@code performClick()}.
+     *
+     * @param listener the same listener used for the row body click
+     */
+    void setAccessibilityClickAction(@NonNull final View.OnClickListener listener) {
+        ViewCompat.replaceAccessibilityAction(
+                this,
+                AccessibilityActionCompat.ACTION_CLICK,
+                getContext().getString(R.string.ct_carousel_open_message),
+                (view, arguments) -> {
+                    listener.onClick(view);
+                    return true;
+                });
     }
 
     @Override

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -9,8 +9,9 @@
     <string name="ct_inbox_image_content_description">Message Image</string>
     <string name="ct_inbox_icon_content_description">Message Icon</string>
     <string name="ct_inbox_unread_indicator_content_description">Unread message</string>
-    <string name="ct_carousel_content_description">Image carousel, %1$s, Page %2$d of %3$d</string>
-    <string name="ct_carousel_page_announcement">%1$s, Page %2$d of %3$d</string>
+    <string name="ct_carousel_label">Image carousel</string>
+    <string name="ct_carousel_position">%1$s, page %2$d of %3$d</string>
+    <string name="ct_carousel_open_message">Open message</string>
     <string name="ct_notification_big_picture_alt_text">Notification Big Picture</string>
     <string name="ct_inapp_close_btn">Close</string>
     <string name="ct_inapp_message_shown">Popup shown</string>


### PR DESCRIPTION
Replace CTCarouselViewPager's hand-rolled AccessibilityDelegateCompat with ViewCompat property APIs; ViewPager's own delegate already handles scroll semantics. Fixes duplicate position announcements, adds a missing ACTION_CLICK so carousel messages can be opened with TalkBack, stops the title being read twice, and makes page 0's description survive holder recycling.