### PR TITLE
bug(SDK-5951): AbstractMethodError

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/internal/renderer/PIPVideoPlayerWrapper.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/internal/renderer/PIPVideoPlayerWrapper.kt
@@ -19,6 +19,7 @@ import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import androidx.media3.ui.PlayerView
+import com.clevertap.android.sdk.video.inbox.Media3PlayerListener
 import kotlin.math.min
 
 /**
@@ -255,7 +256,7 @@ internal class PIPVideoPlayerWrapper {
      *  after network recovery). Without this, controls only update on user tap.
      *  Registered once in [initPlayer] — survives rotation since the player is not recreated. */
     private fun registerPlayingChangedListener(player: ExoPlayer) {
-        val listener = object : Player.Listener {
+        val listener = object : Media3PlayerListener() {
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 onPlayingChanged?.invoke(isPlaying)
             }
@@ -264,11 +265,11 @@ internal class PIPVideoPlayerWrapper {
         player.addListener(listener)
     }
 
-    /** Registers a one-shot [Player.Listener] that fires [onFirstFrame] when the first
+    /** Registers a one-shot [Media3PlayerListener] that fires [onFirstFrame] when the first
      *  video frame is rendered. Used by both [initPlayer] (initial load) and
      *  [rebindSurface] (post-rotation) so [notifyWhenFirstFrame] works in both cases. */
     private fun registerFirstFrameListener(player: ExoPlayer) {
-        player.addListener(object : Player.Listener {
+        player.addListener(object : Media3PlayerListener() {
             override fun onRenderedFirstFrame() {
                 val cb: (() -> Unit)?
                 synchronized(firstFrameLock) {
@@ -283,12 +284,12 @@ internal class PIPVideoPlayerWrapper {
     }
 
     /**
-     * Registers a [Player.Listener] on the underlying player to receive error events.
+     * Registers a [Media3PlayerListener] on the underlying player to receive error events.
      */
     fun setErrorListener(onError: (PlaybackException) -> Unit) {
         val p = player ?: return
         errorListener?.let { p.removeListener(it) }
-        val listener = object : Player.Listener {
+        val listener = object : Media3PlayerListener() {
             override fun onPlayerError(error: PlaybackException) {
                 onError(error)
             }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/Media3PlayerListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/Media3PlayerListener.kt
@@ -1,12 +1,21 @@
 package com.clevertap.android.sdk.video.inbox
 
-import androidx.media3.common.*
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.DeviceInfo
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Metadata
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+import androidx.media3.common.TrackSelectionParameters
+import androidx.media3.common.Tracks
+import androidx.media3.common.VideoSize
 import androidx.media3.common.text.Cue
 import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 
-
-@UnstableApi
 /**
  * This class addresses an AbstractMethodError because of the Java 8 feature of default methods in interfaces.
  * Default methods are somewhat not supported if minSDKVersion < 24
@@ -14,10 +23,11 @@ import androidx.media3.common.util.UnstableApi
 open class Media3PlayerListener : Player.Listener {
     override fun onSurfaceSizeChanged(width: Int, height: Int) {}
     override fun onRenderedFirstFrame() {}
-    @Deprecated("Deprecated in Java")
+
+    @UnstableApi @Deprecated("Deprecated in Java")
     override fun onCues(cues: MutableList<Cue>) {}
     override fun onCues(cueGroup: CueGroup) {}
-    override fun onMetadata(metadata: Metadata) {}
+    @UnstableApi override fun onMetadata(metadata: Metadata) {}
     override fun onEvents(player: Player, events: Player.Events) {}
     override fun onTimelineChanged(timeline: Timeline, reason: Int) {}
     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {}
@@ -25,8 +35,16 @@ open class Media3PlayerListener : Player.Listener {
     override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {}
     override fun onPlaylistMetadataChanged(mediaMetadata: MediaMetadata) {}
     override fun onIsLoadingChanged(isLoading: Boolean) {}
+    @UnstableApi @Deprecated("Deprecated in Java")
+    override fun onLoadingChanged(isLoading: Boolean) {}
+
     override fun onAvailableCommandsChanged(availableCommands: Player.Commands) {}
     override fun onTrackSelectionParametersChanged(parameters: TrackSelectionParameters) {}
+    @UnstableApi @Deprecated("Deprecated in Java")
+    override fun onPlayerStateChanged(playWhenReady: Boolean, playbackState: Int) {}
+
+    override fun onPlaybackStateChanged(playbackState: Int) {}
+
     override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {}
     override fun onPlaybackSuppressionReasonChanged(playbackSuppressionReason: Int) {}
     override fun onIsPlayingChanged(isPlaying: Boolean) {}
@@ -34,6 +52,9 @@ open class Media3PlayerListener : Player.Listener {
     override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {}
     override fun onPlayerError(error: PlaybackException) {}
     override fun onPlayerErrorChanged(error: PlaybackException?) {}
+    @UnstableApi @Deprecated("Deprecated in Java")
+    override fun onPositionDiscontinuity(reason: Int) {}
+
     override fun onPositionDiscontinuity(
         oldPosition: Player.PositionInfo,
         newPosition: Player.PositionInfo,
@@ -43,7 +64,7 @@ open class Media3PlayerListener : Player.Listener {
     override fun onSeekBackIncrementChanged(seekBackIncrementMs: Long) {}
     override fun onSeekForwardIncrementChanged(seekForwardIncrementMs: Long) {}
     override fun onMaxSeekToPreviousPositionChanged(maxSeekToPreviousPositionMs: Long) {}
-    override fun onAudioSessionIdChanged(audioSessionId: Int) {}
+    @UnstableApi override fun onAudioSessionIdChanged(audioSessionId: Int) {}
     override fun onAudioAttributesChanged(audioAttributes: AudioAttributes) {}
     override fun onVolumeChanged(volume: Float) {}
     override fun onSkipSilenceEnabledChanged(skipSilenceEnabled: Boolean) {}


### PR DESCRIPTION
- Solves AbstractMethodError which occurs during PIP playback, in CleverTap's own PIPVideoPlayerWrapper Kotlin class. This occurs due to desugaring and kotlin 'default' keyword.