### PR TITLE
fix(SDK-5955): save inbox messages with UPDATE-then-INSERT instead of SQLite UPSERT

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/db/dao/InboxMessageDAOImpl.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/db/dao/InboxMessageDAOImpl.kt
@@ -1,6 +1,7 @@
 package com.clevertap.android.sdk.db.dao
 
 import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteException
 import androidx.annotation.WorkerThread
 import com.clevertap.android.sdk.ILogger
@@ -73,65 +74,143 @@ internal class InboxMessageDAOImpl(
         return messageDAOArrayList
     }
 
+    /**
+     * Saves a list of inbox messages. A message already in the table is updated; a new one
+     * is inserted.
+     *
+     * ### Why UPDATE-then-INSERT instead of SQLite UPSERT
+     *
+     * The obvious way to write this is SQLite UPSERT:
+     * `INSERT ... ON CONFLICT(messageUser, _id) DO UPDATE SET ...`. We cannot use it.
+     * UPSERT was added in SQLite 3.24.0, and Android does not ship its own SQLite — it uses
+     * the one built into the phone's operating system:
+     *
+     * | API level | Android | SQLite   | UPSERT works? |
+     * |-----------|---------|----------|---------------|
+     * | 23        | 6.0     | 3.8.10.2 | no            |
+     * | 26        | 8.0     | 3.18.2   | no            |
+     * | 28        | 9       | 3.22.0   | no            |
+     * | 29        | 10      | 3.22.0   | no            |
+     * | 30        | 11      | 3.28.0   | yes           |
+     *
+     * Our minSdk is 23, so on Android 6.0 through 10 the phone's SQLite is too old and the
+     * statement fails to compile at all — `near "ON": syntax error`. Watch out for Android
+     * 10: it kept the same SQLite as Android 9, so the cut-off is Android 11, not 10.
+     *
+     * So instead we UPDATE the row for this `(messageUser, _id)` pair, and INSERT only when
+     * the UPDATE found nothing to change. Both are plain SQLite that works everywhere.
+     *
+     * ### Why the read flag and index_state survive correctly
+     *
+     * `index_state` marks whether the server has confirmed a message. A message can be
+     * delivered again later, and when that happens its `index_state` must not be reset —
+     * the cross-device delete sweep would otherwise mistake a valid message for a deleted
+     * one. See [findSweepableV2Ids] and [markIndexed].
+     *
+     * This is why we cannot simply use `insertWithOnConflict(CONFLICT_REPLACE)` either:
+     * REPLACE deletes the old row and inserts a fresh one, wiping `index_state`.
+     *
+     * Our version handles it by construction: `index_state` is not in the UPDATE's column
+     * list at all, so an existing row's value cannot be touched. Only the INSERT sets it.
+     *
+     * Example — the table holds `(_id = m1, messageUser = userA, index_state = INDEXED)`
+     * and message `m1` arrives again for `userA`:
+     * - the UPDATE refreshes the text, read flag and expiry, and leaves `index_state` alone
+     * - so it stays `INDEXED`, which is correct
+     *
+     * ### Why one transaction
+     *
+     * The whole list is written inside a single transaction. That gives two things: the
+     * UPDATE and INSERT for one message cannot be split apart by another process writing
+     * at the same time, and the database commits once for the batch instead of once per
+     * message.
+     */
     @WorkerThread
     override fun upsertMessages(inboxMessages: List<CTMessageDAO>) {
+        if (inboxMessages.isEmpty()) {
+            return
+        }
+
         if (!dbHelper.belowMemThreshold()) {
             logger.verbose(NOT_ENOUGH_SPACE_LOG)
             return
         }
 
-        // SQLite UPSERT — INSERT writes index_state for fresh rows; the
-        // ON CONFLICT clause intentionally omits index_state so an existing
-        // row's state survives upsert. The cross-device delete sweep relies
-        // on this: an /a1 redelivery (or any subsequent upsert) must never
-        // downgrade an INDEXED row back to PENDING_INDEXING. The FETCH path
-        // promotes survivors via a separate markIndexed() call.
-        val sql = """
-            INSERT INTO ${INBOX_MESSAGES.tableName} (
-                ${Column.ID},
-                ${Column.DATA},
-                ${Column.WZRKPARAMS},
-                ${Column.CAMPAIGN},
-                ${Column.TAGS},
-                ${Column.IS_READ},
-                ${Column.EXPIRES},
-                ${Column.CREATED_AT},
-                ${Column.USER_ID},
-                ${Column.SOURCE},
-                ${Column.INDEX_STATE}
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(${Column.USER_ID}, ${Column.ID}) DO UPDATE SET
-                ${Column.DATA} = excluded.${Column.DATA},
-                ${Column.WZRKPARAMS} = excluded.${Column.WZRKPARAMS},
-                ${Column.CAMPAIGN} = excluded.${Column.CAMPAIGN},
-                ${Column.TAGS} = excluded.${Column.TAGS},
-                ${Column.IS_READ} = excluded.${Column.IS_READ},
-                ${Column.EXPIRES} = excluded.${Column.EXPIRES},
-                ${Column.CREATED_AT} = excluded.${Column.CREATED_AT},
-                ${Column.SOURCE} = excluded.${Column.SOURCE}
-        """.trimIndent()
-
         val db = dbHelper.writableDatabase
-        for (messageDAO in inboxMessages) {
+
+        // The outer catch keeps the long-standing contract that this method never throws.
+        // Before this class used a transaction, every write went through execSQL inside a
+        // try/catch, so callers were never given an exception. beginTransaction() and
+        // endTransaction() can both fail (for example when the disk is full or the database
+        // is locked), and CryptMigrator.migrateInboxData calls us during SDK start-up
+        // without any try/catch of its own — so a throw here would break initialisation.
+        try {
+            db.beginTransaction()
             try {
-                val encryptedData = dbEncryptionHandler.wrapDbData(messageDAO.jsonData.toString())
-                val args = arrayOf<Any?>(
-                    messageDAO.id,
-                    encryptedData,
-                    messageDAO.wzrkParams.toString(),
-                    messageDAO.campaignId,
-                    messageDAO.tags,
-                    messageDAO.isRead(),
-                    messageDAO.expires,
-                    messageDAO.date,
-                    messageDAO.userId,
-                    (messageDAO.source ?: InboxMessageSource.V1).name,
-                    messageDAO.indexState ?: InboxIndexState.PENDING_INDEXING
-                )
-                db.execSQL(sql, args)
-            } catch (e: SQLiteException) {
-                logger.verbose("Error adding data to table ${INBOX_MESSAGES.tableName}", e)
+                inboxMessages.forEach { messageDAO -> writeMessage(db, messageDAO) }
+                db.setTransactionSuccessful()
+            } finally {
+                db.endTransaction()
             }
+        } catch (e: SQLiteException) {
+            logger.verbose("Error writing inbox messages to ${INBOX_MESSAGES.tableName}", e)
+        }
+    }
+
+    /**
+     * Saves one message: update the row for this `(messageUser, _id)` pair, or insert it if
+     * there is no such row yet.
+     *
+     * If saving this one message fails we log it and carry on to the next message, rather
+     * than giving up on the whole list. In SQLite a single failed statement does not cancel
+     * the surrounding transaction, so the other messages still get saved. That matches how
+     * this worked before: one bad message costs you that message, not the whole batch.
+     */
+    @WorkerThread
+    private fun writeMessage(db: SQLiteDatabase, messageDAO: CTMessageDAO) {
+        val tName = INBOX_MESSAGES.tableName
+
+        // The columns a repeat delivery is allowed to overwrite.
+        //
+        // index_state is deliberately missing: leaving it out of the UPDATE is what stops an
+        // already-confirmed message being reset back to unconfirmed. _id and messageUser are
+        // missing because they identify the row — they go in the WHERE clause below, and are
+        // only written when we insert a brand-new row.
+        val mutableColumns = ContentValues().apply {
+            put(Column.DATA, dbEncryptionHandler.wrapDbData(messageDAO.jsonData.toString()))
+            put(Column.WZRKPARAMS, messageDAO.wzrkParams.toString())
+            put(Column.CAMPAIGN, messageDAO.campaignId)
+            put(Column.TAGS, messageDAO.tags)
+            put(Column.IS_READ, messageDAO.isRead())
+            put(Column.EXPIRES, messageDAO.expires)
+            put(Column.CREATED_AT, messageDAO.date)
+            put(Column.SOURCE, (messageDAO.source ?: InboxMessageSource.V1).name)
+        }
+
+        try {
+            val updated = db.update(
+                tName,
+                mutableColumns,
+                "${Column.USER_ID} = ? AND ${Column.ID} = ?",
+                arrayOf(messageDAO.userId, messageDAO.id)
+            )
+            // updated > 0 means a row already existed and we just refreshed it, so there is
+            // nothing left to do.
+            if (updated > 0) {
+                return
+            }
+
+            // We get here only when the UPDATE matched no rows, i.e. this message is new to
+            // this user. Add the two identifying columns, plus index_state — the insert is
+            // the only place index_state is ever written.
+            val insertColumns = ContentValues(mutableColumns).apply {
+                put(Column.ID, messageDAO.id)
+                put(Column.USER_ID, messageDAO.userId)
+                put(Column.INDEX_STATE, messageDAO.indexState ?: InboxIndexState.PENDING_INDEXING)
+            }
+            db.insert(tName, null, insertColumns)
+        } catch (e: SQLiteException) {
+            logger.verbose("Error adding data to table $tName", e)
         }
     }
 

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/db/dao/InboxMessageDAOImplTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/db/dao/InboxMessageDAOImplTest.kt
@@ -251,6 +251,101 @@ class InboxMessageDAOImplTest : BaseTestCase() {
     }
 
     @Test
+    fun `upsert does not depend on the userid_id_idx unique index`() {
+        // "userid_id_idx" is a rule on the table: no two rows may share the same
+        // (messageUser, _id) pair.
+        //
+        // The old code wrote messages with:
+        //     INSERT ... ON CONFLICT(messageUser, _id) DO UPDATE SET ...
+        // SQLite can only spot a "conflict" if such a uniqueness rule exists. With no
+        // rule there is nothing to compare against, so SQLite refuses to run the
+        // statement at all and every inbox write fails.
+        //
+        // The new code does UPDATE ... WHERE messageUser = ? AND _id = ?, then INSERT
+        // only if the UPDATE changed nothing. Searching needs no uniqueness rule. Without
+        // the index SQLite just checks rows one by one — slower, but it still works.
+        //
+        // Example. Table holds (_id = m1, messageUser = user_11, isRead = 0), and m1
+        // arrives again marked read:
+        //     old code, no index -> statement fails, isRead stays 0, message lost
+        //     new code, no index -> UPDATE finds the row, isRead becomes 1
+        //
+        // Every shipped version does create this index, so this cannot happen today. We
+        // test it anyway for two reasons. First, saving a message must not secretly
+        // depend on a rule defined in a different file — if a future migration ever
+        // forgot it, every inbox write would break on every device. Second, this is the
+        // only way to make the old code fail in a unit test: the real bug is that
+        // ON CONFLICT needs SQLite 3.24.0 (Android 11+), but Robolectric always supplies
+        // a modern SQLite, so the version problem cannot be reproduced here. A missing
+        // index breaks the old code on every SQLite version, so it guards the same line.
+        dbHelper.writableDatabase.execSQL("DROP INDEX IF EXISTS userid_id_idx;")
+
+        val userId = "user_11"
+        inboxMessageDAO.upsertMessages(listOf(getCtMsgDao("m1", userId, read = false)))
+        inboxMessageDAO.upsertMessages(listOf(getCtMsgDao("m1", userId, read = true)))
+
+        val messages = inboxMessageDAO.getMessages(userId)
+        assertEquals(1, messages.size)
+        assertEquals(1, messages.single().isRead)
+    }
+
+    @Test
+    fun `upsert writes every message in a batch`() {
+        val userId = "user_11"
+        inboxMessageDAO.upsertMessages(
+            listOf(getCtMsgDao("m1", userId), getCtMsgDao("m2", userId), getCtMsgDao("m3", userId))
+        )
+        assertEquals(3, inboxMessageDAO.getMessages(userId).size)
+    }
+
+    @Test
+    fun `upsert with an empty list is a no-op`() {
+        inboxMessageDAO.upsertMessages(emptyList())
+        assertEquals(0, inboxMessageDAO.getMessages("user_11").size)
+    }
+
+    @Test
+    fun `upsert never throws even when the table is missing`() {
+        // upsertMessages must never throw. Before it used a transaction, every write went
+        // through execSQL inside a try/catch, so callers never saw an exception.
+        // CryptMigrator.migrateInboxData calls this during SDK start-up with no try/catch of
+        // its own, so a throw here would break initialisation on that path.
+        dbHelper.writableDatabase.execSQL("DROP TABLE IF EXISTS ${Table.INBOX_MESSAGES.tableName};")
+
+        // Must return normally, not throw.
+        inboxMessageDAO.upsertMessages(listOf(getCtMsgDao("m1", "user_11")))
+    }
+
+    @Test
+    fun `upsert saves the good messages in a batch even when one message is bad`() {
+        // A single failing statement does not cancel the surrounding SQLite transaction, so
+        // one unwritable message must cost only that message - not the whole batch.
+        // campaignId is NOT NULL in the schema, so a null value makes just that row fail.
+        val userId = "user_11"
+        val bad = getCtMsgDao("m2", userId).also { it.campaignId = null }
+
+        inboxMessageDAO.upsertMessages(
+            listOf(getCtMsgDao("m1", userId), bad, getCtMsgDao("m3", userId))
+        )
+
+        val savedIds = inboxMessageDAO.getMessages(userId).map { it.id }.toSet()
+        assertEquals(setOf("m1", "m3"), savedIds)
+    }
+
+    @Test
+    fun `upsert updates a row scoped to its own userId only`() {
+        // The UPDATE keys on (messageUser, _id), so the same message id under a
+        // different user must be an independent row.
+        inboxMessageDAO.upsertMessages(listOf(getCtMsgDao("m1", "user_11", read = false)))
+        inboxMessageDAO.upsertMessages(listOf(getCtMsgDao("m1", "user_22", read = true)))
+
+        assertEquals(1, inboxMessageDAO.getMessages("user_11").size)
+        assertEquals(0, inboxMessageDAO.getMessages("user_11").single().isRead)
+        assertEquals(1, inboxMessageDAO.getMessages("user_22").size)
+        assertEquals(1, inboxMessageDAO.getMessages("user_22").single().isRead)
+    }
+
+    @Test
     fun `markIndexed flips supplied PENDING_INDEXING rows to INDEXED`() {
         val userId = "user_11"
         inboxMessageDAO.upsertMessages(


### PR DESCRIPTION
## What was broken

**App Inbox messages were never saved on Android 6.0 through Android 10.** The inbox just looked permanently empty on those phones.

`InboxMessageDAOImpl.upsertMessages` saved messages using SQLite UPSERT:

```sql
INSERT ... ON CONFLICT(messageUser, _id) DO UPDATE SET ...
```

UPSERT was added in SQLite 3.24.0. Android does not ship its own SQLite — it uses the one built into the phone's operating system:

| API level | Android | SQLite | UPSERT works? |
|---|---|---|---|
| 23 | 6.0 | 3.8.10.2 | no |
| 24 / 25 | 7.x | 3.9.2 | no |
| 26 | 8.0 | 3.18.2 | no |
| 27 | 8.1 | 3.19.4 | no |
| 28 | 9 | 3.22.0 | no |
| **29** | **10** | **3.22.0** | **no** |
| 30 | 11 | 3.28.0 | yes |
| 31+ | 12+ | 3.32.2+ | yes |

`minSdk` is 23, so on Android 6.0–10 the statement could not even compile:

```
SQLiteException: near "ON": syntax error (code 1)
  at InboxMessageDAOImpl.upsertMessages(InboxMessageDAOImpl.kt:131)
  at CTInboxController.processV2Response(CTInboxController.java:394)
```

**Note the Android 10 row.** Android 10 kept the same SQLite as Android 9, so the cut-off is Android 11, not Android 10. Every version above was read from the `SQLITE_VERSION` define in `platform/external/sqlite/dist/sqlite3.h` at the matching AOSP release tag — developer.android.com no longer publishes this table, and the community copies still in circulation stop at API 27.

Shipped in **corev8.2.0** (2026-05-20) and **corev8.3.0** (2026-06-04). Introduced by `97776beec` ("Release 8.2.0 - Inbox v2 sync", #1008).

## It affected more than Inbox V2

Three callers share this one method:

| Caller | Path |
|---|---|
| `CTInboxController.updateMessages:281` | **classic V1 App Inbox**, via `/a1` |
| `CTInboxController.processV2Response:394` | Inbox V2 |
| `CryptMigrator.migrateInboxData:134` | encryption migration |

So App Inbox was non-functional on Android 6.0–10 for **every** customer on 8.2.0 or later, whether or not they adopted V2.

## The fix

UPDATE the row for this `(messageUser, _id)` pair, and INSERT only when the UPDATE changed nothing. Both are plain SQLite that works on every version. Uses only the framework `update()` and `insert()` helpers, so no raw SQL remains in the method.

The whole list is written in one transaction, so a message's UPDATE and INSERT cannot be split apart by another process, and the database commits once for the batch instead of once per message.

### Why not branch on `Build.VERSION.SDK_INT`

`SDK_INT` tells you the Android version, not which SQLite the phone actually has, and custom ROMs are not obliged to match. It would also double the number of code paths to test and leave copy-pasteable UPSERT in the tree. Since `minSdk` is 23, the right posture is a single dialect ceiling of SQLite 3.8.10.2 with no escape hatch.

## No database version bump

`DATABASE_VERSION` stays **7**, and `CtDatabase.kt` is untouched. The columns written are byte-for-byte identical (verified by extracting the column sets from both versions):

```
OLD: CAMPAIGN CREATED_AT DATA EXPIRES ID INDEX_STATE IS_READ SOURCE TAGS USER_ID WZRKPARAMS
NEW: CAMPAIGN CREATED_AT DATA EXPIRES ID INDEX_STATE IS_READ SOURCE TAGS USER_ID WZRKPARAMS
```

Only the statement changed, not the table. 

**Broken installs also recover on their own.** The fetch request carries no `since` cursor, so the server always returns the full inbox. Update the app, open the inbox, and every message is rewritten. No migration or user action needed.

## Tests

**30 tests in `InboxMessageDAOImplTest`, 0 failures.** The original 24 pass **unmodified**, including `upsert preserves indexState on UPDATE — never downgrades INDEXED`.

6 new cases. The key one drops `userid_id_idx` and checks the message is still saved — it **fails on the old code** (`Expected <1>, actual <0>`, i.e. nothing was written) and passes now. Also covers batch writes, empty list, per-user scoping, never-throws, and one bad message not costing the whole batch.

Full suite green (3408 tests), `assembleRelease` green, detekt no new findings.

### Honest limitation

**No unit test can reproduce the original bug.** Robolectric links its own SQLite and reports **3.28.0** — the Android 11 build — even under `@Config(sdk = [VERSION_CODES.P])`, which claims API 28. A real API 28 or 29 device reports 3.22.0. That gap is exactly why this shipped with five green tests covering the broken statement. Real-device coverage across API 23/26/29/30 is filed as follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inbox message saving and updating across batches.
  - Ensured messages remain correctly separated between users.
  - Preserved valid messages when one message cannot be saved.
  - Upserting now works reliably without relying on a database index.
  - Empty updates complete safely without errors.

- **Tests**
  - Added coverage for partial failures, missing storage, batch updates, and user-specific message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->