### PR TITLE
Release Core 8.4.0 and PT 2.5.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 ## CHANGE LOG.
+### July 28, 2026
+* [CleverTap Android SDK v8.4.0](docs/CTCORECHANGELOG.md).
+* [CleverTap Push Templates SDK v2.5.0](docs/CTPUSHTEMPLATESCHANGELOG.md).
 
 ### June 2026
+> ⚠️ **NOTE**
+8.3.0 does not save App Inbox messages on Android 6.0 – 10, please update to 8.4.0 and above.
+
 * [CleverTap Android SDK v8.3.0](docs/CTCORECHANGELOG.md).
 
 ### May 20, 2026
+> ⚠️ **NOTE**
+8.2.0 does not save App Inbox messages on Android 6.0 – 10, please update to 8.4.0 and above.
+
 * [CleverTap Android SDK v8.2.0](docs/CTCORECHANGELOG.md).
 
 ### April 17, 2026

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We publish the SDK to `mavenCentral` as an `AAR` file. Just declare it as depend
 
 ```groovy
     dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:8.3.0"
+         implementation "com.clevertap.android:clevertap-android-sdk:8.4.0"
     }
 ```
 
@@ -34,7 +34,7 @@ Alternatively, you can download and add the AAR file included in this repo in yo
     
  ```groovy
     dependencies {      
-        implementation (name: "clevertap-android-sdk-8.3.0", ext: 'aar')
+        implementation (name: "clevertap-android-sdk-8.4.0", ext: 'aar')
     }
 ```
 
@@ -46,7 +46,7 @@ Add the Firebase Messaging library and Android Support Library v4 as dependencie
 
 ```groovy
      dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:8.3.0"
+         implementation "com.clevertap.android:clevertap-android-sdk:8.4.0"
          implementation "androidx.core:core:1.13.0"
          implementation "com.google.firebase:firebase-messaging:24.0.0"
          implementation "com.google.android.gms:play-services-ads:23.6.0" // Required only if you enable Google ADID collection in the SDK (turned off by default).

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
@@ -454,7 +454,11 @@ public class AnalyticsManager extends BaseAnalyticsManager {
                 for (String x : customData.keySet()) {
 
                     Object value = customData.get(x);
-                    if (value != null) {
+                    if (value instanceof Map) {
+                        // Nested payloads (e.g. wzrk_data for a key-values action) are carried as a
+                        // Map and emitted as a nested JSON object.
+                        notif.put(x, new JSONObject((Map<?, ?>) value));
+                    } else if (value != null) {
                         notif.put(x, value);
                     }
                 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTWebInterface.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTWebInterface.java
@@ -423,8 +423,9 @@ public class CTWebInterface {
             }
 
             Bundle actionData = new Bundle();
+            // Element identity flows only through wzrk_element_id; button_id is no longer emitted.
             if (buttonId != null) {
-                actionData.putString("button_id", buttonId);
+                actionData.putString(Constants.KEY_WZRK_ELEMENT_ID, buttonId);
             }
 
             fragment.triggerAction(action, callToAction, actionData);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
@@ -508,6 +508,7 @@ internal object CleverTapFactory {
             SYSTEM,
             networkMonitor,
             pipManager,
+            validationResultStack,
         )
         controllerManager.inAppController = inAppController
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -118,7 +118,7 @@ public interface Constants {
     String INAPP_KEY = "inApp";
     String INAPP_WZRK_PIVOT = "wzrk_pivot";
     String INAPP_WZRK_CGID = "wzrk_cgId";
-    int INAPP_CLOSE_IV_WIDTH = 40;
+    int INAPP_CLOSE_IV_WIDTH = 48;
     String INAPP_JS_ENABLED = "isJsEnabled";
     String NOTIFICATION_ID_TAG = "wzrk_id";
     String DEEP_LINK_KEY = "wzrk_dl";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -172,6 +172,37 @@ public interface Constants {
     String IMAGE_PLACEHOLDER = "ct_image";
     String KEY_CONFIG = "config";
     String KEY_C2A = "wzrk_c2a";
+
+    // Split-of-clicks: per-element identity + action descriptors (must match iOS wire contract)
+    String KEY_WZRK_ELEMENT_ID = "wzrk_element_id";
+    String KEY_WZRK_ACTION = "wzrk_action";
+    String KEY_WZRK_DATA = "wzrk_data";
+
+    // key for parsing
+    String KEY_SWIPE_TO_DISMISS = "swipe-dismiss";
+
+    // wzrk_element_id values
+    String INAPP_ELEMENT_ID_IMAGE = "image-1";
+    String INAPP_ELEMENT_ID_CLOSE = "closeButton";
+    String INAPP_ELEMENT_ID_BUTTON_PREFIX = "button-";
+
+    // wzrk_c2a values for dismiss gestures
+    String INAPP_CTA_DISMISS_BUTTON = "Dismiss Button";
+    String INAPP_CTA_SWIPE_DISMISS = "Swipe to Dismiss";
+
+    // wzrk_data literal value for a close action
+    String INAPP_WZRK_DATA_CLOSE = "close";
+
+    // Media-error synthetic-close descriptors emitted by the bundled advanced-builder HTML template
+    String INAPP_CTA_IMAGE_ERROR_DISMISS = "image-error-dismiss";
+    String INAPP_CTA_VIDEO_ERROR_DISMISS = "video-error-dismiss";
+
+    // wzrk_error codes/messages for media preload failures.
+    int INAPP_IMAGE_LOAD_FAILED_ERROR_CODE = 591;
+    int INAPP_VIDEO_LOAD_FAILED_ERROR_CODE = 592;
+    String INAPP_IMAGE_LOAD_FAILED_ERROR_MSG = "InApp image failed to load";
+    String INAPP_VIDEO_LOAD_FAILED_ERROR_MSG = "InApp video failed to load";
+
     String KEY_EFC = "efc";
     String KEY_EXCLUDE_GLOBAL_CAPS = "excludeGlobalFCaps";
     String KEY_TLC = "tlc";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -186,6 +186,8 @@ public interface Constants {
     String INAPP_ELEMENT_ID_IMAGE = "image-1";
     String INAPP_ELEMENT_ID_CLOSE = "closeButton";
     String INAPP_ELEMENT_ID_BUTTON_PREFIX = "button-";
+    // PIP exposes a single CTA button; its element id is a fixed literal
+    String INAPP_ELEMENT_ID_PIP_CTA = "button-cta";
 
     // wzrk_c2a values for dismiss gestures
     String INAPP_CTA_DISMISS_BUTTON = "Dismiss Button";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -118,7 +118,8 @@ public interface Constants {
     String INAPP_KEY = "inApp";
     String INAPP_WZRK_PIVOT = "wzrk_pivot";
     String INAPP_WZRK_CGID = "wzrk_cgId";
-    int INAPP_CLOSE_IV_WIDTH = 48;
+    int INAPP_CLOSE_IV_WIDTH = 40;
+    int INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH = 48;
     String INAPP_JS_ENABLED = "isJsEnabled";
     String NOTIFICATION_ID_TAG = "wzrk_id";
     String DEEP_LINK_KEY = "wzrk_dl";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/InAppNotificationActivity.java
@@ -209,10 +209,11 @@ public final class InAppNotificationActivity extends FragmentActivity implements
     public Bundle inAppNotificationDidClick(
             @NonNull final CTInAppNotification inAppNotification,
             @NonNull final CTInAppNotificationButton button,
+            final int buttonIndex,
             @Nullable final Context activityContext) {
         InAppListener listener = getListener();
         if (listener != null) {
-            return listener.inAppNotificationDidClick(inAppNotification, button, this);
+            return listener.inAppNotificationDidClick(inAppNotification, button, buttonIndex, this);
         } else {
             return null;
         }
@@ -332,10 +333,10 @@ public final class InAppNotificationActivity extends FragmentActivity implements
     }
 
     @Nullable
-    private Bundle didClick(CTInAppNotificationButton button) {
+    private Bundle didClick(CTInAppNotificationButton button, int buttonIndex) {
         InAppListener listener = getListener();
         if (listener != null) {
-            return listener.inAppNotificationDidClick(inAppNotification, button, this);
+            return listener.inAppNotificationDidClick(inAppNotification, button, buttonIndex, this);
         } else {
             return null;
         }
@@ -414,14 +415,14 @@ public final class InAppNotificationActivity extends FragmentActivity implements
                     .setTitle(inAppNotification.getTitle())
                     .setMessage(inAppNotification.getMessage())
                     .setPositiveButton(positiveButton.getText(),
-                            (dialogInterface, i) -> onAlertButtonClick(positiveButton, true))
+                            (dialogInterface, i) -> onAlertButtonClick(positiveButton, 0, true))
                     .create();
 
             if (inAppNotification.getButtons().size() == 2) {
                 CTInAppNotificationButton negativeButton = buttons.get(1);
                 alertDialog.setButton(DialogInterface.BUTTON_NEGATIVE,
                         negativeButton.getText(),
-                        (dialog, which) -> onAlertButtonClick(negativeButton, false));
+                        (dialog, which) -> onAlertButtonClick(negativeButton, 1, false));
             }
 
         //By default, we will allow 2 button alerts and set a third button if it is configured
@@ -429,7 +430,7 @@ public final class InAppNotificationActivity extends FragmentActivity implements
             CTInAppNotificationButton button = buttons.get(2);
             alertDialog.setButton(DialogInterface.BUTTON_NEUTRAL,
                     button.getText(),
-                    (dialogInterface, i) -> onAlertButtonClickLegacy(button));
+                    (dialogInterface, i) -> onAlertButtonClickLegacy(button, 2));
         }
 
         alertDialog.show();
@@ -437,13 +438,13 @@ public final class InAppNotificationActivity extends FragmentActivity implements
         didShow(null);
     }
 
-    private void onAlertButtonClickLegacy(final CTInAppNotificationButton button) {
-        Bundle clickData = didClick(button);
+    private void onAlertButtonClickLegacy(final CTInAppNotificationButton button, int buttonIndex) {
+        Bundle clickData = didClick(button, buttonIndex);
         didDismiss(clickData);
     }
 
-    private void onAlertButtonClick(CTInAppNotificationButton button, boolean isPositive) {
-        Bundle clickData = didClick(button);
+    private void onAlertButtonClick(CTInAppNotificationButton button, int buttonIndex, boolean isPositive) {
+        Bundle clickData = didClick(button, buttonIndex);
 
         if (inAppNotification.isLocalInApp()) {
             if(isPositive) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
@@ -8,9 +8,11 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.util.AttributeSet;
 import android.util.TypedValue;
+import android.view.View;
 import androidx.appcompat.widget.AppCompatImageView;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.Logger;
+import com.clevertap.android.sdk.R;
 
 /**
  * Represents the close button.
@@ -24,18 +26,26 @@ public final class CloseImageView extends AppCompatImageView {
     public CloseImageView(Context context) {
         super(context);
         setId(VIEW_ID);
+        initAccessibility(context);
     }
 
     @SuppressLint("ResourceType")
     public CloseImageView(Context context, AttributeSet attrs) {
         super(context, attrs);
         setId(VIEW_ID);
+        initAccessibility(context);
     }
 
     @SuppressLint("ResourceType")
     public CloseImageView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         setId(VIEW_ID);
+        initAccessibility(context);
+    }
+
+    private void initAccessibility(Context context) {
+        setContentDescription(context.getString(R.string.ct_inapp_close_btn));
+        setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
     }
 
     @SuppressLint("DrawAllocation")

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
@@ -20,7 +20,8 @@ import com.clevertap.android.sdk.R;
 public final class CloseImageView extends AppCompatImageView {
 
     public static final int VIEW_ID = 199272;
-    private final int canvasSize = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH);
+    private final int iconSize = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH);
+    private final int touchTargetSize = getScaledPixels(Constants.INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH);
 
     @SuppressLint("ResourceType")
     public CloseImageView(Context context) {
@@ -60,8 +61,9 @@ public final class CloseImageView extends AppCompatImageView {
 
             if (closeBitmap != null) {
                 Bitmap scaledCloseBitmap = Bitmap.createScaledBitmap(closeBitmap,
-                        canvasSize, canvasSize, true);
-                canvas.drawBitmap(scaledCloseBitmap, 0, 0, new Paint());
+                        iconSize, iconSize, true);
+                float offset = (touchTargetSize - iconSize) / 2f;
+                canvas.drawBitmap(scaledCloseBitmap, offset, offset, new Paint());
             } else {
                 Logger.v("Unable to find inapp notif close button image");
             }
@@ -73,7 +75,7 @@ public final class CloseImageView extends AppCompatImageView {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         // The image view is fixed in dip on all devices
-        setMeasuredDimension(canvasSize, canvasSize);
+        setMeasuredDimension(touchTargetSize, touchTargetSize);
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/customviews/CloseImageView.java
@@ -56,8 +56,8 @@ public final class CloseImageView extends AppCompatImageView {
         try {
 
             Context context = getContext();
-            int resourceID = context.getResources().getIdentifier("ct_close", "drawable", context.getPackageName());
-            Bitmap closeBitmap = BitmapFactory.decodeResource(context.getResources(), resourceID, null);
+            // Static R reference (instead of getIdentifier) so R8 resource shrinking cannot strip ct_close
+            Bitmap closeBitmap = BitmapFactory.decodeResource(context.getResources(), R.drawable.ct_close, null);
 
             if (closeBitmap != null) {
                 Bitmap scaledCloseBitmap = Bitmap.createScaledBitmap(closeBitmap,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/db/dao/InboxMessageDAOImpl.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/db/dao/InboxMessageDAOImpl.kt
@@ -1,6 +1,7 @@
 package com.clevertap.android.sdk.db.dao
 
 import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteException
 import androidx.annotation.WorkerThread
 import com.clevertap.android.sdk.ILogger
@@ -73,65 +74,143 @@ internal class InboxMessageDAOImpl(
         return messageDAOArrayList
     }
 
+    /**
+     * Saves a list of inbox messages. A message already in the table is updated; a new one
+     * is inserted.
+     *
+     * ### Why UPDATE-then-INSERT instead of SQLite UPSERT
+     *
+     * The obvious way to write this is SQLite UPSERT:
+     * `INSERT ... ON CONFLICT(messageUser, _id) DO UPDATE SET ...`. We cannot use it.
+     * UPSERT was added in SQLite 3.24.0, and Android does not ship its own SQLite — it uses
+     * the one built into the phone's operating system:
+     *
+     * | API level | Android | SQLite   | UPSERT works? |
+     * |-----------|---------|----------|---------------|
+     * | 23        | 6.0     | 3.8.10.2 | no            |
+     * | 26        | 8.0     | 3.18.2   | no            |
+     * | 28        | 9       | 3.22.0   | no            |
+     * | 29        | 10      | 3.22.0   | no            |
+     * | 30        | 11      | 3.28.0   | yes           |
+     *
+     * Our minSdk is 23, so on Android 6.0 through 10 the phone's SQLite is too old and the
+     * statement fails to compile at all — `near "ON": syntax error`. Watch out for Android
+     * 10: it kept the same SQLite as Android 9, so the cut-off is Android 11, not 10.
+     *
+     * So instead we UPDATE the row for this `(messageUser, _id)` pair, and INSERT only when
+     * the UPDATE found nothing to change. Both are plain SQLite that works everywhere.
+     *
+     * ### Why the read flag and index_state survive correctly
+     *
+     * `index_state` marks whether the server has confirmed a message. A message can be
+     * delivered again later, and when that happens its `index_state` must not be reset —
+     * the cross-device delete sweep would otherwise mistake a valid message for a deleted
+     * one. See [findSweepableV2Ids] and [markIndexed].
+     *
+     * This is why we cannot simply use `insertWithOnConflict(CONFLICT_REPLACE)` either:
+     * REPLACE deletes the old row and inserts a fresh one, wiping `index_state`.
+     *
+     * Our version handles it by construction: `index_state` is not in the UPDATE's column
+     * list at all, so an existing row's value cannot be touched. Only the INSERT sets it.
+     *
+     * Example — the table holds `(_id = m1, messageUser = userA, index_state = INDEXED)`
+     * and message `m1` arrives again for `userA`:
+     * - the UPDATE refreshes the text, read flag and expiry, and leaves `index_state` alone
+     * - so it stays `INDEXED`, which is correct
+     *
+     * ### Why one transaction
+     *
+     * The whole list is written inside a single transaction. That gives two things: the
+     * UPDATE and INSERT for one message cannot be split apart by another process writing
+     * at the same time, and the database commits once for the batch instead of once per
+     * message.
+     */
     @WorkerThread
     override fun upsertMessages(inboxMessages: List<CTMessageDAO>) {
+        if (inboxMessages.isEmpty()) {
+            return
+        }
+
         if (!dbHelper.belowMemThreshold()) {
             logger.verbose(NOT_ENOUGH_SPACE_LOG)
             return
         }
 
-        // SQLite UPSERT — INSERT writes index_state for fresh rows; the
-        // ON CONFLICT clause intentionally omits index_state so an existing
-        // row's state survives upsert. The cross-device delete sweep relies
-        // on this: an /a1 redelivery (or any subsequent upsert) must never
-        // downgrade an INDEXED row back to PENDING_INDEXING. The FETCH path
-        // promotes survivors via a separate markIndexed() call.
-        val sql = """
-            INSERT INTO ${INBOX_MESSAGES.tableName} (
-                ${Column.ID},
-                ${Column.DATA},
-                ${Column.WZRKPARAMS},
-                ${Column.CAMPAIGN},
-                ${Column.TAGS},
-                ${Column.IS_READ},
-                ${Column.EXPIRES},
-                ${Column.CREATED_AT},
-                ${Column.USER_ID},
-                ${Column.SOURCE},
-                ${Column.INDEX_STATE}
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(${Column.USER_ID}, ${Column.ID}) DO UPDATE SET
-                ${Column.DATA} = excluded.${Column.DATA},
-                ${Column.WZRKPARAMS} = excluded.${Column.WZRKPARAMS},
-                ${Column.CAMPAIGN} = excluded.${Column.CAMPAIGN},
-                ${Column.TAGS} = excluded.${Column.TAGS},
-                ${Column.IS_READ} = excluded.${Column.IS_READ},
-                ${Column.EXPIRES} = excluded.${Column.EXPIRES},
-                ${Column.CREATED_AT} = excluded.${Column.CREATED_AT},
-                ${Column.SOURCE} = excluded.${Column.SOURCE}
-        """.trimIndent()
-
         val db = dbHelper.writableDatabase
-        for (messageDAO in inboxMessages) {
+
+        // The outer catch keeps the long-standing contract that this method never throws.
+        // Before this class used a transaction, every write went through execSQL inside a
+        // try/catch, so callers were never given an exception. beginTransaction() and
+        // endTransaction() can both fail (for example when the disk is full or the database
+        // is locked), and CryptMigrator.migrateInboxData calls us during SDK start-up
+        // without any try/catch of its own — so a throw here would break initialisation.
+        try {
+            db.beginTransaction()
             try {
-                val encryptedData = dbEncryptionHandler.wrapDbData(messageDAO.jsonData.toString())
-                val args = arrayOf<Any?>(
-                    messageDAO.id,
-                    encryptedData,
-                    messageDAO.wzrkParams.toString(),
-                    messageDAO.campaignId,
-                    messageDAO.tags,
-                    messageDAO.isRead(),
-                    messageDAO.expires,
-                    messageDAO.date,
-                    messageDAO.userId,
-                    (messageDAO.source ?: InboxMessageSource.V1).name,
-                    messageDAO.indexState ?: InboxIndexState.PENDING_INDEXING
-                )
-                db.execSQL(sql, args)
-            } catch (e: SQLiteException) {
-                logger.verbose("Error adding data to table ${INBOX_MESSAGES.tableName}", e)
+                inboxMessages.forEach { messageDAO -> writeMessage(db, messageDAO) }
+                db.setTransactionSuccessful()
+            } finally {
+                db.endTransaction()
             }
+        } catch (e: SQLiteException) {
+            logger.verbose("Error writing inbox messages to ${INBOX_MESSAGES.tableName}", e)
+        }
+    }
+
+    /**
+     * Saves one message: update the row for this `(messageUser, _id)` pair, or insert it if
+     * there is no such row yet.
+     *
+     * If saving this one message fails we log it and carry on to the next message, rather
+     * than giving up on the whole list. In SQLite a single failed statement does not cancel
+     * the surrounding transaction, so the other messages still get saved. That matches how
+     * this worked before: one bad message costs you that message, not the whole batch.
+     */
+    @WorkerThread
+    private fun writeMessage(db: SQLiteDatabase, messageDAO: CTMessageDAO) {
+        val tName = INBOX_MESSAGES.tableName
+
+        // The columns a repeat delivery is allowed to overwrite.
+        //
+        // index_state is deliberately missing: leaving it out of the UPDATE is what stops an
+        // already-confirmed message being reset back to unconfirmed. _id and messageUser are
+        // missing because they identify the row — they go in the WHERE clause below, and are
+        // only written when we insert a brand-new row.
+        val mutableColumns = ContentValues().apply {
+            put(Column.DATA, dbEncryptionHandler.wrapDbData(messageDAO.jsonData.toString()))
+            put(Column.WZRKPARAMS, messageDAO.wzrkParams.toString())
+            put(Column.CAMPAIGN, messageDAO.campaignId)
+            put(Column.TAGS, messageDAO.tags)
+            put(Column.IS_READ, messageDAO.isRead())
+            put(Column.EXPIRES, messageDAO.expires)
+            put(Column.CREATED_AT, messageDAO.date)
+            put(Column.SOURCE, (messageDAO.source ?: InboxMessageSource.V1).name)
+        }
+
+        try {
+            val updated = db.update(
+                tName,
+                mutableColumns,
+                "${Column.USER_ID} = ? AND ${Column.ID} = ?",
+                arrayOf(messageDAO.userId, messageDAO.id)
+            )
+            // updated > 0 means a row already existed and we just refreshed it, so there is
+            // nothing left to do.
+            if (updated > 0) {
+                return
+            }
+
+            // We get here only when the UPDATE matched no rows, i.e. this message is new to
+            // this user. Add the two identifying columns, plus index_state — the insert is
+            // the only place index_state is ever written.
+            val insertColumns = ContentValues(mutableColumns).apply {
+                put(Column.ID, messageDAO.id)
+                put(Column.USER_ID, messageDAO.userId)
+                put(Column.INDEX_STATE, messageDAO.indexState ?: InboxIndexState.PENDING_INDEXING)
+            }
+            db.insert(tName, null, insertColumns)
+        } catch (e: SQLiteException) {
+            logger.verbose("Error adding data to table $tName", e)
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppNotification.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppNotification.kt
@@ -79,6 +79,13 @@ class CTInAppNotification : Parcelable {
     var isRequestForPushPermission: Boolean = false
         private set
 
+    /**
+     * Per-campaign dismiss-gesture flag. Default to `true` when the JSON key is absent or an
+     * explicit null (parsed null-safely via [org.json.JSONObject.optBoolean]).
+     */
+    var swipeToDismiss: Boolean = true
+        private set
+
     internal var customTemplateData: CustomTemplateInAppData? = null
         private set
 
@@ -161,6 +168,9 @@ class CTInAppNotification : Parcelable {
             } else {
                 configureWithJson(jsonObject)
             }
+            // Take the server value when present (boolean or 0/1); absent key or explicit JSON null
+            // falls back to true.
+            swipeToDismiss = parseDismissFlag(jsonObject, Constants.KEY_SWIPE_TO_DISMISS)
         } catch (e: JSONException) {
             error = "Invalid JSON: ${e.localizedMessage}"
         }
@@ -229,6 +239,7 @@ class CTInAppNotification : Parcelable {
             parcel.readParcelable<CustomTemplateInAppData?>(CustomTemplateInAppData::class.java.getClassLoader())
         aspectRatio = parcel.readDouble()
         isRequestForPushPermission = parcel.readByte().toInt() != 0x00
+        swipeToDismiss = parcel.readByte().toInt() != 0x00
         pipConfigJson = _jsonDescription.optJSONObject("pip")
     }
 
@@ -288,7 +299,31 @@ class CTInAppNotification : Parcelable {
         dest.writeParcelable(customTemplateData, flags)
         dest.writeDouble(aspectRatio)
         dest.writeByte((if (isRequestForPushPermission) 0x01 else 0x00).toByte())
+        dest.writeByte((if (swipeToDismiss) 0x01 else 0x00).toByte())
     }
+
+    /**
+     * True for the image-only native templates whose whole image is tappable. Used to tag the
+     * whole-image tap as [Constants.INAPP_ELEMENT_ID_IMAGE] instead of a CTA button.
+     */
+    internal fun isImageOnlyInApp(): Boolean =
+        inAppType == CTInAppType.CTInAppTypeCoverImageOnly ||
+                inAppType == CTInAppType.CTInAppTypeHalfInterstitialImageOnly ||
+                inAppType == CTInAppType.CTInAppTypeInterstitialImageOnly
+
+    /**
+     * True for HTML in-apps (including the advanced-builder media template, which is delivered as the
+     * in-app's HTML content). Media-error reporting is scoped to HTML in-apps: aspect ratio only affects
+     * window sizing and isn't guaranteed to be set, so gating on the in-app type is the reliable signal
+     * and still excludes native templates (so a native CTA's wzrk_c2a is never misread).
+     */
+    internal fun isHtml(): Boolean =
+        inAppType == CTInAppType.CTInAppTypeHTML ||
+                inAppType == CTInAppType.CTInAppTypeCoverHTML ||
+                inAppType == CTInAppType.CTInAppTypeInterstitialHTML ||
+                inAppType == CTInAppType.CTInAppTypeHeaderHTML ||
+                inAppType == CTInAppType.CTInAppTypeFooterHTML ||
+                inAppType == CTInAppType.CTInAppTypeHalfInterstitialHTML
 
     internal fun getInAppMediaForOrientation(orientation: Int): CTInAppNotificationMedia? {
         var returningMedia: CTInAppNotificationMedia? = null
@@ -607,6 +642,19 @@ class CTInAppNotification : Parcelable {
 
         fun defaultTtl(): Long {
             return (System.currentTimeMillis() + 2 * Constants.ONE_DAY_IN_MILLIS) / 1000
+        }
+
+        /**
+         * Parses a per-campaign dismiss-gesture flag. Uses the server value when present as a real
+         * boolean or as 0/1 (1 -> true, 0 -> false). A missing key, an explicit JSON null, or any
+         * other/unparseable value falls back to true.
+         */
+        private fun parseDismissFlag(json: JSONObject, key: String): Boolean {
+            return when (val value = json.opt(key)) {
+                is Boolean -> value
+                is Number -> value.toInt() != 0
+                else -> true // absent, JSONObject.NULL, or unexpected type
+            }
         }
 
         private fun getBundleFromJsonObject(notif: JSONObject): Bundle {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -13,6 +13,8 @@ import com.clevertap.android.sdk.AnalyticsManager
 import com.clevertap.android.sdk.BaseCallbackManager
 import com.clevertap.android.sdk.CleverTapInstanceConfig
 import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.validation.ValidationResult
+import com.clevertap.android.sdk.validation.ValidationResultStack
 import com.clevertap.android.sdk.ControllerManager
 import com.clevertap.android.sdk.CoreMetaData
 import com.clevertap.android.sdk.DeviceInfo
@@ -80,6 +82,7 @@ internal class InAppController(
     private val clock: Clock,
     private val networkMonitor: NetworkMonitor,
     private val pipManager: PIPManager,
+    private val validationResultStack: ValidationResultStack,
 ) : InAppListener, PIPShowFailureHandler {
 
     private enum class InAppState {
@@ -280,12 +283,25 @@ internal class InAppController(
             data.putString(Constants.DEEP_LINK_KEY, deepLink)
         }
 
+        // Media preload failures from the bundled advanced-builder template (delivered as HTML content)
+        // arrive as a synthetic close carrying a reserved wzrk_c2a. Report them as a structured wzrk_error
+        // and DO NOT raise a click or viewed event. Scoped to HTML in-apps only: aspect ratio isn't a
+        // reliable signal, and gating on the HTML type excludes native templates so a native CTA's
+        // wzrk_c2a is never misread as a media error.
+        if (inAppNotification.isHtml() && reportMediaErrorIfAny(callToAction)) {
+            return data
+        }
+
+        val type = action.type
+        // Enrich the clicked event with the action descriptors (wzrk_action/wzrk_data) at this single
+        // choke point, derived from the action being triggered.
+        addActionDescriptors(data, action, type)
+
         // send clicked event
         if (!inAppNotification.isLocalInApp) {
             analyticsManager.pushInAppNotificationStateEvent(true, inAppNotification, data)
         }
 
-        val type = action.type
         if (type == null) {
             logger.debug("Triggered in-app action without type")
             return data
@@ -330,20 +346,94 @@ internal class InAppController(
         return data
     }
 
+    /**
+     * Maps a media-error synthetic-close [callToAction] to a structured [ValidationResult] and pushes it
+     * onto the validation stack, so it rides along on the next queued event as the top-level `wzrk_error`.
+     * No event is raised here. Returns true if the callToAction was a media-error descriptor.
+     */
+    private fun reportMediaErrorIfAny(callToAction: String): Boolean {
+        val validationResult = when (callToAction) {
+            Constants.INAPP_CTA_IMAGE_ERROR_DISMISS -> ValidationResult(
+                Constants.INAPP_IMAGE_LOAD_FAILED_ERROR_CODE,
+                Constants.INAPP_IMAGE_LOAD_FAILED_ERROR_MSG
+            )
+
+            Constants.INAPP_CTA_VIDEO_ERROR_DISMISS -> ValidationResult(
+                Constants.INAPP_VIDEO_LOAD_FAILED_ERROR_CODE,
+                Constants.INAPP_VIDEO_LOAD_FAILED_ERROR_MSG
+            )
+
+            else -> return false
+        }
+        logger.debug("InApp media failed to load, reporting wzrk_error ${validationResult.errorCode}")
+        validationResultStack.pushValidationResult(validationResult)
+        return true
+    }
+
+    /**
+     * Adds `wzrk_action` (the action type) and `wzrk_data` (the action payload) to the clicked-event
+     * extras. `wzrk_data` for a key-values action is a nested object.
+     */
+    private fun addActionDescriptors(data: Bundle, action: CTInAppAction, type: InAppActionType?) {
+        if (type == null) {
+            return
+        }
+        data.putString(Constants.KEY_WZRK_ACTION, type.toString())
+        when (type) {
+            InAppActionType.OPEN_URL ->
+                action.actionUrl?.takeIf { it.isNotEmpty() }
+                    ?.let { data.putString(Constants.KEY_WZRK_DATA, it) }
+
+            InAppActionType.CLOSE ->
+                data.putString(Constants.KEY_WZRK_DATA, Constants.INAPP_WZRK_DATA_CLOSE)
+
+            InAppActionType.CUSTOM_CODE ->
+                action.customTemplateInAppData?.templateName?.takeIf { it.isNotEmpty() }
+                    ?.let { data.putString(Constants.KEY_WZRK_DATA, it) }
+
+            InAppActionType.KEY_VALUES -> {
+                val keyValues = action.keyValues
+                if (!keyValues.isNullOrEmpty()) {
+                    // Nested payload carried as a Serializable map; analytics emits it as a nested JSON object.
+                    data.putSerializable(Constants.KEY_WZRK_DATA, HashMap(keyValues))
+                }
+            }
+
+            else -> {
+                // no wzrk_data payload for other action types
+            }
+        }
+    }
+
     override fun inAppNotificationDidClick(
         inAppNotification: CTInAppNotification,
         button: CTInAppNotificationButton,
+        buttonIndex: Int,
         activityContext: Context?
     ): Bundle? {
         val action = button.action
         if (action == null) {
             return null
         }
+        // Tag the clicked element for CTA buttons that don't route through the fragment's
+        // handleButtonClickAtIndex (e.g. alert-template buttons). The caller passes the exact clicked
+        // index (buttons are built from a JSON array and CTInAppNotificationButton.equals is value-based,
+        // so indexOf would resolve a duplicate CTA payload to the wrong slot). 1-based, matching iOS.
+        val additionalData = if (buttonIndex >= 0) {
+            val elementId = if (inAppNotification.isImageOnlyInApp()) {
+                Constants.INAPP_ELEMENT_ID_IMAGE
+            } else {
+                Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX + (buttonIndex + 1)
+            }
+            Bundle().apply { putString(Constants.KEY_WZRK_ELEMENT_ID, elementId) }
+        } else {
+            null
+        }
         return inAppNotificationActionTriggered(
             inAppNotification,
             action,
             button.text,
-            null,
+            additionalData,
             activityContext
         )
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppListener.kt
@@ -8,6 +8,7 @@ internal interface InAppListener {
     fun inAppNotificationDidClick(
         inAppNotification: CTInAppNotification,
         button: CTInAppNotificationButton,
+        buttonIndex: Int,
         activityContext: Context?
     ): Bundle?
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PIPInAppCallbacksBridge.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PIPInAppCallbacksBridge.kt
@@ -1,5 +1,7 @@
 package com.clevertap.android.sdk.inapp
 
+import android.os.Bundle
+import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.ILogger
 import com.clevertap.android.sdk.inapp.pipsdk.PIPCallbacks
 
@@ -22,6 +24,26 @@ internal class PIPInAppCallbacksBridge(
     override fun onClose() {
         logger.debug(LOG_TAG, "PIP onClose for campaign: ${inAppNotification.campaignId}")
         inAppListener.inAppNotificationDidDismiss(inAppNotification, null)
+    }
+
+    /**
+     * Close (X) button tap. Raises a "Notification Clicked" event with close descriptors
+     *  (`wzrk_element_id = closeButton`, `wzrk_c2a = Dismiss Button`,
+     * `wzrk_action = close`, `wzrk_data = close`), matching every other in-app type's close button.
+     * The dismiss itself is reported separately via the [onClose] that follows.
+     */
+    override fun onCloseButtonClick() {
+        logger.debug(LOG_TAG, "PIP onCloseButtonClick for campaign: ${inAppNotification.campaignId}")
+        val extras = Bundle().apply {
+            putString(Constants.KEY_WZRK_ELEMENT_ID, Constants.INAPP_ELEMENT_ID_CLOSE)
+        }
+        inAppListener.inAppNotificationActionTriggered(
+            inAppNotification,
+            CTInAppAction.createCloseAction(),
+            Constants.INAPP_CTA_DISMISS_BUTTON,
+            extras,
+            null
+        )
     }
 
     override fun onAction() {
@@ -50,8 +72,13 @@ internal class PIPInAppCallbacksBridge(
         //
         // No Activity finishes, so the app's task is never at risk of being killed
         // because it was never reduced to an empty/background state.
+        //
+        // PIP exposes a single CTA surface, so its element id is the fixed literal "button-cta"
+        val extras = Bundle().apply {
+            putString(Constants.KEY_WZRK_ELEMENT_ID, Constants.INAPP_ELEMENT_ID_PIP_CTA)
+        }
         inAppListener.inAppNotificationActionTriggered(
-            inAppNotification, action, callToAction, null, null
+            inAppNotification, action, callToAction, extras, null
         )
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -8,6 +8,7 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 
+import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.CleverTapInstanceConfig
 import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.DidClickForHardPermissionListener

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -177,6 +177,36 @@ internal abstract class CTInAppBaseFragment : Fragment() {
         triggerAction(CTInAppAction.CREATOR.createOpenUrlAction(url), null, null)
     }
 
+    /**
+     * Close (X) button dismissal, raised as a click: `wzrk_element_id = closeButton`,
+     * `wzrk_c2a = Dismiss Button`, `wzrk_action = close`, `wzrk_data = close`.
+     */
+    fun triggerCloseButtonAction() {
+        val extras = Bundle().apply {
+            putString(Constants.KEY_WZRK_ELEMENT_ID, Constants.INAPP_ELEMENT_ID_CLOSE)
+        }
+        triggerAction(
+            CTInAppAction.CREATOR.createCloseAction(), Constants.INAPP_CTA_DISMISS_BUTTON, extras
+        )
+    }
+
+    /**
+     * Swipe-to-dismiss, raised as a click: `wzrk_c2a = Swipe to Dismiss`, `wzrk_action = close`,
+     * `wzrk_data = close`. No `wzrk_element_id` (gesture, not an element).
+     */
+    fun triggerSwipeDismissAction() {
+        triggerAction(
+            CTInAppAction.CREATOR.createCloseAction(), Constants.INAPP_CTA_SWIPE_DISMISS, null
+        )
+    }
+
+    /**
+     * The swipe/pan dismiss gesture is enabled only when there is no close button and the campaign
+     * allows swipe-to-dismiss. When disabled, the gesture must not be attached at all.
+     */
+    protected fun isSwipeToDismissEnabled(): Boolean =
+        !inAppNotification.isShowClose && inAppNotification.swipeToDismiss
+
     fun didDismiss(data: Bundle?) {
         cleanup()
         getListener()?.inAppNotificationDidDismiss(inAppNotification, data)
@@ -211,7 +241,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
     fun handleButtonClickAtIndex(index: Int) {
         try {
             val button = inAppNotification.buttons[index]
-            val clickData = didClick(button)
+            val clickData = didClick(button, index)
 
             if (inAppNotification.isLocalInApp && didClickForHardPermissionListener != null) {
                 when (index) {
@@ -246,12 +276,22 @@ internal abstract class CTInAppBaseFragment : Fragment() {
         return FileResourceProvider.getInstance(requireContext(), config.logger)
     }
 
-    private fun didClick(button: CTInAppNotificationButton): Bundle? {
+    private fun didClick(button: CTInAppNotificationButton, index: Int): Bundle? {
         var action = button.action
         if (action == null) {
             action = CTInAppAction.CREATOR.createCloseAction()
         }
-        return notifyActionTriggered(action, button.text, null)
+        // Whole-image tap on image-only templates is tagged image-1; otherwise it is a 1-based CTA button.
+        val isImageTap = inAppNotification.isImageOnlyInApp()
+        val elementId = if (isImageTap) {
+            Constants.INAPP_ELEMENT_ID_IMAGE
+        } else {
+            Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX + (index + 1)
+        }
+        val extras = Bundle().apply { putString(Constants.KEY_WZRK_ELEMENT_ID, elementId) }
+        // wzrk_c2a: for a whole-image tap use the element id ("image-1"); for a CTA button use its text.
+        val callToAction = if (isImageTap) elementId else button.text
+        return notifyActionTriggered(action, callToAction, extras)
     }
 
     private fun notifyActionTriggered(

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -118,7 +118,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        ViewCompat.announceForAccessibility(view, "InApp message shown")
+        ViewCompat.announceForAccessibility(view, getString(R.string.ct_inapp_message_shown))
         didShow(null)
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.View
-
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 
@@ -118,6 +118,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        ViewCompat.announceForAccessibility(view, "InApp message shown")
         didShow(null)
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.View
-import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 
@@ -118,7 +117,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        ViewCompat.announceForAccessibility(view, getString(R.string.ct_inapp_message_shown))
+        view.announceForAccessibility(getString(R.string.ct_inapp_message_shown))
         didShow(null)
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.View
+import androidx.core.view.ViewCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 
@@ -118,7 +119,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        view.announceForAccessibility(getString(R.string.ct_inapp_message_shown))
+        ViewCompat.setAccessibilityPaneTitle(view, getString(R.string.ct_inapp_message_shown))
         didShow(null)
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
@@ -56,7 +56,7 @@ internal abstract class CTInAppBaseFullHtmlFragment : CTInAppBaseFullFragment() 
         closeIvLp.addRule(RelativeLayout.ABOVE, webViewId)
         closeIvLp.addRule(RelativeLayout.RIGHT_OF, webViewId)
 
-        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH) / 2
+        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH) / 2
         closeIvLp.setMargins(-sub, 0, 0, -sub)
         return closeIvLp
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
@@ -103,7 +103,7 @@ internal abstract class CTInAppBaseFullHtmlFragment : CTInAppBaseFullFragment() 
                 val context = inflater.context
                 val closeImageView = CloseImageView(context)
                 val closeIvLp = getLayoutParamsForCloseButton(webView.id)
-                closeImageView.setOnClickListener { didDismiss(null) }
+                closeImageView.setOnClickListener { triggerCloseButtonAction() }
                 closeImageView.contentDescription = context.getString(R.string.ct_inapp_close_btn)
                 this.closeImageView = closeImageView
                 rl.addView(closeImageView, closeIvLp)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -19,7 +19,6 @@ import android.view.animation.TranslateAnimation
 import com.clevertap.android.sdk.CTWebInterface
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.Logger
-import com.clevertap.android.sdk.inapp.CTInAppAction.CREATOR.createCloseAction
 import com.clevertap.android.sdk.inapp.CTInAppWebView
 import com.clevertap.android.sdk.inapp.InAppWebViewClient
 import kotlin.math.abs
@@ -61,7 +60,7 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
             animSet.isFillEnabled = true
             animSet.setAnimationListener(object : Animation.AnimationListener {
                 override fun onAnimationEnd(animation: Animation?) {
-                    triggerAction(createCloseAction(), CTA_SWIPE_DISMISS, null)
+                    triggerSwipeDismissAction()
                 }
 
                 override fun onAnimationRepeat(animation: Animation?) {
@@ -145,7 +144,11 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
             this.webView = webView
             val webViewClient = InAppWebViewClient(this)
             webView.setWebViewClient(webViewClient)
-            webView.setOnTouchListener(this)
+            // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no close
+            // button. When swipeToDismiss == false, the gesture is not attached at all.
+            if (isSwipeToDismissEnabled()) {
+                webView.setOnTouchListener(this)
+            }
             webView.setOnLongClickListener(this)
 
             if (inAppNotification.isJsEnabled) {
@@ -185,7 +188,6 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
     }
 
     companion object {
-        private const val CTA_SWIPE_DISMISS = "swipe-dismiss"
         private const val SWIPE_MIN_DISTANCE = 120
         private const val SWIPE_THRESHOLD_VELOCITY = 200
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialNativeFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialNativeFragment.kt
@@ -63,7 +63,7 @@ internal abstract class CTInAppBasePartialNativeFragment : CTInAppBasePartialFra
             animSet.isFillEnabled = true
             animSet.setAnimationListener(object : Animation.AnimationListener {
                 override fun onAnimationEnd(animation: Animation?) {
-                    didDismiss(null)
+                    triggerSwipeDismissAction()
                 }
 
                 override fun onAnimationRepeat(animation: Animation?) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppHtmlCoverFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppHtmlCoverFragment.kt
@@ -17,7 +17,7 @@ internal class CTInAppHtmlCoverFragment : CTInAppBaseFullHtmlFragment() {
         closeIvLp.addRule(RelativeLayout.ALIGN_PARENT_RIGHT)
         closeIvLp.addRule(RelativeLayout.ALIGN_PARENT_TOP)
 
-        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_WIDTH) / 4
+        val sub = getScaledPixels(Constants.INAPP_CLOSE_IV_TOUCH_TARGET_WIDTH) / 4
         closeIvLp.setMargins(0, sub, sub, 0)
         return closeIvLp
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverFragment.kt
@@ -11,6 +11,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -57,13 +58,18 @@ internal class CTInAppNativeCoverFragment : CTInAppBaseFullNativeFragment() {
             InAppMediaConfig(imageViewId = R.id.backgroundImage, clickableMedia = false, gifImageId = R.id.gifImage)
         )
 
+        relativeLayout.findViewById<View>(R.id.backgroundImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val textView1 = relativeLayout.findViewById<TextView>(R.id.cover_title)
         textView1.text = inAppNotification.title
         textView1.setTextColor(inAppNotification.titleColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView1, true)
 
         val textView2 = relativeLayout.findViewById<TextView>(R.id.cover_message)
         textView2.text = inAppNotification.message
         textView2.setTextColor(inAppNotification.messageColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView2, true)
 
         val buttons = inAppNotification.buttons
         if (buttons.size == 1) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverFragment.kt
@@ -87,7 +87,7 @@ internal class CTInAppNativeCoverFragment : CTInAppBaseFullNativeFragment() {
         val closeImageView = fl.findViewById<CloseImageView>(CloseImageView.VIEW_ID)
 
         closeImageView.setOnClickListener {
-            didDismiss(null)
+            triggerCloseButtonAction()
             activity?.finish()
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverImageFragment.kt
@@ -53,7 +53,7 @@ internal class CTInAppNativeCoverImageFragment : CTInAppBaseFullFragment() {
         val closeImageView = fl.findViewById<CloseImageView>(CloseImageView.VIEW_ID)
 
         closeImageView.setOnClickListener {
-            didDismiss(null)
+            triggerCloseButtonAction()
             activity?.finish()
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeCoverImageFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -49,6 +50,9 @@ internal class CTInAppNativeCoverImageFragment : CTInAppBaseFullFragment() {
             InAppMediaConfig(imageViewId = R.id.cover_image, clickableMedia = true, videoFrameId = R.id.video_frame, gifImageId = R.id.gifImage),
             CTInAppNativeButtonClickListener()
         )
+
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val closeImageView = fl.findViewById<CloseImageView>(CloseImageView.VIEW_ID)
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeFooterFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeFooterFragment.kt
@@ -86,9 +86,12 @@ internal class CTInAppNativeFooterFragment : CTInAppBasePartialNativeFragment() 
         }
 
         @SuppressLint("ClickableViewAccessibility")
-        inAppView.setOnTouchListener { v, event ->
-            gd.onTouchEvent(event)
-            true
+        // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled.
+        if (isSwipeToDismissEnabled()) {
+            inAppView.setOnTouchListener { v, event ->
+                gd.onTouchEvent(event)
+                true
+            }
         }
         inAppView.applyInsetsWithMarginAdjustment { insets, mlp ->
             mlp.leftMargin = insets.left

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeFooterFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeFooterFragment.kt
@@ -12,6 +12,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -61,13 +62,18 @@ internal class CTInAppNativeFooterFragment : CTInAppBasePartialNativeFragment() 
             )
         )
 
+        ViewCompat.setScreenReaderFocusable(imageView, true)
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val textView1 = linearLayout2.findViewById<TextView>(R.id.footer_title)
         textView1.text = inAppNotification.title
         textView1.setTextColor(inAppNotification.titleColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView1, true)
 
         val textView2 = linearLayout2.findViewById<TextView>(R.id.footer_message)
         textView2.text = inAppNotification.message
         textView2.setTextColor(inAppNotification.messageColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView2, true)
 
         val buttons = inAppNotification.buttons
         if (!buttons.isEmpty()) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialFragment.kt
@@ -15,6 +15,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.DeviceInfo
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
@@ -138,6 +139,9 @@ internal class CTInAppNativeHalfInterstitialFragment : CTInAppBaseFullNativeFrag
             InAppMediaConfig(imageViewId = R.id.backgroundImage, clickableMedia = false, gifImageId = R.id.gifImage)
         )
 
+        relativeLayout?.findViewById<View>(R.id.backgroundImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val linearLayout =
             relativeLayout?.findViewById<LinearLayout>(R.id.half_interstitial_linear_layout)
         val mainButton = linearLayout?.findViewById<Button>(R.id.half_interstitial_button1)
@@ -148,10 +152,12 @@ internal class CTInAppNativeHalfInterstitialFragment : CTInAppBaseFullNativeFrag
         val textView1 = relativeLayout?.findViewById<TextView>(R.id.half_interstitial_title)
         textView1?.text = inAppNotification.title
         textView1?.setTextColor(inAppNotification.titleColor.toColorInt())
+        textView1?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val textView2 = relativeLayout?.findViewById<TextView>(R.id.half_interstitial_message)
         textView2?.text = inAppNotification.message
         textView2?.setTextColor(inAppNotification.messageColor.toColorInt())
+        textView2?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val buttons = inAppNotification.buttons
         if (buttons.size == 1) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialFragment.kt
@@ -175,7 +175,7 @@ internal class CTInAppNativeHalfInterstitialFragment : CTInAppBaseFullNativeFrag
         fl.background = ColorDrawable(-0x45000000)
 
         closeImageView.setOnClickListener {
-            didDismiss(null)
+            triggerCloseButtonAction()
             activity?.finish()
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialImageFragment.kt
@@ -138,7 +138,7 @@ internal class CTInAppNativeHalfInterstitialImageFragment : CTInAppBaseFullFragm
         )
 
         closeImageView.setOnClickListener {
-            didDismiss(null)
+            triggerCloseButtonAction()
             activity?.finish()
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHalfInterstitialImageFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -136,6 +137,9 @@ internal class CTInAppNativeHalfInterstitialImageFragment : CTInAppBaseFullFragm
             InAppMediaConfig(imageViewId = R.id.half_interstitial_image, clickableMedia = true, videoFrameId = R.id.video_frame, gifImageId = R.id.gifImage),
             CTInAppNativeButtonClickListener()
         )
+
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         closeImageView.setOnClickListener {
             triggerCloseButtonAction()

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHeaderFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHeaderFragment.kt
@@ -87,9 +87,12 @@ internal class CTInAppNativeHeaderFragment : CTInAppBasePartialNativeFragment() 
         }
 
         @SuppressLint("ClickableViewAccessibility")
-        inAppView.setOnTouchListener { v, event ->
-            gd.onTouchEvent(event)
-            true
+        // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled.
+        if (isSwipeToDismissEnabled()) {
+            inAppView.setOnTouchListener { v, event ->
+                gd.onTouchEvent(event)
+                true
+            }
         }
         inAppView.applyInsetsWithMarginAdjustment { insets, mlp ->
             mlp.leftMargin = insets.left

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHeaderFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeHeaderFragment.kt
@@ -12,6 +12,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -62,13 +63,18 @@ internal class CTInAppNativeHeaderFragment : CTInAppBasePartialNativeFragment() 
             )
         )
 
+        ViewCompat.setScreenReaderFocusable(imageView, true)
+        relativeLayout.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         val textView1 = linearLayout2.findViewById<TextView>(R.id.header_title)
         textView1.text = inAppNotification.title
         textView1.setTextColor(inAppNotification.titleColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView1, true)
 
         val textView2 = linearLayout2.findViewById<TextView>(R.id.header_message)
         textView2.text = inAppNotification.message
         textView2.setTextColor(inAppNotification.messageColor.toColorInt())
+        ViewCompat.setScreenReaderFocusable(textView2, true)
 
         val buttons = inAppNotification.buttons
         if (!buttons.isEmpty()) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialFragment.kt
@@ -82,7 +82,7 @@ internal class CTInAppNativeInterstitialFragment : CTInAppBaseFullNativeFragment
         } else {
             closeImageView?.setVisibility(View.VISIBLE)
             closeImageView?.setOnClickListener {
-                didDismiss(null)
+                triggerCloseButtonAction()
                 activity?.finish()
             }
         }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialFragment.kt
@@ -15,6 +15,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -68,6 +69,11 @@ internal class CTInAppNativeInterstitialFragment : CTInAppBaseFullNativeFragment
                 gifImageId = R.id.gifImage,
             )
         )
+
+        relativeLayout?.findViewById<View>(R.id.backgroundImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+
         setTitleAndMessage()
         setButtons()
         handleCloseButton()
@@ -121,10 +127,12 @@ internal class CTInAppNativeInterstitialFragment : CTInAppBaseFullNativeFragment
         val textView1 = relativeLayout?.findViewById<TextView>(R.id.interstitial_title)
         textView1?.text = inAppNotification.title
         textView1?.setTextColor(inAppNotification.titleColor.toColorInt())
+        textView1?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         val textView2 = relativeLayout?.findViewById<TextView>(R.id.interstitial_message)
         textView2?.text = inAppNotification.message
         textView2?.setTextColor(inAppNotification.messageColor.toColorInt())
+        textView2?.let { ViewCompat.setScreenReaderFocusable(it, true) }
     }
 
     private fun resizeContainer(fl: FrameLayout, closeImageView: CloseImageView) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialImageFragment.kt
@@ -121,7 +121,7 @@ internal class CTInAppNativeInterstitialImageFragment : CTInAppBaseFullFragment(
         )
 
         closeImageView.setOnClickListener {
-            didDismiss(null)
+            triggerCloseButtonAction()
             activity?.finish()
         }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialImageFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppNativeInterstitialImageFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.widget.FrameLayout
 import android.widget.RelativeLayout
 import androidx.core.graphics.toColorInt
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.media.InAppMediaConfig
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
@@ -119,6 +120,9 @@ internal class CTInAppNativeInterstitialImageFragment : CTInAppBaseFullFragment(
             InAppMediaConfig(imageViewId = R.id.interstitial_image, clickableMedia = true, videoFrameId = R.id.video_frame, gifImageId = R.id.gifImage),
             CTInAppNativeButtonClickListener()
         )
+
+        relativeLayout?.findViewById<View>(R.id.gifImage)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
+        relativeLayout?.findViewById<View>(R.id.video_frame)?.let { ViewCompat.setScreenReaderFocusable(it, true) }
 
         closeImageView.setOnClickListener {
             triggerCloseButtonAction()

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppGifHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppGifHandler.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.widget.ImageView
 import android.widget.RelativeLayout
 import androidx.lifecycle.LifecycleOwner
+import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.gif.GifImageView
 import com.clevertap.android.sdk.inapp.CTInAppNotificationMedia
 import com.clevertap.android.sdk.inapp.images.FileResourceProvider
@@ -23,7 +24,12 @@ internal class InAppGifHandler(
         if (config.gifImageId == 0) return
         val gifByteArray = resourceProvider.cachedInAppGifV1(media.mediaUrl) ?: return
         gifImageView = relativeLayout?.findViewById(config.gifImageId)
-        gifImageView?.setContentDescriptionIfNotBlank(media.contentDescription)
+        gifImageView?.let { view ->
+            view.setContentDescriptionOrDefault(
+                media.contentDescription,
+                view.context.getString(R.string.ct_inapp_gif)
+            )
+        }
         gifImageView?.visibility = View.VISIBLE
         gifImageView?.setBytes(gifByteArray)
         gifImageView?.startAnimation()

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppImageHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppImageHandler.kt
@@ -3,6 +3,7 @@ package com.clevertap.android.sdk.inapp.media
 import android.view.View
 import android.widget.ImageView
 import android.widget.RelativeLayout
+import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.CTInAppNotificationMedia
 import com.clevertap.android.sdk.inapp.images.FileResourceProvider
 
@@ -21,13 +22,17 @@ internal class InAppImageHandler(
         clickListener: View.OnClickListener?
     ) {
         val bitmap = resourceProvider.cachedInAppImageV1(media.mediaUrl) ?: return
-        val imageView = relativeLayout?.findViewById<ImageView>(config.imageViewId)
-        imageView?.setContentDescriptionIfNotBlank(media.contentDescription)
-        imageView?.setImageBitmap(bitmap)
-        imageView?.visibility = View.VISIBLE
+        val layout = relativeLayout ?: return
+        val imageView = layout.findViewById<ImageView>(config.imageViewId) ?: return
+        imageView.setContentDescriptionOrDefault(
+            media.contentDescription,
+            imageView.context.getString(R.string.ct_inapp_img)
+        )
+        imageView.setImageBitmap(bitmap)
+        imageView.visibility = View.VISIBLE
         if (config.clickableMedia && clickListener != null) {
-            imageView?.tag = 0
-            imageView?.setOnClickListener(clickListener)
+            imageView.tag = 0
+            imageView.setOnClickListener(clickListener)
         }
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppMediaHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppMediaHandler.kt
@@ -63,13 +63,9 @@ internal interface InAppMediaHandler : DefaultLifecycleObserver {
     }
 }
 
-internal fun View.setContentDescriptionIfNotBlank(contentDescription: String) {
-    if (contentDescription.isNotBlank()) {
-        this.contentDescription = contentDescription
-        this.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
-    } else {
-        this.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
-    }
+internal fun View.setContentDescriptionOrDefault(contentDescription: String, defaultDescription: String) {
+    this.contentDescription = contentDescription.ifBlank { defaultDescription }
+    this.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
 }
 
 /**

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppMediaHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppMediaHandler.kt
@@ -66,6 +66,9 @@ internal interface InAppMediaHandler : DefaultLifecycleObserver {
 internal fun View.setContentDescriptionIfNotBlank(contentDescription: String) {
     if (contentDescription.isNotBlank()) {
         this.contentDescription = contentDescription
+        this.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+    } else {
+        this.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
     }
 }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppStreamMediaHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/media/InAppStreamMediaHandler.kt
@@ -12,6 +12,7 @@ import com.clevertap.android.sdk.applyInsetsWithMarginAdjustment
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.LifecycleOwner
 import androidx.media3.common.util.UnstableApi
+import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.inapp.CTInAppNotificationMedia
 import com.clevertap.android.sdk.video.InAppVideoPlayerHandle
 import com.clevertap.android.sdk.video.VideoLibChecker
@@ -74,7 +75,12 @@ internal class InAppStreamMediaHandler
             onBackPressedCallback.isEnabled = true
             openFullscreenDialog()
         }
-        videoFrameLayout?.setContentDescriptionIfNotBlank(media.contentDescription)
+        videoFrameLayout?.let { layout ->
+            layout.setContentDescriptionOrDefault(
+                media.contentDescription,
+                layout.context.getString(R.string.ct_inapp_media)
+            )
+        }
     }
 
     override fun onResume(owner: LifecycleOwner) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/PIPCallbacks.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/PIPCallbacks.kt
@@ -8,6 +8,11 @@ package com.clevertap.android.sdk.inapp.pipsdk
 interface PIPCallbacks {
     fun onShow() {}
     fun onClose() {}
+
+    /** Called when the user taps the close (X) button specifically — as opposed to a CTA-triggered
+     *  dismiss, a media-load failure, or Activity/session teardown, all of which surface via [onClose].
+     *  Fires just before the corresponding [onClose] for the same dismissal. */
+    fun onCloseButtonClick() {}
     fun onExpand() {}
     fun onCollapse() {}
     fun onAction() {}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/PIPManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/PIPManager.kt
@@ -116,6 +116,7 @@ internal class PIPManager(
         // Attach PIPRootContainer to the Activity's content view
         val container = PIPRootContainer(activity)
         container.onDismissRequested = { runOnMain { dismissInternal() } }
+        container.onCloseButtonClicked = { runOnMain { dismissInternal(DismissReason.UserClose) } }
         container.onShowFailed = { runOnMain { dismissInternal(DismissReason.ShowFailed, animate = false) } }
         newSession.pipRootContainer = container
         container.setupBackPressCallback(activity)
@@ -133,8 +134,11 @@ internal class PIPManager(
     }
 
     private sealed interface DismissReason {
-        /** User tapped close, or action triggered dismiss. */
+        /** User tapped the close (X) button. Surfaces as a close-button click AND a dismiss. */
         data object UserClose : DismissReason
+        /** Dismissed without a close-button tap — after a CTA action or a post-show media failure.
+         *  Surfaces as a dismiss only (the CTA already reports its own click via onAction). */
+        data object Dismiss : DismissReason
         /** All media URLs failed — PIP was never visible. */
         data object ShowFailed : DismissReason
         /** Activity destroyed (non-config) or Fragment view stopped (SAA). */
@@ -144,7 +148,7 @@ internal class PIPManager(
     }
 
     private fun dismissInternal(
-        reason: DismissReason = DismissReason.UserClose,
+        reason: DismissReason = DismissReason.Dismiss,
         animate: Boolean = true,
     ) {
         val s = session ?: return
@@ -154,7 +158,12 @@ internal class PIPManager(
         val cleanup: () -> Unit = {
             performCleanup(s)
             when (reason) {
-                DismissReason.UserClose,
+                DismissReason.UserClose -> {
+                    // Close (X) button: report the click first, then the dismiss.
+                    s.config.callbacks?.onCloseButtonClick()
+                    s.config.callbacks?.onClose()
+                }
+                DismissReason.Dismiss,
                 DismissReason.SessionCleanup -> s.config.callbacks?.onClose()
                 DismissReason.ShowFailed -> s.config.callbacks?.onShowFailed()
                 DismissReason.Replaced -> {}
@@ -254,6 +263,7 @@ internal class PIPManager(
         s.activityRef = WeakReference(activity)
         val container = PIPRootContainer(activity)
         container.onDismissRequested = { runOnMain { dismissInternal() } }
+        container.onCloseButtonClicked = { runOnMain { dismissInternal(DismissReason.UserClose) } }
         container.onShowFailed = { runOnMain { dismissInternal(DismissReason.ShowFailed, animate = false) } }
         container.setupBackPressCallback(activity)
         s.pipRootContainer = container

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/internal/renderer/PIPVideoPlayerWrapper.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/internal/renderer/PIPVideoPlayerWrapper.kt
@@ -19,6 +19,7 @@ import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import androidx.media3.ui.PlayerView
+import com.clevertap.android.sdk.video.inbox.Media3PlayerListener
 import kotlin.math.min
 
 /**
@@ -255,7 +256,7 @@ internal class PIPVideoPlayerWrapper {
      *  after network recovery). Without this, controls only update on user tap.
      *  Registered once in [initPlayer] — survives rotation since the player is not recreated. */
     private fun registerPlayingChangedListener(player: ExoPlayer) {
-        val listener = object : Player.Listener {
+        val listener = object : Media3PlayerListener() {
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 onPlayingChanged?.invoke(isPlaying)
             }
@@ -264,11 +265,11 @@ internal class PIPVideoPlayerWrapper {
         player.addListener(listener)
     }
 
-    /** Registers a one-shot [Player.Listener] that fires [onFirstFrame] when the first
+    /** Registers a one-shot [Media3PlayerListener] that fires [onFirstFrame] when the first
      *  video frame is rendered. Used by both [initPlayer] (initial load) and
      *  [rebindSurface] (post-rotation) so [notifyWhenFirstFrame] works in both cases. */
     private fun registerFirstFrameListener(player: ExoPlayer) {
-        player.addListener(object : Player.Listener {
+        player.addListener(object : Media3PlayerListener() {
             override fun onRenderedFirstFrame() {
                 val cb: (() -> Unit)?
                 synchronized(firstFrameLock) {
@@ -283,12 +284,12 @@ internal class PIPVideoPlayerWrapper {
     }
 
     /**
-     * Registers a [Player.Listener] on the underlying player to receive error events.
+     * Registers a [Media3PlayerListener] on the underlying player to receive error events.
      */
     fun setErrorListener(onError: (PlaybackException) -> Unit) {
         val p = player ?: return
         errorListener?.let { p.removeListener(it) }
-        val listener = object : Player.Listener {
+        val listener = object : Media3PlayerListener() {
             override fun onPlayerError(error: PlaybackException) {
                 onError(error)
             }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/internal/view/PIPRootContainer.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/internal/view/PIPRootContainer.kt
@@ -39,6 +39,10 @@ internal class PIPRootContainer(context: Context) : FrameLayout(context) {
     /** Called by internal close/dismiss actions — wired to PIPManager.dismissInternal. */
     var onDismissRequested: (() -> Unit)? = null
 
+    /** Called specifically when the user taps the close (X) button, so the dismissal can be
+     *  attributed as a close-button click (distinct from a CTA-triggered or media-fail dismiss). */
+    var onCloseButtonClicked: (() -> Unit)? = null
+
     /** Called when media failed to load during fresh show — PIP was never visible.
      *  Wired to silent cleanup in PIPManager (no animation, no onClose). */
     var onShowFailed: (() -> Unit)? = null
@@ -149,7 +153,7 @@ internal class PIPRootContainer(context: Context) : FrameLayout(context) {
             showPlayPauseButton = s.config.showPlayPauseButton,
             showMuteButton = s.config.showMuteButton,
             onCollapse = { collapseToCompact() },
-            onClose = { onDismissRequested?.invoke() },
+            onClose = { onCloseButtonClicked?.invoke() },
             onAction = actionHandler,
         )
         expandedView = ev
@@ -166,7 +170,7 @@ internal class PIPRootContainer(context: Context) : FrameLayout(context) {
         val cv = PIPCompactView(
             context, mv, s,
             onExpand = { expandToFull() },
-            onClose = { onDismissRequested?.invoke() },
+            onClose = { onCloseButtonClicked?.invoke() },
             onAction = actionHandler,
             onSnap = {},   // session.currentPosition already updated inside PIPCompactView
         )

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
@@ -57,14 +57,10 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
             }
             dots[position].setImageDrawable(
                     ResourcesCompat.getDrawable(context.getResources(), R.drawable.ct_selected_dot, null));
-            int totalPages = inboxMessage.getInboxMessageContents().size();
-            String imageDesc = getImageContentDescription(context, inboxMessage, position);
-            String announcement = context.getString(R.string.ct_carousel_page_announcement,
-                    imageDesc, position + 1, totalPages);
-            viewHolder.imageViewPager.setContentDescription(
-                    context.getString(R.string.ct_carousel_content_description,
-                            imageDesc, position + 1, totalPages));
-            viewHolder.imageViewPager.announceForAccessibility(announcement);
+            viewHolder.imageViewPager.setAccessibilityState(
+                    getImageContentDescription(context, inboxMessage, position),
+                    position,
+                    inboxMessage.getInboxMessageContents().size());
         }
     }
 
@@ -110,11 +106,14 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
         LinearLayout.LayoutParams layoutParams = (LinearLayout.LayoutParams) this.imageViewPager.getLayoutParams();
         CTCarouselViewPagerAdapter carouselViewPagerAdapter = new CTCarouselViewPagerAdapter(appContext, parent,
                 inboxMessage, layoutParams, position);
+        // Detach the recycled holder's listener BEFORE swapping the adapter. setAdapter() resets
+        // the current item to 0, and that dispatch would otherwise reach a listener still holding
+        // the previous message's data and dots array.
+        if (activePageChangeListener != null) {
+            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
+            activePageChangeListener = null;
+        }
         this.imageViewPager.setAdapter(carouselViewPagerAdapter);
-        int itemCount = inboxMessage.getInboxMessageContents().size();
-        String firstImageDesc = getImageContentDescription(appContext, inboxMessage, 0);
-        this.imageViewPager.setContentDescription(
-                appContext.getString(R.string.ct_carousel_content_description, firstImageDesc, 1, itemCount));
         //Adds the dots for the carousel
         int dotsCount = inboxMessage.getInboxMessageContents().size();
         if (this.sliderDots.getChildCount() > 0) {
@@ -124,15 +123,22 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
         setDots(dots, dotsCount, appContext, this.sliderDots);
         dots[0].setImageDrawable(
                 ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_selected_dot, null));
-        if (activePageChangeListener != null) {
-            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
-        }
         activePageChangeListener = new CTCarouselImageViewHolder.CarouselPageChangeListener(
                 parent.getActivity().getApplicationContext(), this, dots, inboxMessage);
         this.imageViewPager.addOnPageChangeListener(activePageChangeListener);
+        // onPageSelected() never fires for the initial page - ViewPager only dispatches on a
+        // change - so page 0's state must be set explicitly, and last, so nothing triggered by
+        // the adapter swap can overwrite it.
+        this.imageViewPager.setAccessibilityState(
+                getImageContentDescription(appContext, inboxMessage, 0), 0, dotsCount);
 
-        this.clickLayout.setOnClickListener(
-                new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true, APP_INBOX_ITEM_INDEX));
+        CTInboxButtonClickListener bodyClickListener = new CTInboxButtonClickListener(position, inboxMessage, null,
+                parentWeak, this.imageViewPager, true, APP_INBOX_ITEM_INDEX);
+        this.clickLayout.setOnClickListener(bodyClickListener);
+        // The adapter hides each page from the accessibility tree, which also hides the page's
+        // own click listener. Without this a TalkBack user can page through the carousel but
+        // has no way to open the message.
+        this.imageViewPager.setAccessibilityClickAction(bodyClickListener);
 
         markItemAsRead(inboxMessage, position);
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselImageViewHolder.java
@@ -57,6 +57,14 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
             }
             dots[position].setImageDrawable(
                     ResourcesCompat.getDrawable(context.getResources(), R.drawable.ct_selected_dot, null));
+            int totalPages = inboxMessage.getInboxMessageContents().size();
+            String imageDesc = getImageContentDescription(context, inboxMessage, position);
+            String announcement = context.getString(R.string.ct_carousel_page_announcement,
+                    imageDesc, position + 1, totalPages);
+            viewHolder.imageViewPager.setContentDescription(
+                    context.getString(R.string.ct_carousel_content_description,
+                            imageDesc, position + 1, totalPages));
+            viewHolder.imageViewPager.announceForAccessibility(announcement);
         }
     }
 
@@ -67,6 +75,8 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
     private final CTCarouselViewPager imageViewPager;
 
     private final LinearLayout sliderDots;
+
+    private CarouselPageChangeListener activePageChangeListener;
 
     CTCarouselImageViewHolder(@NonNull View itemView) {
         super(itemView);
@@ -101,6 +111,10 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
         CTCarouselViewPagerAdapter carouselViewPagerAdapter = new CTCarouselViewPagerAdapter(appContext, parent,
                 inboxMessage, layoutParams, position);
         this.imageViewPager.setAdapter(carouselViewPagerAdapter);
+        int itemCount = inboxMessage.getInboxMessageContents().size();
+        String firstImageDesc = getImageContentDescription(appContext, inboxMessage, 0);
+        this.imageViewPager.setContentDescription(
+                appContext.getString(R.string.ct_carousel_content_description, firstImageDesc, 1, itemCount));
         //Adds the dots for the carousel
         int dotsCount = inboxMessage.getInboxMessageContents().size();
         if (this.sliderDots.getChildCount() > 0) {
@@ -110,10 +124,12 @@ class CTCarouselImageViewHolder extends CTInboxBaseMessageViewHolder {
         setDots(dots, dotsCount, appContext, this.sliderDots);
         dots[0].setImageDrawable(
                 ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_selected_dot, null));
-        CTCarouselImageViewHolder.CarouselPageChangeListener carouselPageChangeListener
-                = new CTCarouselImageViewHolder.CarouselPageChangeListener(
+        if (activePageChangeListener != null) {
+            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
+        }
+        activePageChangeListener = new CTCarouselImageViewHolder.CarouselPageChangeListener(
                 parent.getActivity().getApplicationContext(), this, dots, inboxMessage);
-        this.imageViewPager.addOnPageChangeListener(carouselPageChangeListener);
+        this.imageViewPager.addOnPageChangeListener(activePageChangeListener);
 
         this.clickLayout.setOnClickListener(
                 new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true, APP_INBOX_ITEM_INDEX));

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
@@ -65,14 +65,10 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
             viewHolder.message.setText(inboxMessage.getInboxMessageContents().get(position).getMessage());
             viewHolder.message.setTextColor(
                     Color.parseColor(inboxMessage.getInboxMessageContents().get(position).getMessageColor()));
-            int totalPages = inboxMessage.getInboxMessageContents().size();
-            String imageDesc = getImageContentDescription(context, inboxMessage, position);
-            String announcement = context.getString(R.string.ct_carousel_page_announcement,
-                    imageDesc, position + 1, totalPages);
-            viewHolder.imageViewPager.setContentDescription(
-                    context.getString(R.string.ct_carousel_content_description,
-                            imageDesc, position + 1, totalPages));
-            viewHolder.imageViewPager.announceForAccessibility(announcement);
+            viewHolder.imageViewPager.setAccessibilityState(
+                    getImageContentDescription(context, inboxMessage, position),
+                    position,
+                    inboxMessage.getInboxMessageContents().size());
         }
     }
 
@@ -132,11 +128,14 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
         LinearLayout.LayoutParams layoutParams = (LinearLayout.LayoutParams) this.imageViewPager.getLayoutParams();
         CTCarouselViewPagerAdapter carouselViewPagerAdapter = new CTCarouselViewPagerAdapter(appContext, parent,
                 inboxMessage, layoutParams, position);
+        // Detach the recycled holder's listener BEFORE swapping the adapter. setAdapter() resets
+        // the current item to 0, and that dispatch would otherwise reach a listener still holding
+        // the previous message's data and dots array.
+        if (activePageChangeListener != null) {
+            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
+            activePageChangeListener = null;
+        }
         this.imageViewPager.setAdapter(carouselViewPagerAdapter);
-        int itemCount = inboxMessage.getInboxMessageContents().size();
-        String firstImageDesc = getImageContentDescription(appContext, inboxMessage, 0);
-        this.imageViewPager.setContentDescription(
-                appContext.getString(R.string.ct_carousel_content_description, firstImageDesc, 1, itemCount));
         //Adds the dots for the carousel
         int dotsCount = inboxMessage.getInboxMessageContents().size();
         if (this.sliderDots.getChildCount() > 0) {
@@ -146,15 +145,22 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
         setDots(dots, dotsCount, appContext, this.sliderDots);
         dots[0].setImageDrawable(
                 ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_selected_dot, null));
-        if (activePageChangeListener != null) {
-            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
-        }
         activePageChangeListener = new CTCarouselMessageViewHolder.CarouselPageChangeListener(
                 parent.getActivity().getApplicationContext(), this, dots, inboxMessage);
         this.imageViewPager.addOnPageChangeListener(activePageChangeListener);
+        // onPageSelected() never fires for the initial page - ViewPager only dispatches on a
+        // change - so page 0's state must be set explicitly, and last, so nothing triggered by
+        // the adapter swap can overwrite it.
+        this.imageViewPager.setAccessibilityState(
+                getImageContentDescription(appContext, inboxMessage, 0), 0, dotsCount);
 
-        this.clickLayout.setOnClickListener(
-                new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true, APP_INBOX_ITEM_INDEX));
+        CTInboxButtonClickListener bodyClickListener = new CTInboxButtonClickListener(position, inboxMessage, null,
+                parentWeak, this.imageViewPager, true, APP_INBOX_ITEM_INDEX);
+        this.clickLayout.setOnClickListener(bodyClickListener);
+        // The adapter hides each page from the accessibility tree, which also hides the page's
+        // own click listener. Without this a TalkBack user can page through the carousel but
+        // has no way to open the message.
+        this.imageViewPager.setAccessibilityClickAction(bodyClickListener);
 
         markItemAsRead(inboxMessage, position);
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselMessageViewHolder.java
@@ -65,6 +65,14 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
             viewHolder.message.setText(inboxMessage.getInboxMessageContents().get(position).getMessage());
             viewHolder.message.setTextColor(
                     Color.parseColor(inboxMessage.getInboxMessageContents().get(position).getMessageColor()));
+            int totalPages = inboxMessage.getInboxMessageContents().size();
+            String imageDesc = getImageContentDescription(context, inboxMessage, position);
+            String announcement = context.getString(R.string.ct_carousel_page_announcement,
+                    imageDesc, position + 1, totalPages);
+            viewHolder.imageViewPager.setContentDescription(
+                    context.getString(R.string.ct_carousel_content_description,
+                            imageDesc, position + 1, totalPages));
+            viewHolder.imageViewPager.announceForAccessibility(announcement);
         }
     }
 
@@ -74,6 +82,8 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
 
 
     private final LinearLayout sliderDots;
+
+    private CarouselPageChangeListener activePageChangeListener;
 
     private final TextView title;
 
@@ -123,6 +133,10 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
         CTCarouselViewPagerAdapter carouselViewPagerAdapter = new CTCarouselViewPagerAdapter(appContext, parent,
                 inboxMessage, layoutParams, position);
         this.imageViewPager.setAdapter(carouselViewPagerAdapter);
+        int itemCount = inboxMessage.getInboxMessageContents().size();
+        String firstImageDesc = getImageContentDescription(appContext, inboxMessage, 0);
+        this.imageViewPager.setContentDescription(
+                appContext.getString(R.string.ct_carousel_content_description, firstImageDesc, 1, itemCount));
         //Adds the dots for the carousel
         int dotsCount = inboxMessage.getInboxMessageContents().size();
         if (this.sliderDots.getChildCount() > 0) {
@@ -132,10 +146,12 @@ class CTCarouselMessageViewHolder extends CTInboxBaseMessageViewHolder {
         setDots(dots, dotsCount, appContext, this.sliderDots);
         dots[0].setImageDrawable(
                 ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_selected_dot, null));
-        CTCarouselMessageViewHolder.CarouselPageChangeListener carouselPageChangeListener
-                = new CTCarouselMessageViewHolder.CarouselPageChangeListener(
+        if (activePageChangeListener != null) {
+            this.imageViewPager.removeOnPageChangeListener(activePageChangeListener);
+        }
+        activePageChangeListener = new CTCarouselMessageViewHolder.CarouselPageChangeListener(
                 parent.getActivity().getApplicationContext(), this, dots, inboxMessage);
-        this.imageViewPager.addOnPageChangeListener(carouselPageChangeListener);
+        this.imageViewPager.addOnPageChangeListener(activePageChangeListener);
 
         this.clickLayout.setOnClickListener(
                 new CTInboxButtonClickListener(position, inboxMessage, null, parentWeak, this.imageViewPager,true, APP_INBOX_ITEM_INDEX));

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
@@ -1,17 +1,16 @@
 package com.clevertap.android.sdk.inbox;
 
 import android.content.Context;
-import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.View;
-import android.view.accessibility.AccessibilityEvent;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
-import androidx.core.view.AccessibilityDelegateCompat;
 import androidx.core.view.ViewCompat;
-import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat.AccessibilityActionCompat;
 import androidx.viewpager.widget.ViewPager;
+
 import com.clevertap.android.sdk.R;
 
 @RestrictTo(Scope.LIBRARY)
@@ -28,75 +27,69 @@ public class CTCarouselViewPager extends ViewPager {
     }
 
     private void setupAccessibility() {
-        setFocusable(true);
-        setFocusableInTouchMode(true);
+        // YES is load-bearing, not defensive. Under the default AUTO,
+        // View.includeForAccessibility() keeps a view only if it is actionable, has
+        // touch/hover listeners, exposes a node provider, or is a live region. A ViewPager is
+        // none of those - it consumes touch inside onTouchEvent() rather than through a
+        // listener - and contentDescription is NOT part of that test. So under AUTO the pager
+        // is dropped from the tree entirely and TalkBack skips the carousel even when a
+        // contentDescription has been set. This line is what fixes that.
         setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
-        final AccessibilityDelegateCompat originalDelegate = ViewCompat.getAccessibilityDelegate(this);
-        ViewCompat.setAccessibilityDelegate(this, new AccessibilityDelegateCompat() {
-            @Override
-            public void onInitializeAccessibilityNodeInfo(@NonNull View host,
-                    @NonNull AccessibilityNodeInfoCompat info) {
-                if (originalDelegate != null) {
-                    originalDelegate.onInitializeAccessibilityNodeInfo(host, info);
-                } else {
-                    super.onInitializeAccessibilityNodeInfo(host, info);
-                }
-                info.setClassName("android.widget.ScrollView");
-                if (getAdapter() != null && getAdapter().getCount() > 1) {
-                    info.setScrollable(true);
-                    if (getCurrentItem() < getAdapter().getCount() - 1) {
-                        info.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_SCROLL_FORWARD);
-                    }
-                    if (getCurrentItem() > 0) {
-                        info.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_SCROLL_BACKWARD);
-                    }
-                }
-            }
 
-            @Override
-            public void onInitializeAccessibilityEvent(@NonNull View host,
-                    @NonNull AccessibilityEvent event) {
-                if (originalDelegate != null) {
-                    originalDelegate.onInitializeAccessibilityEvent(host, event);
-                } else {
-                    super.onInitializeAccessibilityEvent(host, event);
-                }
-            }
+        // Present the pager as one atomic node instead of letting the reader dive into it.
+        // This is the ViewCompat equivalent of the old setFocusable() pair - and unlike them
+        // it describes screen-reader intent rather than input focus.
+        ViewCompat.setScreenReaderFocusable(this, true);
 
-            @Override
-            public boolean performAccessibilityAction(@NonNull View host, int action, Bundle args) {
-                if (action == AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD) {
-                    if (getAdapter() != null && getCurrentItem() < getAdapter().getCount() - 1) {
-                        setCurrentItem(getCurrentItem() + 1, true);
-                        restoreAccessibilityFocus();
-                        return true;
-                    }
-                } else if (action == AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD) {
-                    if (getCurrentItem() > 0) {
-                        setCurrentItem(getCurrentItem() - 1, true);
-                        restoreAccessibilityFocus();
-                        return true;
-                    }
-                }
-                if (originalDelegate != null) {
-                    return originalDelegate.performAccessibilityAction(host, action, args);
-                }
-                return super.performAccessibilityAction(host, action, args);
-            }
-        });
+        // Stable identity only. The part that changes per page (image alt text + "page x of y")
+        // is published as stateDescription by setAccessibilityState(), which TalkBack announces
+        // on its own - no interruptive announceForAccessibility() needed.
+        setContentDescription(getContext().getString(R.string.ct_carousel_label));
+
+        // Makes the node report isClickable() so TalkBack offers "double-tap to activate" for
+        // the ACTION_CLICK installed by setAccessibilityClickAction(). This does not change
+        // touch behaviour: ViewPager overrides onTouchEvent() without delegating to
+        // View.onTouchEvent(), so performClick() is never reached from a real touch.
+        setClickable(true);
     }
 
-    private void restoreAccessibilityFocus() {
-        postDelayed(() -> {
-            clearFocus();
-            requestFocus();
-            sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
-            ViewCompat.performAccessibilityAction(
-                    CTCarouselViewPager.this,
-                    AccessibilityNodeInfoCompat.ACTION_ACCESSIBILITY_FOCUS,
-                    null
-            );
-        }, 300);
+    /**
+     * Publishes the currently visible page to screen readers as a state change.
+     * <p>
+     * Call this on bind and from {@code OnPageChangeListener.onPageSelected}. Uses
+     * stateDescription rather than contentDescription so TalkBack announces the change itself
+     * and the carousel is not announced twice.
+     *
+     * @param pageDescription description of the current page's content
+     * @param position        zero-based index of the current page
+     * @param total           total number of pages
+     */
+    void setAccessibilityState(@NonNull CharSequence pageDescription, int position, int total) {
+        ViewCompat.setStateDescription(this, getContext().getString(
+                R.string.ct_carousel_position, pageDescription, position + 1, total));
+    }
+
+    /**
+     * Installs an accessibility-only {@code ACTION_CLICK} so a screen-reader user can open the
+     * carousel message.
+     * <p>
+     * Needed because the adapter hides each page from the accessibility tree, which also hides
+     * the per-page {@code OnClickListener}; without this the carousel can be paged through but
+     * never opened. Registered as an accessibility action rather than via
+     * {@code setOnClickListener} because ViewPager consumes the touch stream in
+     * {@code onTouchEvent()} and never calls {@code performClick()}.
+     *
+     * @param listener the same listener used for the row body click
+     */
+    void setAccessibilityClickAction(@NonNull final View.OnClickListener listener) {
+        ViewCompat.replaceAccessibilityAction(
+                this,
+                AccessibilityActionCompat.ACTION_CLICK,
+                getContext().getString(R.string.ct_carousel_open_message),
+                (view, arguments) -> {
+                    listener.onClick(view);
+                    return true;
+                });
     }
 
     @Override

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPager.java
@@ -1,35 +1,102 @@
 package com.clevertap.android.sdk.inbox;
 
 import android.content.Context;
+import android.os.Bundle;
 import android.util.AttributeSet;
 import android.view.View;
+import android.view.accessibility.AccessibilityEvent;
+import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
+import androidx.core.view.AccessibilityDelegateCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 import androidx.viewpager.widget.ViewPager;
+import com.clevertap.android.sdk.R;
 
-/**
- * Custom Viewpager class to handle orientation of images
- */
 @RestrictTo(Scope.LIBRARY)
 public class CTCarouselViewPager extends ViewPager {
 
-    /**
-     * Constructor
-     *
-     * @param context the context
-     */
     public CTCarouselViewPager(Context context) {
         super(context);
+        setupAccessibility();
     }
 
-    /**
-     * Constructor
-     *
-     * @param context the context
-     * @param attrs   the attribute set
-     */
     public CTCarouselViewPager(Context context, AttributeSet attrs) {
         super(context, attrs);
+        setupAccessibility();
+    }
+
+    private void setupAccessibility() {
+        setFocusable(true);
+        setFocusableInTouchMode(true);
+        setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
+        final AccessibilityDelegateCompat originalDelegate = ViewCompat.getAccessibilityDelegate(this);
+        ViewCompat.setAccessibilityDelegate(this, new AccessibilityDelegateCompat() {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(@NonNull View host,
+                    @NonNull AccessibilityNodeInfoCompat info) {
+                if (originalDelegate != null) {
+                    originalDelegate.onInitializeAccessibilityNodeInfo(host, info);
+                } else {
+                    super.onInitializeAccessibilityNodeInfo(host, info);
+                }
+                info.setClassName("android.widget.ScrollView");
+                if (getAdapter() != null && getAdapter().getCount() > 1) {
+                    info.setScrollable(true);
+                    if (getCurrentItem() < getAdapter().getCount() - 1) {
+                        info.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_SCROLL_FORWARD);
+                    }
+                    if (getCurrentItem() > 0) {
+                        info.addAction(AccessibilityNodeInfoCompat.AccessibilityActionCompat.ACTION_SCROLL_BACKWARD);
+                    }
+                }
+            }
+
+            @Override
+            public void onInitializeAccessibilityEvent(@NonNull View host,
+                    @NonNull AccessibilityEvent event) {
+                if (originalDelegate != null) {
+                    originalDelegate.onInitializeAccessibilityEvent(host, event);
+                } else {
+                    super.onInitializeAccessibilityEvent(host, event);
+                }
+            }
+
+            @Override
+            public boolean performAccessibilityAction(@NonNull View host, int action, Bundle args) {
+                if (action == AccessibilityNodeInfoCompat.ACTION_SCROLL_FORWARD) {
+                    if (getAdapter() != null && getCurrentItem() < getAdapter().getCount() - 1) {
+                        setCurrentItem(getCurrentItem() + 1, true);
+                        restoreAccessibilityFocus();
+                        return true;
+                    }
+                } else if (action == AccessibilityNodeInfoCompat.ACTION_SCROLL_BACKWARD) {
+                    if (getCurrentItem() > 0) {
+                        setCurrentItem(getCurrentItem() - 1, true);
+                        restoreAccessibilityFocus();
+                        return true;
+                    }
+                }
+                if (originalDelegate != null) {
+                    return originalDelegate.performAccessibilityAction(host, action, args);
+                }
+                return super.performAccessibilityAction(host, action, args);
+            }
+        });
+    }
+
+    private void restoreAccessibilityFocus() {
+        postDelayed(() -> {
+            clearFocus();
+            requestFocus();
+            sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_FOCUSED);
+            ViewCompat.performAccessibilityAction(
+                    CTCarouselViewPager.this,
+                    AccessibilityNodeInfoCompat.ACTION_ACCESSIBILITY_FOCUS,
+                    null
+            );
+        }, 300);
     }
 
     @Override
@@ -49,32 +116,5 @@ public class CTCarouselViewPager extends ViewPager {
         }
 
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-    }
-
-    /**
-     * Determines the height of this view
-     *
-     * @param measureSpec A measureSpec packed into an int
-     * @param view        the base view with already measured height
-     * @return The height of the view, honoring constraints from measureSpec
-     */
-    @SuppressWarnings({"unused"})
-    private int measureHeight(int measureSpec, View view) {
-        int result = 0;
-        int specMode = MeasureSpec.getMode(measureSpec);
-        int specSize = MeasureSpec.getSize(measureSpec);
-
-        if (specMode == MeasureSpec.EXACTLY) {
-            result = specSize;
-        } else {
-            // set the height from the base view if available
-            if (view != null) {
-                result = view.getMeasuredHeight();
-            }
-            if (specMode == MeasureSpec.AT_MOST) {
-                result = Math.min(result, specSize);
-            }
-        }
-        return result;
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPagerAdapter.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTCarouselViewPagerAdapter.java
@@ -94,11 +94,8 @@ public class CTCarouselViewPagerAdapter extends PagerAdapter {
 
     void addImageAndSetClick(ImageView imageView, View view, final int position, ViewGroup container) {
         imageView.setVisibility(View.VISIBLE);
-        String contentDescription = carouselImagesData.get(position).getContentDescription();
-        if (contentDescription.isEmpty()) {
-            contentDescription = context.getString(R.string.ct_inbox_image_content_description) + (position + 1);
-        }
-        imageView.setContentDescription(contentDescription);
+        imageView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+        view.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
         try {
             Glide.with(imageView.getContext())
                     .load(carouselImagesData.get(position).getUrl())

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTIconMessageViewHolder.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.Logger;
+import androidx.core.view.ViewCompat;
 import com.clevertap.android.sdk.R;
 import com.clevertap.android.sdk.Utils;
 import org.json.JSONArray;
@@ -67,6 +68,10 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
         ctaLinearLayout = itemView.findViewById(R.id.cta_linear_layout);
         progressBarFrameLayout = itemView.findViewById(R.id.icon_progress_frame_layout);
         mediaLayout = itemView.findViewById(R.id.media_layout);
+
+        ViewCompat.setScreenReaderFocusable(title, true);
+        ViewCompat.setScreenReaderFocusable(message, true);
+        ViewCompat.setScreenReaderFocusable(timestamp, true);
     }
 
     @Override
@@ -145,6 +150,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         this.cta3.setText(content.getLinkText(cta3Object));
                         this.cta3.setTextColor(Color.parseColor(content.getLinkColor(cta3Object)));
                         this.cta3.setBackgroundColor(Color.parseColor(content.getLinkBGColor(cta3Object)));
+                        showThreeButtons(this.cta1, this.cta2, this.cta3);
                         if (parentWeak != null) {
                             this.cta1.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
                                     this.cta1.getText().toString(), cta1Object, parentWeak,false, APP_INBOX_CTA1_INDEX));
@@ -164,11 +170,18 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
 
         this.mediaImage.setVisibility(View.GONE);
         this.mediaImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.mediaImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.mediaImage, false);
         this.squareImage.setVisibility(View.GONE);
         this.squareImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.squareImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.squareImage, false);
         this.defaultImage.setVisibility(View.GONE);
         this.defaultImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.defaultImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.defaultImage, false);
+        this.iconImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.iconImage, false);
         this.mediaLayout.setVisibility(View.GONE);
         this.progressBarFrameLayout.setVisibility(View.GONE);
         try {
@@ -176,6 +189,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "l":
                     if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.mediaImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.mediaImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -267,6 +281,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "p":
                     if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.squareImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.squareImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -368,6 +383,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                     if (!TextUtils.isEmpty(content.getMedia())) {
                         if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                             this.defaultImage.setContentDescription(content.getMediaContentDescription());
+                            ViewCompat.setScreenReaderFocusable(this.defaultImage, true);
                         }
                         if (content.mediaIsImage()) {
                             this.mediaLayout.setVisibility(View.VISIBLE);
@@ -485,6 +501,7 @@ class CTIconMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 iconImage.setVisibility(View.VISIBLE);
                 if (!content.getIconContentDescription().isEmpty()) {
                     iconImage.setContentDescription(content.getIconContentDescription());
+                    ViewCompat.setScreenReaderFocusable(iconImage, true);
                 }
                 try {
                     Glide.with(iconImage.getContext())

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTInboxBaseMessageViewHolder.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
 import androidx.core.content.res.ResourcesCompat;
+import androidx.core.view.ViewCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import com.clevertap.android.sdk.R;
 import java.lang.ref.WeakReference;
@@ -134,9 +135,11 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
             // Initial state setup
             setMuteIconState(muteIcon, context, currentVolume);
 
-            int iconWidth = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30, displayMetrics);
-            int iconHeight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 30, displayMetrics);
-            FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(iconWidth, iconHeight);
+            // 48dp tap target; 9dp padding keeps the visual icon at 30dp
+            int iconSize = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 48, displayMetrics);
+            int iconPadding = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 9, displayMetrics);
+            muteIcon.setPadding(iconPadding, iconPadding, iconPadding, iconPadding);
+            FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(iconSize, iconSize);
             int iconTop = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 4, displayMetrics);
             int iconRight = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 2, displayMetrics);
             layoutParams.setMargins(0, iconTop, iconRight, 0);
@@ -158,8 +161,9 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
     private void setMuteIconState(ImageView icon, Context context, float volume) {
         boolean isMuted = volume <= 0;
         int drawableRes = isMuted ? R.drawable.ct_volume_off : R.drawable.ct_volume_on;
-        int contentDescRes = isMuted ? R.string.ct_mute_button_content_description
-                : R.string.ct_unmute_button_content_description;
+        // When muted, the action available is "Unmute"; when audible, the action is "Mute"
+        int contentDescRes = isMuted ? R.string.ct_unmute_button_content_description
+                : R.string.ct_mute_button_content_description;
 
         icon.setContentDescription(context.getString(contentDescRes));
         icon.setImageDrawable(ResourcesCompat.getDrawable(context.getResources(), drawableRes, null));
@@ -216,6 +220,12 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
         tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 0));
     }
 
+    void showThreeButtons(Button mainButton, Button secondaryButton, Button tertiaryButton) {
+        mainButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 2));
+        secondaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 2));
+        tertiaryButton.setLayoutParams(new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 2));
+    }
+
     void hideTwoButtons(Button mainButton, Button secondaryButton, Button tertiaryButton) {
         secondaryButton.setVisibility(View.GONE);
         tertiaryButton.setVisibility(View.GONE);
@@ -259,12 +269,21 @@ public class CTInboxBaseMessageViewHolder extends RecyclerView.ViewHolder {
         }
     }
 
+    String getImageContentDescription(Context context, CTInboxMessage inboxMessage, int position) {
+        String desc = inboxMessage.getInboxMessageContents().get(position).getMediaContentDescription();
+        if (desc == null || desc.isEmpty()) {
+            desc = context.getString(R.string.ct_inbox_image_content_description) + " " + (position + 1);
+        }
+        return desc;
+    }
+
     void setDots(ImageView[] dots, int dotsCount, Context appContext, LinearLayout sliderDots) {
         for (int k = 0; k < dotsCount; k++) {
             dots[k] = new ImageView(appContext);
             dots[k].setVisibility(View.VISIBLE);
             dots[k].setImageDrawable(
                     ResourcesCompat.getDrawable(appContext.getResources(), R.drawable.ct_unselected_dot, null));
+            ViewCompat.setImportantForAccessibility(dots[k], ViewCompat.IMPORTANT_FOR_ACCESSIBILITY_NO);
             LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.WRAP_CONTENT,
                     LinearLayout.LayoutParams.WRAP_CONTENT);
             params.setMargins(8, 6, 4, 6);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inbox/CTSimpleMessageViewHolder.java
@@ -19,6 +19,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.RequestOptions;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.Logger;
+import androidx.core.view.ViewCompat;
 import com.clevertap.android.sdk.R;
 import com.clevertap.android.sdk.Utils;
 import org.json.JSONArray;
@@ -141,6 +142,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                         this.cta3.setText(content.getLinkText(cta3Object));
                         this.cta3.setTextColor(Color.parseColor(content.getLinkColor(cta3Object)));
                         this.cta3.setBackgroundColor(Color.parseColor(content.getLinkBGColor(cta3Object)));
+                        showThreeButtons(this.cta1, this.cta2, this.cta3);
                         if (parentWeak != null) {
                             this.cta1.setOnClickListener(new CTInboxButtonClickListener(position, inboxMessage,
                                     this.cta1.getText().toString(), cta1Object, parentWeak,false, APP_INBOX_CTA1_INDEX));
@@ -159,11 +161,16 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
         }
         this.mediaImage.setVisibility(View.GONE);
         this.mediaImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.mediaImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.mediaImage, false);
         this.squareImage.setVisibility(View.GONE);
         this.squareImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
+        this.squareImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.squareImage, false);
         this.defaultImage.setVisibility(View.GONE);
         this.defaultImage.setBackgroundColor(Color.parseColor(inboxMessage.getBgColor()));
         this.defaultImage.setContentDescription(null);
+        ViewCompat.setScreenReaderFocusable(this.defaultImage, false);
         this.mediaLayout.setVisibility(View.GONE);
         this.progressBarFrameLayout.setVisibility(View.GONE);
         try {
@@ -171,6 +178,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "l":
                     if(!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.mediaImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.mediaImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -261,6 +269,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                 case "p":
                     if(!TextUtils.isEmpty(content.getMediaContentDescription())) {
                         this.squareImage.setContentDescription(content.getMediaContentDescription());
+                        ViewCompat.setScreenReaderFocusable(this.squareImage, true);
                     }
                     if (content.mediaIsImage()) {
                         this.mediaLayout.setVisibility(View.VISIBLE);
@@ -359,6 +368,7 @@ class CTSimpleMessageViewHolder extends CTInboxBaseMessageViewHolder {
                     if (!TextUtils.isEmpty(content.getMedia())) {
                         if (!TextUtils.isEmpty(content.getMediaContentDescription())) {
                             this.defaultImage.setContentDescription(content.getMediaContentDescription());
+                            ViewCompat.setScreenReaderFocusable(this.defaultImage, true);
                         }
                         if (content.mediaIsImage()) {
                             this.mediaLayout.setVisibility(View.VISIBLE);

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/Media3PlayerListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/video/inbox/Media3PlayerListener.kt
@@ -1,12 +1,21 @@
 package com.clevertap.android.sdk.video.inbox
 
-import androidx.media3.common.*
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.DeviceInfo
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Metadata
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+import androidx.media3.common.TrackSelectionParameters
+import androidx.media3.common.Tracks
+import androidx.media3.common.VideoSize
 import androidx.media3.common.text.Cue
 import androidx.media3.common.text.CueGroup
 import androidx.media3.common.util.UnstableApi
 
-
-@UnstableApi
 /**
  * This class addresses an AbstractMethodError because of the Java 8 feature of default methods in interfaces.
  * Default methods are somewhat not supported if minSDKVersion < 24
@@ -14,10 +23,11 @@ import androidx.media3.common.util.UnstableApi
 open class Media3PlayerListener : Player.Listener {
     override fun onSurfaceSizeChanged(width: Int, height: Int) {}
     override fun onRenderedFirstFrame() {}
-    @Deprecated("Deprecated in Java")
+
+    @UnstableApi @Deprecated("Deprecated in Java")
     override fun onCues(cues: MutableList<Cue>) {}
     override fun onCues(cueGroup: CueGroup) {}
-    override fun onMetadata(metadata: Metadata) {}
+    @UnstableApi override fun onMetadata(metadata: Metadata) {}
     override fun onEvents(player: Player, events: Player.Events) {}
     override fun onTimelineChanged(timeline: Timeline, reason: Int) {}
     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {}
@@ -25,8 +35,16 @@ open class Media3PlayerListener : Player.Listener {
     override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {}
     override fun onPlaylistMetadataChanged(mediaMetadata: MediaMetadata) {}
     override fun onIsLoadingChanged(isLoading: Boolean) {}
+    @UnstableApi @Deprecated("Deprecated in Java")
+    override fun onLoadingChanged(isLoading: Boolean) {}
+
     override fun onAvailableCommandsChanged(availableCommands: Player.Commands) {}
     override fun onTrackSelectionParametersChanged(parameters: TrackSelectionParameters) {}
+    @UnstableApi @Deprecated("Deprecated in Java")
+    override fun onPlayerStateChanged(playWhenReady: Boolean, playbackState: Int) {}
+
+    override fun onPlaybackStateChanged(playbackState: Int) {}
+
     override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {}
     override fun onPlaybackSuppressionReasonChanged(playbackSuppressionReason: Int) {}
     override fun onIsPlayingChanged(isPlaying: Boolean) {}
@@ -34,6 +52,9 @@ open class Media3PlayerListener : Player.Listener {
     override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {}
     override fun onPlayerError(error: PlaybackException) {}
     override fun onPlayerErrorChanged(error: PlaybackException?) {}
+    @UnstableApi @Deprecated("Deprecated in Java")
+    override fun onPositionDiscontinuity(reason: Int) {}
+
     override fun onPositionDiscontinuity(
         oldPosition: Player.PositionInfo,
         newPosition: Player.PositionInfo,
@@ -43,7 +64,7 @@ open class Media3PlayerListener : Player.Listener {
     override fun onSeekBackIncrementChanged(seekBackIncrementMs: Long) {}
     override fun onSeekForwardIncrementChanged(seekForwardIncrementMs: Long) {}
     override fun onMaxSeekToPreviousPositionChanged(maxSeekToPreviousPositionMs: Long) {}
-    override fun onAudioSessionIdChanged(audioSessionId: Int) {}
+    @UnstableApi override fun onAudioSessionIdChanged(audioSessionId: Int) {}
     override fun onAudioAttributesChanged(audioAttributes: AudioAttributes) {}
     override fun onVolumeChanged(volume: Float) {}
     override fun onSkipSilenceEnabledChanged(skipSilenceEnabled: Boolean) {}

--- a/clevertap-core/src/main/res/layout-land/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="30sp"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -58,8 +55,7 @@
             android:gravity="center"
             android:maxLines="2"
             android:textColor="@android:color/black"
-            android:textSize="22sp"
-            android:focusable="true" />
+            android:textSize="22sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"
@@ -92,8 +88,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="10dp"
         android:layout_marginTop="10dp"

--- a/clevertap-core/src/main/res/layout-land/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,14 +36,13 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="10dp"
         android:layout_marginTop="10dp"

--- a/clevertap-core/src/main/res/layout-land/inapp_footer.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_footer.xml
@@ -14,8 +14,7 @@
             android:id="@+id/footer_linear_layout_1"
             android:layout_width="match_parent"
             android:layout_height="118dp"
-            android:orientation="horizontal"
-            android:focusable="true" >
+            android:orientation="horizontal" >
 
             <FrameLayout
                 android:id="@+id/footer_media_container"
@@ -29,7 +28,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -38,7 +36,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -43,8 +41,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -60,8 +57,7 @@
             android:gravity="center"
             android:maxLines="3"
             android:textColor="@android:color/black"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"
@@ -99,8 +95,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_half_interstitial_image.xml
@@ -28,7 +28,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,15 +37,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_header.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_header.xml
@@ -13,8 +13,7 @@
             android:id="@+id/header_linear_layout_1"
             android:layout_width="match_parent"
             android:layout_height="118dp"
-            android:orientation="horizontal"
-            android:focusable="true">
+            android:orientation="horizontal">
 
             <FrameLayout
                 android:id="@+id/header_media_container"
@@ -28,7 +27,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -37,7 +35,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_interstitial.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:focusable="true"
         android:layout_margin="35dp">
 
         <TextView
@@ -111,8 +110,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-land/inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,15 +40,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-land/inbox_carousel_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_carousel_layout.xml
@@ -49,7 +49,8 @@
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="10dp"
                     android:layout_marginRight="10dp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
                 <ImageView
                     android:id="@+id/read_circle"
@@ -60,6 +61,8 @@
                     android:layout_marginLeft="10dp"
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
+                    android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                    android:importantForAccessibility="yes"
                     android:src="@drawable/ct_read_circle" />
             </LinearLayout>
         </RelativeLayout>

--- a/clevertap-core/src/main/res/layout-land/inbox_carousel_text_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_carousel_text_layout.xml
@@ -39,6 +39,7 @@
                     android:layout_marginTop="10dp"
                     android:maxLines="2"
                     android:textColor="@android:color/black"
+                    android:textSize="@dimen/ct_inbox_title_text_size"
                     android:textStyle="bold" />
 
                 <TextView
@@ -51,7 +52,8 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_body_text_size" />
 
                 <RelativeLayout
                     android:id="@+id/timestamp_linear_layout"
@@ -81,7 +83,8 @@
                             android:layout_height="wrap_content"
                             android:layout_marginEnd="10dp"
                             android:layout_marginRight="10dp"
-                            android:textColor="@android:color/darker_gray" />
+                            android:textColor="@android:color/darker_gray"
+                        android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
                         <ImageView
                             android:id="@+id/read_circle"
@@ -92,6 +95,8 @@
                             android:layout_marginLeft="10dp"
                             android:layout_marginRight="20dp"
                             android:layout_marginStart="10dp"
+                            android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                            android:importantForAccessibility="yes"
                             android:src="@drawable/ct_read_circle" />
                     </LinearLayout>
                 </RelativeLayout>
@@ -113,9 +118,10 @@
                 android:layout_height="match_parent"
                 android:layout_weight="2"
                 android:background="@android:color/white"
+                android:importantForAccessibility="yes"
                 android:padding="2dp"
                 android:textColor="@android:color/holo_blue_light"
-                android:textSize="14sp"
+                android:textSize="@dimen/ct_inbox_cta_button_text_size"
                 android:visibility="gone" />
 
             <Button
@@ -124,9 +130,10 @@
                 android:layout_height="match_parent"
                 android:layout_weight="2"
                 android:background="@android:color/white"
+                android:importantForAccessibility="yes"
                 android:padding="2dp"
                 android:textColor="@android:color/holo_blue_light"
-                android:textSize="14sp"
+                android:textSize="@dimen/ct_inbox_cta_button_text_size"
                 android:visibility="gone" />
 
             <Button
@@ -135,9 +142,10 @@
                 android:layout_height="match_parent"
                 android:layout_weight="2"
                 android:background="@android:color/white"
+                android:importantForAccessibility="yes"
                 android:padding="2dp"
                 android:textColor="@android:color/holo_blue_light"
-                android:textSize="14sp"
+                android:textSize="@dimen/ct_inbox_cta_button_text_size"
                 android:visibility="gone" />
         </LinearLayout>
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout-land/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_icon_message_layout.xml
@@ -27,7 +27,7 @@
                     android:layout_height="wrap_content"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+
                     android:visibility="gone" />
 
                 <com.clevertap.android.sdk.customviews.HorizontalSquareImageView
@@ -37,7 +37,7 @@
                     android:layout_centerInParent="true"
                     android:scaleType="centerCrop"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+
                     android:visibility="gone" />
 
                 <ImageView
@@ -47,7 +47,7 @@
                     android:adjustViewBounds="true"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+
                     android:visibility="gone" />
 
                 <FrameLayout
@@ -98,7 +98,7 @@
                         android:layout_marginStart="8dp"
                         android:layout_marginTop="8dp"
                         android:contentDescription="@string/ct_inbox_icon_content_description"
-                        android:focusable="true"
+    
                         android:scaleType="fitCenter" />
 
                     <TextView
@@ -111,8 +111,9 @@
                         android:layout_marginStart="10dp"
                         android:layout_marginTop="10dp"
                         android:maxLines="2"
-                        android:focusable="true"
+    
                         android:textColor="@android:color/black"
+                        android:textSize="@dimen/ct_inbox_title_text_size"
                         android:textStyle="bold" />
 
                 </LinearLayout>
@@ -127,8 +128,9 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:focusable="true"
-                    android:textColor="@android:color/darker_gray" />
+
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_body_text_size" />
             </RelativeLayout>
         </LinearLayout>
 
@@ -148,8 +150,8 @@
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
                 android:gravity="end"
-                android:focusable="true"
-                android:textColor="@android:color/darker_gray" />
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
             <ImageView
                 android:id="@+id/read_circle"
@@ -158,6 +160,8 @@
                 android:layout_gravity="center"
                 android:layout_marginEnd="20dp"
                 android:layout_marginRight="20dp"
+                android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                android:importantForAccessibility="yes"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
 
@@ -184,9 +188,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -195,9 +200,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -206,9 +212,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
     </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-land/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout-land/inbox_simple_message_layout.xml
@@ -28,7 +28,6 @@
                     android:layout_height="wrap_content"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
                     android:visibility="gone" />
 
                 <com.clevertap.android.sdk.customviews.HorizontalSquareImageView
@@ -38,7 +37,7 @@
                     android:layout_centerInParent="true"
                     android:scaleType="centerCrop"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+
                     android:visibility="gone" />
 
                 <ImageView
@@ -48,7 +47,7 @@
                     android:adjustViewBounds="true"
                     android:scaleType="fitCenter"
                     android:contentDescription="@string/ct_inbox_media_content_description"
-                    android:focusable="true"
+
                     android:visibility="gone" />
 
                 <FrameLayout
@@ -90,6 +89,7 @@
                     android:layout_marginTop="10dp"
                     android:maxLines="2"
                     android:textColor="@android:color/black"
+                    android:textSize="@dimen/ct_inbox_title_text_size"
                     android:textStyle="bold" />
 
 
@@ -103,7 +103,8 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_body_text_size" />
             </RelativeLayout>
         </LinearLayout>
 
@@ -123,7 +124,8 @@
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
                 android:gravity="end"
-                android:textColor="@android:color/darker_gray" />
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
             <ImageView
                 android:id="@+id/read_circle"
@@ -132,6 +134,8 @@
                 android:layout_gravity="center"
                 android:layout_marginEnd="20dp"
                 android:layout_marginRight="20dp"
+                android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                android:importantForAccessibility="yes"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
 
@@ -157,9 +161,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -168,9 +173,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -179,9 +185,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
     </LinearLayout>
 

--- a/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="2"
             android:textColor="@android:color/black"
             android:textSize="40sp"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -57,8 +54,7 @@
             android:layout_marginTop="40dp"
             android:gravity="center"
             android:textColor="@android:color/black"
-            android:textSize="24sp"
-            android:focusable="true" />
+            android:textSize="24sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"
@@ -93,8 +89,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginRight="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,14 +36,13 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginTop="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -43,8 +41,7 @@
             android:maxLines="1"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -59,8 +56,7 @@
             android:layout_marginTop="36dp"
             android:gravity="center"
             android:maxLines="3"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"
@@ -99,8 +95,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_half_interstitial_image.xml
@@ -28,7 +28,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,15 +37,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:focusable="true"
         android:layout_margin="40dp">
 
         <TextView
@@ -111,8 +110,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp-land/tab_inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,15 +40,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="2"
             android:textColor="@android:color/black"
             android:textSize="30sp"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -53,8 +50,7 @@
             android:layout_marginTop="80dp"
             android:gravity="center"
             android:textColor="@android:color/black"
-            android:textSize="18sp"
-            android:focusable="true" />
+            android:textSize="18sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"
@@ -88,8 +84,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginTop="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,14 +36,13 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="12dp"
         android:layout_marginTop="12dp"

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -42,8 +40,7 @@
             android:gravity="center"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -53,8 +50,7 @@
             android:layout_centerHorizontal="true"
             android:layout_marginTop="30dp"
             android:gravity="center"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"
@@ -89,8 +85,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_half_interstitial_image.xml
@@ -29,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -39,15 +38,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:focusable="true"
         android:layout_margin="40dp">
 
         <TextView
@@ -103,8 +102,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout-sw600dp/tab_inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,15 +40,14 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover.xml
@@ -17,8 +17,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true" />
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -28,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -41,8 +39,7 @@
             android:maxLines="2"
             android:textColor="@android:color/black"
             android:textSize="30sp"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/cover_message"
@@ -53,8 +50,7 @@
             android:layout_marginTop="40dp"
             android:gravity="center"
             android:textColor="@android:color/black"
-            android:textSize="18sp"
-            android:focusable="true" />
+            android:textSize="18sp" />
 
         <LinearLayout
             android:id="@+id/cover_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_cover.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover.xml
@@ -88,8 +88,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="10dp"
         android:layout_marginRight="10dp"

--- a/clevertap-core/src/main/res/layout/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover_image.xml
@@ -27,7 +27,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -37,7 +36,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
     </RelativeLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_cover_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_cover_image.xml
@@ -43,8 +43,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="10dp"
         android:layout_marginTop="10dp"

--- a/clevertap-core/src/main/res/layout/inapp_footer.xml
+++ b/clevertap-core/src/main/res/layout/inapp_footer.xml
@@ -14,8 +14,7 @@
             android:id="@+id/footer_linear_layout_1"
             android:layout_width="match_parent"
             android:layout_height="118dp"
-            android:orientation="horizontal"
-            android:focusable="true" >
+            android:orientation="horizontal" >
 
             <FrameLayout
                 android:id="@+id/footer_media_container"
@@ -29,7 +28,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -38,7 +36,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
                     android:visibility="gone" />
             </FrameLayout>
 

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
@@ -89,8 +89,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial.xml
@@ -19,8 +19,7 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:scaleType="centerCrop"
-            android:focusable="true"/>
+            android:scaleType="centerCrop" />
 
         <com.clevertap.android.sdk.gif.GifImageView
             android:id="@+id/gifImage"
@@ -30,7 +29,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <TextView
@@ -42,8 +40,7 @@
             android:gravity="center"
             android:textColor="@android:color/black"
             android:textSize="@dimen/txt_size_inapp_half_title"
-            android:textStyle="bold"
-            android:focusable="true" />
+            android:textStyle="bold" />
 
         <TextView
             android:id="@+id/half_interstitial_message"
@@ -53,8 +50,7 @@
             android:layout_centerHorizontal="true"
             android:layout_marginTop="20dp"
             android:gravity="center"
-            android:textSize="@dimen/txt_size_inapp_half_message"
-            android:focusable="true" />
+            android:textSize="@dimen/txt_size_inapp_half_message" />
 
         <LinearLayout
             android:id="@+id/half_interstitial_linear_layout"

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
@@ -45,8 +45,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_half_interstitial_image.xml
@@ -28,7 +28,6 @@
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -38,7 +37,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentStart="true"
             android:layout_alignParentTop="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inapp_header.xml
+++ b/clevertap-core/src/main/res/layout/inapp_header.xml
@@ -13,8 +13,7 @@
             android:id="@+id/header_linear_layout_1"
             android:layout_width="match_parent"
             android:layout_height="118dp"
-            android:orientation="horizontal"
-            android:focusable="true">
+            android:orientation="horizontal">
 
             <FrameLayout
                 android:id="@+id/header_media_container"
@@ -28,7 +27,6 @@
                     android:contentDescription="@string/ct_inapp_img"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:focusable="true"
                     android:scaleType="fitCenter" />
 
                 <com.clevertap.android.sdk.gif.GifImageView
@@ -37,7 +35,6 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="fitCenter"
-                    android:focusable="true"
                     android:visibility="gone" />
 
             </FrameLayout>

--- a/clevertap-core/src/main/res/layout/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial.xml
@@ -103,8 +103,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:adjustViewBounds="true" />
 </FrameLayout>

--- a/clevertap-core/src/main/res/layout/inapp_interstitial.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial.xml
@@ -11,7 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="center"
-        android:focusable="true"
         android:layout_margin="35dp">
 
         <TextView

--- a/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
@@ -48,8 +48,8 @@
 
     <com.clevertap.android.sdk.customviews.CloseImageView
         android:contentDescription="@string/ct_inapp_close_btn"
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_gravity="top|end"
         android:layout_marginEnd="30dp"
         android:layout_marginTop="45dp"

--- a/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
+++ b/clevertap-core/src/main/res/layout/inapp_interstitial_image.xml
@@ -31,7 +31,6 @@
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
             android:scaleType="centerCrop"
-            android:focusable="true"
             android:visibility="gone" />
 
         <FrameLayout
@@ -41,7 +40,6 @@
             android:layout_height="match_parent"
             android:layout_alignParentTop="true"
             android:layout_centerHorizontal="true"
-            android:focusable="true"
             android:visibility="gone" />
 
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inbox_carousel_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_carousel_layout.xml
@@ -47,7 +47,8 @@
                     android:layout_marginRight="5dp"
                     android:gravity="end"
                     android:text="timestamp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
                 <ImageView
                     android:id="@+id/read_circle"
@@ -56,6 +57,8 @@
                     android:layout_gravity="center"
                     android:layout_marginEnd="20dp"
                     android:layout_marginRight="20dp"
+                    android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                    android:importantForAccessibility="yes"
                     android:src="@drawable/ct_read_circle" />
             </LinearLayout>
         </LinearLayout>

--- a/clevertap-core/src/main/res/layout/inbox_carousel_text_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_carousel_text_layout.xml
@@ -45,6 +45,7 @@
             android:layout_marginTop="20dp"
             android:maxLines="1"
             android:textColor="@android:color/black"
+            android:textSize="@dimen/ct_inbox_title_text_size"
             android:textStyle="bold" />
 
         <TextView
@@ -57,7 +58,8 @@
             android:layout_marginRight="20dp"
             android:layout_marginStart="20dp"
             android:layout_marginTop="5dp"
-            android:textColor="@android:color/darker_gray" />
+            android:textColor="@android:color/darker_gray"
+            android:textSize="@dimen/ct_inbox_body_text_size" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -75,7 +77,8 @@
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
                 android:gravity="end"
-                android:textColor="@android:color/darker_gray" />
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
             <ImageView
                 android:id="@+id/read_circle"
@@ -84,6 +87,8 @@
                 android:layout_gravity="center"
                 android:layout_marginEnd="20dp"
                 android:layout_marginRight="20dp"
+                android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                android:importantForAccessibility="yes"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
     </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_icon_message_layout.xml
@@ -29,7 +29,6 @@
                 android:layout_marginStart="8dp"
                 android:layout_marginTop="8dp"
                 android:contentDescription="@string/ct_inbox_icon_content_description"
-                android:focusable="true"
                 android:scaleType="fitCenter" />
 
             <LinearLayout
@@ -49,6 +48,7 @@
                     android:layout_marginTop="10dp"
                     android:maxLines="1"
                     android:textColor="@android:color/black"
+                    android:textSize="@dimen/ct_inbox_title_text_size"
                     android:textStyle="bold" />
 
                 <TextView
@@ -60,7 +60,8 @@
                     android:layout_marginRight="20dp"
                     android:layout_marginStart="10dp"
                     android:layout_marginTop="5dp"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_body_text_size" />
             </LinearLayout>
         </LinearLayout>
 
@@ -75,7 +76,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.customviews.SquareImageView
@@ -83,7 +84,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+
                 android:visibility="gone" />
 
             <ImageView
@@ -93,7 +94,7 @@
                 android:adjustViewBounds="true"
                 android:scaleType="fitCenter"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+
                 android:visibility="gone" />
 
             <FrameLayout
@@ -112,6 +113,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal|center_vertical"
+                    android:importantForAccessibility="no"
                     android:visibility="visible" />
             </FrameLayout>
         </RelativeLayout>
@@ -131,7 +133,8 @@
                 android:layout_marginEnd="10dp"
                 android:layout_marginRight="10dp"
                 android:gravity="end"
-                android:textColor="@android:color/darker_gray" />
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
             <ImageView
                 android:id="@+id/read_circle"
@@ -140,6 +143,8 @@
                 android:layout_gravity="center"
                 android:layout_marginEnd="20dp"
                 android:layout_marginRight="20dp"
+                android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                android:importantForAccessibility="yes"
                 android:src="@drawable/ct_read_circle" />
         </LinearLayout>
 
@@ -166,9 +171,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="visible" />
 
         <Button
@@ -177,9 +183,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -188,9 +195,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
     </LinearLayout>
 </RelativeLayout>

--- a/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
+++ b/clevertap-core/src/main/res/layout/inbox_simple_message_layout.xml
@@ -22,7 +22,6 @@
                 android:layout_height="wrap_content"
                 android:scaleType="centerCrop"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
                 android:visibility="gone" />
 
             <com.clevertap.android.sdk.customviews.SquareImageView
@@ -31,7 +30,7 @@
                 android:layout_height="wrap_content"
                 android:scaleType="centerCrop"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+
                 android:visibility="gone" />
 
             <ImageView
@@ -41,7 +40,7 @@
                 android:adjustViewBounds="true"
                 android:scaleType="fitCenter"
                 android:contentDescription="@string/ct_inbox_media_content_description"
-                android:focusable="true"
+
                 android:visibility="gone" />
 
             <FrameLayout
@@ -60,6 +59,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal|center_vertical"
+                    android:importantForAccessibility="no"
                     android:visibility="visible" />
             </FrameLayout>
         </RelativeLayout>
@@ -83,6 +83,7 @@
                 android:layout_marginTop="20dp"
                 android:maxLines="1"
                 android:textColor="@android:color/black"
+                android:textSize="@dimen/ct_inbox_title_text_size"
                 android:textStyle="bold" />
 
             <TextView
@@ -94,7 +95,8 @@
                 android:layout_marginRight="20dp"
                 android:layout_marginStart="20dp"
                 android:layout_marginTop="5dp"
-                android:textColor="@android:color/darker_gray" />
+                android:textColor="@android:color/darker_gray"
+                android:textSize="@dimen/ct_inbox_body_text_size" />
 
             <LinearLayout
                 android:id="@+id/timestamp_linear_layout"
@@ -112,7 +114,8 @@
                     android:layout_marginEnd="10dp"
                     android:layout_marginRight="10dp"
                     android:gravity="end"
-                    android:textColor="@android:color/darker_gray" />
+                    android:textColor="@android:color/darker_gray"
+                    android:textSize="@dimen/ct_inbox_timestamp_text_size" />
 
                 <ImageView
                     android:id="@+id/read_circle"
@@ -121,6 +124,8 @@
                     android:layout_gravity="center"
                     android:layout_marginEnd="20dp"
                     android:layout_marginRight="20dp"
+                    android:contentDescription="@string/ct_inbox_unread_indicator_content_description"
+                    android:importantForAccessibility="yes"
                     android:src="@drawable/ct_read_circle" />
             </LinearLayout>
 
@@ -146,9 +151,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -157,9 +163,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
 
         <Button
@@ -168,9 +175,10 @@
             android:layout_height="match_parent"
             android:layout_weight="2"
             android:background="@android:color/white"
+            android:importantForAccessibility="yes"
             android:padding="2dp"
             android:textColor="@android:color/holo_blue_light"
-            android:textSize="14sp"
+            android:textSize="@dimen/ct_inbox_cta_button_text_size"
             android:visibility="gone" />
     </LinearLayout>
 </RelativeLayout>

--- a/clevertap-core/src/main/res/raw/com_clevertap_android_sdk_keep.xml
+++ b/clevertap-core/src/main/res/raw/com_clevertap_android_sdk_keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/ct_close" />

--- a/clevertap-core/src/main/res/values/dimens.xml
+++ b/clevertap-core/src/main/res/values/dimens.xml
@@ -13,6 +13,12 @@
     <dimen name="txt_size_inapp_footer_message">12sp</dimen>
     <dimen name="txt_size_inapp_footer_button">14sp</dimen>
 
+    <dimen name="ct_inbox_cta_button_text_size">14sp</dimen>
+    <dimen name="ct_inbox_title_text_size">14sp</dimen>
+    <dimen name="ct_inbox_body_text_size">14sp</dimen>
+    <dimen name="ct_inbox_timestamp_text_size">14sp</dimen>
+    <dimen name="ct_inbox_min_tap_target">48dp</dimen>
+
     <dimen name="ct_video_bottom_bar_height">60dp</dimen>
     <dimen name="ct_video_bottom_bar_margin_top">10dp</dimen>
     <dimen name="ct_video_time_padding">10dp</dimen>

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -8,9 +8,12 @@
     <string name="ct_inbox_media_content_description">Message Media</string>
     <string name="ct_inbox_image_content_description">Message Image</string>
     <string name="ct_inbox_icon_content_description">Message Icon</string>
+    <string name="ct_inbox_unread_indicator_content_description">Unread message</string>
+    <string name="ct_carousel_content_description">Image carousel, %1$s, Page %2$d of %3$d</string>
+    <string name="ct_carousel_page_announcement">%1$s, Page %2$d of %3$d</string>
     <string name="ct_notification_big_picture_alt_text">Notification Big Picture</string>
     <string name="ct_inapp_close_btn">Close</string>
-    <string name="ct_inapp_message_shown">InApp message shown</string>
+    <string name="ct_inapp_message_shown">Popup shown</string>
     <string name="ct_inapp_img">Inapp Image</string>
     <string name="ct_inapp_media">Inapp Media</string>
     <string name="ct_inapp_gif">Inapp Gif</string>

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -9,8 +9,9 @@
     <string name="ct_inbox_image_content_description">Message Image</string>
     <string name="ct_inbox_icon_content_description">Message Icon</string>
     <string name="ct_inbox_unread_indicator_content_description">Unread message</string>
-    <string name="ct_carousel_content_description">Image carousel, %1$s, Page %2$d of %3$d</string>
-    <string name="ct_carousel_page_announcement">%1$s, Page %2$d of %3$d</string>
+    <string name="ct_carousel_label">Image carousel</string>
+    <string name="ct_carousel_position">%1$s, page %2$d of %3$d</string>
+    <string name="ct_carousel_open_message">Open message</string>
     <string name="ct_notification_big_picture_alt_text">Notification Big Picture</string>
     <string name="ct_inapp_close_btn">Close</string>
     <string name="ct_inapp_message_shown">Popup shown</string>

--- a/clevertap-core/src/main/res/values/strings.xml
+++ b/clevertap-core/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="ct_inbox_icon_content_description">Message Icon</string>
     <string name="ct_notification_big_picture_alt_text">Notification Big Picture</string>
     <string name="ct_inapp_close_btn">Close</string>
+    <string name="ct_inapp_message_shown">InApp message shown</string>
     <string name="ct_inapp_img">Inapp Image</string>
     <string name="ct_inapp_media">Inapp Media</string>
     <string name="ct_inapp_gif">Inapp Gif</string>

--- a/clevertap-core/src/main/res/values/styles.xml
+++ b/clevertap-core/src/main/res/values/styles.xml
@@ -50,7 +50,7 @@
          icon dynamically at runtime via PlayerControlView. -->
     <style name="CtVideoControls.Button.Center.PlayPause" parent="CtVideoControls.Button.Center">
         <item name="android:padding">2dp</item>
-        <item name="android:contentDescription">Play</item>
+        <item name="android:contentDescription">@string/ct_pip_play_button_content_description</item>
     </style>
 
     <!-- Exact mirror of ExoStyledControls.TimeText -->

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/db/dao/InboxMessageDAOImplTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/db/dao/InboxMessageDAOImplTest.kt
@@ -251,6 +251,101 @@ class InboxMessageDAOImplTest : BaseTestCase() {
     }
 
     @Test
+    fun `upsert does not depend on the userid_id_idx unique index`() {
+        // "userid_id_idx" is a rule on the table: no two rows may share the same
+        // (messageUser, _id) pair.
+        //
+        // The old code wrote messages with:
+        //     INSERT ... ON CONFLICT(messageUser, _id) DO UPDATE SET ...
+        // SQLite can only spot a "conflict" if such a uniqueness rule exists. With no
+        // rule there is nothing to compare against, so SQLite refuses to run the
+        // statement at all and every inbox write fails.
+        //
+        // The new code does UPDATE ... WHERE messageUser = ? AND _id = ?, then INSERT
+        // only if the UPDATE changed nothing. Searching needs no uniqueness rule. Without
+        // the index SQLite just checks rows one by one — slower, but it still works.
+        //
+        // Example. Table holds (_id = m1, messageUser = user_11, isRead = 0), and m1
+        // arrives again marked read:
+        //     old code, no index -> statement fails, isRead stays 0, message lost
+        //     new code, no index -> UPDATE finds the row, isRead becomes 1
+        //
+        // Every shipped version does create this index, so this cannot happen today. We
+        // test it anyway for two reasons. First, saving a message must not secretly
+        // depend on a rule defined in a different file — if a future migration ever
+        // forgot it, every inbox write would break on every device. Second, this is the
+        // only way to make the old code fail in a unit test: the real bug is that
+        // ON CONFLICT needs SQLite 3.24.0 (Android 11+), but Robolectric always supplies
+        // a modern SQLite, so the version problem cannot be reproduced here. A missing
+        // index breaks the old code on every SQLite version, so it guards the same line.
+        dbHelper.writableDatabase.execSQL("DROP INDEX IF EXISTS userid_id_idx;")
+
+        val userId = "user_11"
+        inboxMessageDAO.upsertMessages(listOf(getCtMsgDao("m1", userId, read = false)))
+        inboxMessageDAO.upsertMessages(listOf(getCtMsgDao("m1", userId, read = true)))
+
+        val messages = inboxMessageDAO.getMessages(userId)
+        assertEquals(1, messages.size)
+        assertEquals(1, messages.single().isRead)
+    }
+
+    @Test
+    fun `upsert writes every message in a batch`() {
+        val userId = "user_11"
+        inboxMessageDAO.upsertMessages(
+            listOf(getCtMsgDao("m1", userId), getCtMsgDao("m2", userId), getCtMsgDao("m3", userId))
+        )
+        assertEquals(3, inboxMessageDAO.getMessages(userId).size)
+    }
+
+    @Test
+    fun `upsert with an empty list is a no-op`() {
+        inboxMessageDAO.upsertMessages(emptyList())
+        assertEquals(0, inboxMessageDAO.getMessages("user_11").size)
+    }
+
+    @Test
+    fun `upsert never throws even when the table is missing`() {
+        // upsertMessages must never throw. Before it used a transaction, every write went
+        // through execSQL inside a try/catch, so callers never saw an exception.
+        // CryptMigrator.migrateInboxData calls this during SDK start-up with no try/catch of
+        // its own, so a throw here would break initialisation on that path.
+        dbHelper.writableDatabase.execSQL("DROP TABLE IF EXISTS ${Table.INBOX_MESSAGES.tableName};")
+
+        // Must return normally, not throw.
+        inboxMessageDAO.upsertMessages(listOf(getCtMsgDao("m1", "user_11")))
+    }
+
+    @Test
+    fun `upsert saves the good messages in a batch even when one message is bad`() {
+        // A single failing statement does not cancel the surrounding SQLite transaction, so
+        // one unwritable message must cost only that message - not the whole batch.
+        // campaignId is NOT NULL in the schema, so a null value makes just that row fail.
+        val userId = "user_11"
+        val bad = getCtMsgDao("m2", userId).also { it.campaignId = null }
+
+        inboxMessageDAO.upsertMessages(
+            listOf(getCtMsgDao("m1", userId), bad, getCtMsgDao("m3", userId))
+        )
+
+        val savedIds = inboxMessageDAO.getMessages(userId).map { it.id }.toSet()
+        assertEquals(setOf("m1", "m3"), savedIds)
+    }
+
+    @Test
+    fun `upsert updates a row scoped to its own userId only`() {
+        // The UPDATE keys on (messageUser, _id), so the same message id under a
+        // different user must be an independent row.
+        inboxMessageDAO.upsertMessages(listOf(getCtMsgDao("m1", "user_11", read = false)))
+        inboxMessageDAO.upsertMessages(listOf(getCtMsgDao("m1", "user_22", read = true)))
+
+        assertEquals(1, inboxMessageDAO.getMessages("user_11").size)
+        assertEquals(0, inboxMessageDAO.getMessages("user_11").single().isRead)
+        assertEquals(1, inboxMessageDAO.getMessages("user_22").size)
+        assertEquals(1, inboxMessageDAO.getMessages("user_22").single().isRead)
+    }
+
+    @Test
     fun `markIndexed flips supplied PENDING_INDEXING rows to INDEXED`() {
         val userId = "user_11"
         inboxMessageDAO.upsertMessages(

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTInAppNotificationTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTInAppNotificationTest.kt
@@ -30,6 +30,60 @@ class CTInAppNotificationTest {
     }
 
     @Test
+    fun `dismiss-gesture flags default to true when keys are absent`() {
+        val notification = CTInAppNotification(JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL), true)
+
+        assertTrue(notification.swipeToDismiss)
+    }
+
+    @Test
+    fun `dismiss-gesture flags respect explicit boolean values`() {
+        val json = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
+            put(Constants.KEY_SWIPE_TO_DISMISS, false)
+        }
+
+        val notification = CTInAppNotification(json, true)
+
+        assertFalse(notification.swipeToDismiss)
+    }
+
+    @Test
+    fun `dismiss-gesture flags respect integer 0 and 1 values`() {
+        val disabled = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
+            put(Constants.KEY_SWIPE_TO_DISMISS, 0)
+        }
+        val enabled = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
+            put(Constants.KEY_SWIPE_TO_DISMISS, 1)
+        }
+
+        val disabledNotification = CTInAppNotification(disabled, true)
+        val enabledNotification = CTInAppNotification(enabled, true)
+
+        assertFalse(disabledNotification.swipeToDismiss)
+        assertTrue(enabledNotification.swipeToDismiss)
+    }
+
+    @Test
+    fun `dismiss-gesture flags fall back to true for explicit JSON null without crashing`() {
+        val json = JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL).apply {
+            put(Constants.KEY_SWIPE_TO_DISMISS, JSONObject.NULL)
+        }
+
+        val notification = CTInAppNotification(json, true)
+
+        assertTrue(notification.swipeToDismiss)
+    }
+
+    @Test
+    fun `isHtml is true for html in-apps and false for native in-apps`() {
+        val html = CTInAppNotification(JSONObject(InAppFixtures.TYPE_ADVANCED_BUILDER_HEADER), true)
+        val native = CTInAppNotification(JSONObject(InAppFixtures.TYPE_HALF_INTERSTITIAL), true)
+
+        assertTrue(html.isHtml())
+        assertFalse(native.isHtml())
+    }
+
+    @Test
     fun `constructor for advanced builder custom-html should initialize correctly for html footer`() {
         // Arrange - Html in app
         val jsonObject = JSONObject(InAppFixtures.TYPE_ADVANCED_BUILDER_FOOTER)

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
@@ -26,6 +26,8 @@ import com.clevertap.android.sdk.inapp.delay.InAppScheduler
 import com.clevertap.android.sdk.inapp.evaluation.EvaluationManager
 import com.clevertap.android.sdk.inapp.fragment.CTInAppBaseFragment
 import com.clevertap.android.sdk.network.NetworkMonitor
+import com.clevertap.android.sdk.validation.ValidationResult
+import com.clevertap.android.sdk.validation.ValidationResultStack
 import com.clevertap.android.sdk.task.MockCTExecutors
 import com.clevertap.android.sdk.toList
 import com.clevertap.android.sdk.utils.FakeClock
@@ -68,6 +70,7 @@ class InAppControllerTest {
     private lateinit var fakeInAppQueue: FakeInAppQueue
 
     private lateinit var mockNetworkMonitor: NetworkMonitor
+    private lateinit var mockValidationResultStack: ValidationResultStack
     private val fakeClock = FakeClock(timeMillis = 1735686000000) // 01.01.2025
 
     @Before
@@ -90,6 +93,8 @@ class InAppControllerTest {
 
         mockNetworkMonitor = mockk(relaxed = true)
         every { mockNetworkMonitor.isNetworkOnline() } returns true
+
+        mockValidationResultStack = mockk(relaxed = true)
 
 
         mockInAppActionHandler = mockk(relaxed = true)
@@ -316,6 +321,108 @@ class InAppControllerTest {
     }
 
     @Test
+    fun `inAppActionTriggered adds url action descriptors to clicked event`() {
+        val url = "https://clevertap.com"
+        val actionJsonString = """
+        {
+            "${Constants.KEY_TYPE}": "${InAppActionType.OPEN_URL}",
+            "${Constants.KEY_ANDROID}": "$url"
+        }
+        """.trimIndent()
+        val inApp = getInAppWithAction(actionJsonString)
+
+        createInAppController().inAppNotificationActionTriggered(
+            inApp, CTInAppAction.createFromJson(JSONObject(actionJsonString))!!, "cta", null, null
+        )
+
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
+                data.getString(Constants.KEY_WZRK_ACTION) == InAppActionType.OPEN_URL.toString() &&
+                        data.getString(Constants.KEY_WZRK_DATA) == url
+            })
+        }
+    }
+
+    @Test
+    fun `inAppActionTriggered adds close action descriptors to clicked event`() {
+        val inApp = getInAppWithAction("""{"${Constants.KEY_TYPE}": "${InAppActionType.CLOSE}"}""")
+
+        createInAppController().inAppNotificationActionTriggered(
+            inApp,
+            CTInAppAction.createCloseAction(),
+            Constants.INAPP_CTA_DISMISS_BUTTON,
+            Bundle().apply { putString(Constants.KEY_WZRK_ELEMENT_ID, Constants.INAPP_ELEMENT_ID_CLOSE) },
+            null
+        )
+
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
+                data.getString(Constants.KEY_WZRK_ACTION) == InAppActionType.CLOSE.toString() &&
+                        data.getString(Constants.KEY_WZRK_DATA) == Constants.INAPP_WZRK_DATA_CLOSE &&
+                        data.getString(Constants.KEY_WZRK_ELEMENT_ID) == Constants.INAPP_ELEMENT_ID_CLOSE
+            })
+        }
+    }
+
+    @Test
+    fun `inAppActionTriggered adds kv action descriptors as a nested payload`() {
+        every { mockCallbackManager.getInAppNotificationButtonListener() } returns null
+        val keyValues = hashMapOf("key1" to "value1", "key2" to "value2")
+        val actionJsonString = """
+        {
+            "${Constants.KEY_TYPE}": "${InAppActionType.KEY_VALUES}",
+            "${Constants.KEY_KV}": ${JSONObject((keyValues as Map<*, *>?)!!)}
+        }
+        """.trimIndent()
+        val inApp = getInAppWithAction(actionJsonString)
+
+        createInAppController().inAppNotificationActionTriggered(
+            inApp, CTInAppAction.createFromJson(JSONObject(actionJsonString))!!, "cta", null, null
+        )
+
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
+                @Suppress("UNCHECKED_CAST")
+                val kv = data.getSerializable(Constants.KEY_WZRK_DATA) as? Map<String, String>
+                data.getString(Constants.KEY_WZRK_ACTION) == InAppActionType.KEY_VALUES.toString() &&
+                        kv?.get("key1") == "value1" && kv?.get("key2") == "value2"
+            })
+        }
+    }
+
+    @Test
+    fun `media error on html inapp reports wzrk_error and raises no clicked event`() {
+        val inApp = CTInAppNotification(JSONObject(InAppFixtures.TYPE_ADVANCED_BUILDER_HEADER), true)
+
+        createInAppController().inAppNotificationActionTriggered(
+            inApp, CTInAppAction.createCloseAction(), Constants.INAPP_CTA_IMAGE_ERROR_DISMISS, null, null
+        )
+
+        verify(exactly = 1) {
+            mockValidationResultStack.pushValidationResult(match<ValidationResult> {
+                it.errorCode == Constants.INAPP_IMAGE_LOAD_FAILED_ERROR_CODE
+            })
+        }
+        verify(exactly = 0) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `media error c2a on native inapp is treated as a normal click`() {
+        val inApp = getInAppWithAction("""{"${Constants.KEY_TYPE}": "${InAppActionType.CLOSE}"}""")
+
+        createInAppController().inAppNotificationActionTriggered(
+            inApp, CTInAppAction.createCloseAction(), Constants.INAPP_CTA_IMAGE_ERROR_DISMISS, null, null
+        )
+
+        verify(exactly = 0) { mockValidationResultStack.pushValidationResult(any<ValidationResult>()) }
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, any())
+        }
+    }
+
+    @Test
     fun `inAppNotificationDidClick should trigger the InAppButton's action`() {
         val url = "https://clevertap.com"
         val actionJsonString = """
@@ -326,9 +433,53 @@ class InAppControllerTest {
         """.trimIndent()
         val inApp = getInAppWithAction(actionJsonString)
         val inAppController = createInAppController()
-        inAppController.inAppNotificationDidClick(inApp, inApp.buttons[0], null)
+        inAppController.inAppNotificationDidClick(inApp, inApp.buttons[0], 0, null)
 
         verify(exactly = 1) { mockInAppActionHandler.openUrl(url, null) }
+    }
+
+    @Test
+    fun `inAppNotificationDidClick tags the clicked button with a 1-based element id`() {
+        val inApp = getInAppWithAction("""{"${Constants.KEY_TYPE}": "${InAppActionType.CLOSE}"}""")
+
+        createInAppController().inAppNotificationDidClick(inApp, inApp.buttons[0], 0, null)
+
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
+                data.getString(Constants.KEY_WZRK_ELEMENT_ID) == "${Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX}1" &&
+                        data.getString(Constants.KEY_WZRK_ACTION) == InAppActionType.CLOSE.toString() &&
+                        data.getString(Constants.KEY_WZRK_DATA) == Constants.INAPP_WZRK_DATA_CLOSE
+            })
+        }
+    }
+
+    @Test
+    fun `inAppNotificationDidClick uses the passed index for duplicate button payloads`() {
+        // Two identical button payloads: CTInAppNotificationButton.equals is value-based, so indexOf
+        // would resolve buttons[1] back to slot 0 and mis-tag it button-1.
+        val buttonJson = """{
+            "${Constants.KEY_TEXT}": "OK",
+            "${Constants.KEY_ACTIONS}": {"${Constants.KEY_TYPE}": "${InAppActionType.CLOSE}"}
+        }"""
+        val inApp = CTInAppNotification(
+            JSONObject(
+                """{
+            "${Constants.KEY_TYPE}": "${CTInAppType.CTInAppTypeCover}",
+            "${Constants.NOTIFICATION_ID_TAG}": "test-campaign",
+            "${Constants.KEY_BUTTONS}": [$buttonJson, $buttonJson]
+            }""".trimIndent()
+            ), false
+        )
+        // Sanity: the two buttons really are equal, so indexOf(buttons[1]) == 0 (the bug).
+        assertEquals(inApp.buttons[0], inApp.buttons[1])
+
+        createInAppController().inAppNotificationDidClick(inApp, inApp.buttons[1], 1, null)
+
+        verify(exactly = 1) {
+            mockAnalyticsManager.pushInAppNotificationStateEvent(true, inApp, match { data ->
+                data.getString(Constants.KEY_WZRK_ELEMENT_ID) == "${Constants.INAPP_ELEMENT_ID_BUTTON_PREFIX}2"
+            })
+        }
     }
 
     @Test
@@ -820,6 +971,7 @@ class InAppControllerTest {
             networkMonitor = mockNetworkMonitor,
             clock = fakeClock,
             pipManager = mockk(relaxed = true),
+            validationResultStack = mockValidationResultStack,
         )
     }
 

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PIPInAppCallbacksBridgeTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PIPInAppCallbacksBridgeTest.kt
@@ -1,5 +1,6 @@
 package com.clevertap.android.sdk.inapp
 
+import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.TestLogger
 import io.mockk.every
 import io.mockk.mockk
@@ -54,7 +55,11 @@ class PIPInAppCallbacksBridgeTest {
         bridge.onAction()
         verify(exactly = 1) {
             mockListener.inAppNotificationActionTriggered(
-                notification, any(), "pip_cta", null, null
+                notification,
+                any(),
+                "pip_cta",
+                match { it.getString(Constants.KEY_WZRK_ELEMENT_ID) == Constants.INAPP_ELEMENT_ID_PIP_CTA },
+                null
             )
         }
     }
@@ -83,6 +88,34 @@ class PIPInAppCallbacksBridgeTest {
         verify(exactly = 0) {
             mockListener.inAppNotificationActionTriggered(any(), any(), any(), any(), any())
         }
+    }
+
+    @Test
+    fun `onCloseButtonClick raises a close clicked event with the shared close descriptors`() {
+        val notification = mockk<CTInAppNotification> {
+            every { campaignId } returns "test_campaign_123"
+        }
+        val bridge = PIPInAppCallbacksBridge(notification, mockListener, mockShowFailureHandler, logger)
+        bridge.onCloseButtonClick()
+        verify(exactly = 1) {
+            mockListener.inAppNotificationActionTriggered(
+                notification,
+                match { it.type == InAppActionType.CLOSE },
+                Constants.INAPP_CTA_DISMISS_BUTTON,
+                match { it.getString(Constants.KEY_WZRK_ELEMENT_ID) == Constants.INAPP_ELEMENT_ID_CLOSE },
+                null
+            )
+        }
+    }
+
+    @Test
+    fun `onCloseButtonClick does not report a dismiss (that is onClose's job)`() {
+        val notification = mockk<CTInAppNotification> {
+            every { campaignId } returns "test_campaign_123"
+        }
+        val bridge = PIPInAppCallbacksBridge(notification, mockListener, mockShowFailureHandler, logger)
+        bridge.onCloseButtonClick()
+        verify(exactly = 0) { mockListener.inAppNotificationDidDismiss(any(), any()) }
     }
 
     // ─── Callbacks that only log (do not forward to InAppListener) ────────────────

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
@@ -77,12 +77,8 @@ internal data class BasicTemplateData(
 
 internal data class FiveIconsTemplateData(
     override val templateType: TemplateType = TemplateType.FIVE_ICONS,
+    val baseContent: BaseContent,
     val imageList: ArrayList<ImageData>,
-    val deepLinkList: ArrayList<String>,
-    val backgroundColor: String? = null,
-    val title: String? = null,
-    val subtitle: String? = null,
-    val notificationBehavior: NotificationBehavior
 ) : TemplateData()
 
 internal data class ManualCarouselTemplateData(

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
@@ -223,12 +223,8 @@ internal object TemplateDataFactory {
         defaultAltText: String
     ): FiveIconsTemplateData {
         return FiveIconsTemplateData(
+            baseContent = createBaseContent(extras, colorMap),
             imageList = Utils.getImageDataListFromExtras(extras, defaultAltText),
-            deepLinkList = Utils.getDeepLinkListFromExtras(extras),
-            backgroundColor = colorMap[PT_BG],
-            title = getStringWithFallback(extras, PT_TITLE, Constants.NOTIF_TITLE),
-            subtitle = getStringWithFallback(extras, PT_SUBTITLE, Constants.WZRK_SUBTITLE),
-            notificationBehavior = createNotificationBehaviorData(extras)
         )
     }
 
@@ -582,18 +578,16 @@ internal object TemplateDataFactory {
         )
     }
 
-    internal fun FiveIconsTemplateData.toBaseContent(): BaseContent {
-        return BaseContent(
-            textData = BaseTextData(title = this.title, subtitle = this.subtitle),
-            colorData = BaseColorData(
-                backgroundColor = this.backgroundColor,
+    internal fun FiveIconsTemplateData.toBasicTemplateData(): BasicTemplateData {
+        return BasicTemplateData(
+            baseContent = this.baseContent,
+            mediaData = MediaData(
+                bigImage = ImageData(altText = ""),
+                gif = GifData()
             ),
-            iconData = IconData(),
-            deepLinkList = this.deepLinkList,
-            notificationBehavior = this.notificationBehavior
+            actions = null
         )
     }
-
 
     internal fun InputBoxTemplateData.toBaseContent(): BaseContent {
         return BaseContent(
@@ -639,4 +633,3 @@ internal object TemplateDataFactory {
         }
     }
 }
-

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateRenderer.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION", "DiscouragedApi")
+
 package com.clevertap.android.pushtemplates
 
 import android.app.PendingIntent
@@ -11,6 +13,7 @@ import android.os.*
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import androidx.core.app.NotificationCompat.Builder
+import androidx.core.net.toUri
 import com.clevertap.android.pushtemplates.PTConstants.*
 import com.clevertap.android.pushtemplates.TemplateDataFactory.getActions
 import com.clevertap.android.pushtemplates.TemplateDataFactory.toBasicTemplateData
@@ -61,6 +64,7 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
     internal var notificationId: Int = -1//Creates a instance field for access in ContentViews->PendingIntentFactory
 
     enum class LogLevel(private val value: Int) {
+        @Suppress("unused")
         OFF(-1), INFO(0), DEBUG(2), VERBOSE(3);
 
         fun intValue(): Int {
@@ -131,24 +135,33 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
                 RatingStyle(it, this, extras).builderFromStyle(context, extras, notificationId, nb)
             }
 
-            is FiveIconsTemplateData -> templateData.buildIfValid {
-                val fiveIconStyle = FiveIconStyle(it, this, extras)
-                val fiveIconNotificationBuilder = fiveIconStyle.builderFromStyle(
-                    context,
-                    extras,
-                    notificationId,
-                    nb
-                )
-
-                /**
-                 * Checks whether the imageUrls are perfect to download icon's bitmap,
-                 * if not then do not render notification
-                 */
-                if ((fiveIconStyle.fiveIconSmallContentView as FiveIconSmallContentView).getUnloadedFiveIconsCount() > 2 ||
-                    (fiveIconStyle.fiveIconBigContentView as FiveIconBigContentView).getUnloadedFiveIconsCount() > 2) {
+            is FiveIconsTemplateData -> {
+                val validator = ValidatorFactory.getValidator(templateData)
+                if (validator == null) {
                     null
+                } else if (validator.validate()) {
+                    val fiveIconStyle = FiveIconStyle(templateData, this, extras)
+                    val fiveIconNotificationBuilder = fiveIconStyle.builderFromStyle(
+                        context,
+                        extras,
+                        notificationId,
+                        nb
+                    )
+
+                    /**
+                     * If most icon bitmaps fail to load, gracefully fall back to a basic
+                     * title/message notification instead of suppressing the notification.
+                     */
+                    if ((fiveIconStyle.fiveIconSmallContentView as FiveIconSmallContentView).getUnloadedFiveIconsCount() > 2 ||
+                        (fiveIconStyle.fiveIconBigContentView as FiveIconBigContentView).getUnloadedFiveIconsCount() > 2) {
+                        PTLog.debug("More than 2 images were not retrieved in 5CTA Notification, reverting to basic template.")
+                        buildBasicFallback(templateData.toBasicTemplateData(), context, extras, notificationId, nb)
+                    } else {
+                        fiveIconNotificationBuilder
+                    }
                 } else {
-                    fiveIconNotificationBuilder
+                    PTLog.debug("Five Icons template validation failed, reverting to basic template.")
+                    buildBasicFallback(templateData.toBasicTemplateData(), context, extras, notificationId, nb)
                 }
             }
 
@@ -216,6 +229,19 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
     private fun <T : TemplateData> T.buildIfValid(builder: (T) -> Builder?): Builder? =
         ValidatorFactory.getValidator(this)?.takeIf { it.validate() }?.let { builder(this) }
 
+    private fun buildBasicFallback(
+        basicTemplateData: BasicTemplateData,
+        context: Context,
+        extras: Bundle,
+        notificationId: Int,
+        nb: Builder
+    ): Builder? = basicTemplateData.buildIfValid {
+        BasicStyle(it, this).builderFromStyle(context, extras, notificationId, nb)
+    } ?: run {
+        PTLog.debug("Five Icons fallback to basic template also failed validation. Notification will be suppressed.")
+        null
+    }
+
 
     override fun setSmallIcon(smallIcon: Int, context: Context) {
         this.smallIcon = smallIcon
@@ -233,7 +259,7 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
     }
 
     override fun getCollapseKey(extras: Bundle): Any? {
-        return extras[PT_COLLAPSE_KEY] ?: extras[Constants.WZRK_COLLAPSE]
+        return extras.getString(PT_COLLAPSE_KEY) ?: extras.getString(Constants.WZRK_COLLAPSE)
     }
 
     override fun setSound(
@@ -242,11 +268,12 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
         try {
             if (extras.containsKey(Constants.WZRK_SOUND)) {
                 var soundUri: Uri? = null
-                val o = extras[Constants.WZRK_SOUND]
-                if (o is Boolean && o) {
+                val soundString = extras.getString(Constants.WZRK_SOUND)
+                val isDefaultSoundEnabled = soundString == null && extras.getBoolean(Constants.WZRK_SOUND, false)
+                if (isDefaultSoundEnabled) {
                     soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
-                } else if (o is String) {
-                    var s = o
+                } else if (soundString != null) {
+                    var s = soundString
                     if (s == "true") {
                         soundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
                     } else if (s.isNotEmpty()) {
@@ -392,24 +419,24 @@ class TemplateRenderer(context: Context, private val extras: Bundle, internal va
             }
 
             // Create the appropriate intent
-            var actionLaunchIntent: Intent? = null
-
-            if (sendToCTIntentService) {
-                actionLaunchIntent = Intent(CTNotificationIntentService.MAIN_ACTION)
-                actionLaunchIntent.setPackage(context.packageName)
-                actionLaunchIntent.putExtra(
+            val actionLaunchIntent = if (sendToCTIntentService) {
+                Intent(CTNotificationIntentService.MAIN_ACTION).apply {
+                    setPackage(context.packageName)
+                    putExtra(
                     Constants.KEY_CT_TYPE,
                     CTNotificationIntentService.TYPE_BUTTON_CLICK
-                )
-                if (dl.isNotEmpty()) {
-                    actionLaunchIntent.putExtra("dl", dl)
+                    )
+                    if (dl.isNotEmpty()) {
+                        putExtra("dl", dl)
+                    }
                 }
             } else {
                 if (dl.isNotEmpty()) {
-                    actionLaunchIntent = Intent(Intent.ACTION_VIEW, Uri.parse(dl))
-                    Utils.setPackageNameFromResolveInfoList(context, actionLaunchIntent)
+                    Intent(Intent.ACTION_VIEW, dl.toUri()).also {
+                        Utils.setPackageNameFromResolveInfoList(context, it)
+                    }
                 } else {
-                    actionLaunchIntent = context.packageManager
+                    context.packageManager
                         .getLaunchIntentForPackage(context.packageName)
                 }
             }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconBigContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconBigContentView.kt
@@ -21,8 +21,24 @@ internal class FiveIconBigContentView constructor(
     private var imageCounter: Int = 0
 
     init {
-        setCustomBackgroundColour(data.backgroundColor, R.id.content_view_big)
+        setCustomContentViewBasicKeys(
+            data.baseContent.textData.subtitle,
+            data.baseContent.colorData.metaColor
+        )
+        setCustomContentViewTitle(data.baseContent.textData.title)
+        setCustomContentViewMessage(data.baseContent.textData.message)
+        setCustomBackgroundColour(data.baseContent.colorData.backgroundColor, R.id.content_view_big)
+        setCustomTextColour(data.baseContent.colorData.titleColor, R.id.title)
+        setCustomTextColour(data.baseContent.colorData.messageColor, R.id.msg)
+        setCustomContentViewMessageSummary(data.baseContent.textData.messageSummary)
         val ctaIds = listOf(R.id.cta1, R.id.cta2, R.id.cta3, R.id.cta4, R.id.cta5)
+        val fallbackDescriptions = listOf(
+            R.string.pt_five_icon_1,
+            R.string.pt_five_icon_2,
+            R.string.pt_five_icon_3,
+            R.string.pt_five_icon_4,
+            R.string.pt_five_icon_5
+        )
         data.imageList.forEachIndexed { index, imageData ->
             val imageUrl = imageData.url
             val altText = imageData.altText
@@ -30,6 +46,10 @@ internal class FiveIconBigContentView constructor(
 
             val viewId = ctaIds[index]
             remoteView.setViewVisibility(viewId, View.VISIBLE)
+
+            val description = if (altText.isNotEmpty()) altText
+                              else context.getString(fallbackDescriptions[index])
+            remoteView.setContentDescription(viewId, description)
 
             val fallback = loadImageURLIntoRemoteView(
                 viewId,
@@ -47,7 +67,7 @@ internal class FiveIconBigContentView constructor(
         extras.putInt(PTConstants.PT_NOTIF_ID, renderer.notificationId)
         extras.putBoolean(Constants.CLOSE_SYSTEM_DIALOGS, true)
 
-        val deepLinkList = data.deepLinkList
+        val deepLinkList = data.baseContent.deepLinkList
 
         val bundleCTA1 = extras.clone() as Bundle
         bundleCTA1.putBoolean("cta1", true)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconSmallContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconSmallContentView.kt
@@ -8,7 +8,6 @@ import com.clevertap.android.pushtemplates.PTConstants
 import com.clevertap.android.pushtemplates.PTLog
 import com.clevertap.android.pushtemplates.R
 import com.clevertap.android.pushtemplates.TemplateRenderer
-import com.clevertap.android.pushtemplates.Utils
 import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.pushnotification.LaunchPendingIntentFactory
 
@@ -17,18 +16,34 @@ internal class FiveIconSmallContentView(
     renderer: TemplateRenderer,
     data: FiveIconsTemplateData,
     extras: Bundle
-) : ContentView(context, R.layout.five_cta_collapsed, renderer.templateMediaManager) {
+) : ContentView(context,
+    if (!data.baseContent.textData.title.isNullOrEmpty() || !data.baseContent.textData.message.isNullOrEmpty())
+        R.layout.five_cta_collapsed_with_text
+    else
+        R.layout.five_cta_collapsed,
+    renderer.templateMediaManager) {
 
     private var imageCounter: Int = 0
 
     init {
-        var title = data.title
-        if (title.isNullOrEmpty()) {
-            title = Utils.getApplicationName(context)
-        }
-        setCustomBackgroundColour(data.backgroundColor, R.id.content_view_big)
+        setCustomContentViewBasicKeys(
+            data.baseContent.textData.subtitle,
+            data.baseContent.colorData.metaColor
+        )
+        setCustomContentViewTitle(data.baseContent.textData.title)
+        setCustomContentViewMessage(data.baseContent.textData.message)
+        setCustomBackgroundColour(data.baseContent.colorData.backgroundColor, R.id.content_view_big)
+        setCustomTextColour(data.baseContent.colorData.titleColor, R.id.title)
+        setCustomTextColour(data.baseContent.colorData.messageColor, R.id.msg)
 
         val ctaIds = listOf(R.id.cta1, R.id.cta2, R.id.cta3, R.id.cta4, R.id.cta5)
+        val fallbackDescriptions = listOf(
+            R.string.pt_five_icon_1,
+            R.string.pt_five_icon_2,
+            R.string.pt_five_icon_3,
+            R.string.pt_five_icon_4,
+            R.string.pt_five_icon_5
+        )
         data.imageList.forEachIndexed { index, imageData ->
             val imageUrl = imageData.url
             val altText = imageData.altText
@@ -36,6 +51,10 @@ internal class FiveIconSmallContentView(
 
             val viewId = ctaIds[index]
             remoteView.setViewVisibility(viewId, View.VISIBLE)
+
+            val description = if (altText.isNotEmpty()) altText
+                              else context.getString(fallbackDescriptions[index])
+            remoteView.setContentDescription(viewId, description)
 
             val fallback = loadImageURLIntoRemoteView(
                 viewId,
@@ -54,7 +73,7 @@ internal class FiveIconSmallContentView(
         extras.putInt(PTConstants.PT_NOTIF_ID, renderer.notificationId)
         extras.putBoolean(Constants.CLOSE_SYSTEM_DIALOGS, true)
 
-        val deepLinkList = data.deepLinkList
+        val deepLinkList = data.baseContent.deepLinkList
 
         val bundleCTA1 = extras.clone() as Bundle
         bundleCTA1.putBoolean("cta1", true)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
@@ -65,10 +65,15 @@ internal class ManualCarouselContentView(
 
                 tempRemoteView.setViewVisibility(imageViewId, View.VISIBLE)
                 val centerRemoteView = tempRemoteView.clone()
+                val rightRemoteView = tempRemoteView.clone()
+                val leftRemoteView = tempRemoteView.clone()
 
-                remoteView.addView(R.id.carousel_image_right, tempRemoteView)
-                remoteView.addView(R.id.carousel_image_left, tempRemoteView)
                 centerRemoteView.setContentDescription(imageViewId, altText)
+                rightRemoteView.setContentDescription(imageViewId, altText)
+                leftRemoteView.setContentDescription(imageViewId, altText)
+
+                remoteView.addView(R.id.carousel_image_right, rightRemoteView)
+                remoteView.addView(R.id.carousel_image_left, leftRemoteView)
                 remoteView.addView(R.id.carousel_image, centerRemoteView)
 
                 imageCounter++

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.LinearGradient
 import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.RadialGradient
 import android.graphics.RectF
 import android.graphics.Shader
@@ -84,16 +85,29 @@ internal object NotificationBitmapUtils {
         borderWidth: Float?
     ) {
         if (borderColor != null) {
-            val strokeWidth = borderWidth ?: (height * BORDER_STROKE_RATIO)
-            val inset = strokeWidth / 2f
-            val rect = RectF(inset, inset, width - inset, height - inset)
-            canvas.drawRoundRect(rect, cornerRadius, cornerRadius, paint)
-            val borderPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                color = borderColor
-                style = Paint.Style.STROKE
-                this.strokeWidth = strokeWidth
+            val strokeWidth = (borderWidth ?: (height * BORDER_STROKE_RATIO))
+                .coerceAtMost(minOf(width, height) / 2f)
+            val outerRect = RectF(0f, 0f, width.toFloat(), height.toFloat())
+            val clampedOuterRadius = cornerRadius.coerceAtMost(minOf(width / 2f, height / 2f))
+            val innerRect = RectF(strokeWidth, strokeWidth, width - strokeWidth, height - strokeWidth)
+            // Scale inner radius proportionally so corners stay visually consistent
+            // regardless of how small cornerRadius or how large borderWidth is.
+            val innerCornerRadius = if (height > 0)
+                clampedOuterRadius * (innerRect.height() / height.toFloat())
+            else 0f
+
+            // Draw fill first on the transparent bitmap so any alpha in the fill paint
+            // composites against the notification background, not the border colour.
+            canvas.drawRoundRect(innerRect, innerCornerRadius, innerCornerRadius, paint)
+
+            // Draw border as a ring (outer rounded rect minus inner hole) so the border
+            // never bleeds behind the fill area.
+            val borderPath = Path().apply {
+                addRoundRect(outerRect, clampedOuterRadius, clampedOuterRadius, Path.Direction.CW)
+                addRoundRect(innerRect, innerCornerRadius, innerCornerRadius, Path.Direction.CCW)
             }
-            canvas.drawRoundRect(rect, cornerRadius, cornerRadius, borderPaint)
+            val borderPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { color = borderColor }
+            canvas.drawPath(borderPath, borderPaint)
         } else {
             val rect = RectF(0f, 0f, width.toFloat(), height.toFloat())
             canvas.drawRoundRect(rect, cornerRadius, cornerRadius, paint)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/PendingIntentFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/PendingIntentFactory.kt
@@ -204,7 +204,7 @@ internal object PendingIntentFactory {
             }
 
             FIVE_ICON_CONTENT_PENDING_INTENT -> {
-                extras.putString(Constants.DEEP_LINK_KEY, null)
+                extras.putString(Constants.DEEP_LINK_KEY, deepLink)
                 return setPendingIntent(context, notificationId, extras, launchIntent, requestCode)
             }
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/styles/FiveIconStyle.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/styles/FiveIconStyle.kt
@@ -5,12 +5,12 @@ import android.content.Context
 import android.os.Bundle
 import android.widget.RemoteViews
 import com.clevertap.android.pushtemplates.FiveIconsTemplateData
-import com.clevertap.android.pushtemplates.TemplateDataFactory.toBaseContent
 import com.clevertap.android.pushtemplates.TemplateRenderer
 import com.clevertap.android.pushtemplates.content.*
 import com.clevertap.android.pushtemplates.content.PendingIntentFactory
+import com.clevertap.android.sdk.Constants
 
-internal class FiveIconStyle(private val data: FiveIconsTemplateData, renderer: TemplateRenderer, private var extras: Bundle) : Style(data.toBaseContent(), renderer) {
+internal class FiveIconStyle(private val data: FiveIconsTemplateData, renderer: TemplateRenderer, private var extras: Bundle) : Style(data.baseContent, renderer) {
 
     lateinit var fiveIconSmallContentView: ContentView
     lateinit var fiveIconBigContentView: ContentView
@@ -32,7 +32,7 @@ internal class FiveIconStyle(private val data: FiveIconsTemplateData, renderer: 
     ): PendingIntent? {
         return PendingIntentFactory.getPendingIntent(
             context, notificationId, extras, true,
-            FIVE_ICON_CONTENT_PENDING_INTENT, data.deepLinkList.getOrNull(0)
+            FIVE_ICON_CONTENT_PENDING_INTENT, extras.getString(Constants.DEEP_LINK_KEY)
         )
     }
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/validators/ValidatorFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/validators/ValidatorFactory.kt
@@ -30,13 +30,12 @@ fun Iterable<Checker<out Any>>.and(): Boolean {
 }
 
 fun Iterable<Checker<out Any>>.or(): Boolean {
-    var or = false
     for (element in this) {
-        or =
-            element.check() || or
-        if (or) break
+        if (element.check()) {
+            return true
+        }
     }
-    return or
+    return false
 }
 
 /**
@@ -141,6 +140,7 @@ internal class ValidationCheckersBuilder {
     /**
      * Adds integer field validation with minimum value check
      */
+    @Suppress("unused")
     fun addIntValidation(value: Int?, minValue: Int, key: String, errorMessage: String): ValidationCheckersBuilder {
         checkers[key] = IntSizeChecker(value, minValue, errorMessage)
         return this
@@ -149,6 +149,7 @@ internal class ValidationCheckersBuilder {
     /**
      * Adds integer field validation with minimum value check
      */
+    @Suppress("unused")
     fun addLongValidation(value: Long?, minValue: Int, key: String, errorMessage: String): ValidationCheckersBuilder {
         checkers[key] = LongSizeChecker(value, minValue, errorMessage)
         return this
@@ -228,7 +229,7 @@ internal class ValidatorFactory {
 
                 is FiveIconsTemplateData -> {
                     builder
-                        .addDeepLinkValidation(templateData.deepLinkList, 3, PT_FIVE_DEEPLINK_LIST)
+                        .addDeepLinkValidation(templateData.baseContent.deepLinkList, 3, PT_FIVE_DEEPLINK_LIST)
                         .addImageListValidation(templateData.imageList, 3, key = PT_FIVE_IMAGE_LIST)
                         .build()
                 }

--- a/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed.xml
+++ b/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed.xml
@@ -3,17 +3,19 @@
     android:id="@+id/content_view_big"
     android:layout_width="match_parent"
     android:layout_height="64dp"
-    android:padding="@dimen/five_cta_padding"
     android:background="@android:color/transparent"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    android:padding="@dimen/five_cta_padding">
 
-    <ImageView android:id="@+id/cta1"
+    <ImageView
+        android:id="@+id/cta1"
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_weight="1"
         android:layout_margin="4dp"
+        android:contentDescription="@null"
         android:visibility="gone"
-        android:src="@drawable/pt_image"/>
+        android:src="@drawable/pt_image" />
 
     <ImageView
         android:id="@+id/cta2"
@@ -21,6 +23,7 @@
         android:layout_height="match_parent"
         android:layout_weight="1"
         android:layout_margin="4dp"
+        android:contentDescription="@null"
         android:visibility="gone"
         android:src="@drawable/pt_image" />
 
@@ -30,6 +33,7 @@
         android:layout_height="match_parent"
         android:layout_weight="1"
         android:layout_margin="4dp"
+        android:contentDescription="@null"
         android:visibility="gone"
         android:src="@drawable/pt_image" />
 
@@ -39,6 +43,7 @@
         android:layout_height="match_parent"
         android:layout_weight="1"
         android:layout_margin="4dp"
+        android:contentDescription="@null"
         android:visibility="gone"
         android:src="@drawable/pt_image" />
 
@@ -48,6 +53,7 @@
         android:layout_height="match_parent"
         android:layout_weight="1"
         android:layout_margin="4dp"
+        android:contentDescription="@null"
         android:visibility="gone"
         android:src="@drawable/pt_image" />
 </LinearLayout>

--- a/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed_with_text.xml
+++ b/clevertap-pushtemplates/src/main/res/layout/five_cta_collapsed_with_text.xml
@@ -8,11 +8,11 @@
 
     <include
         android:id="@+id/rel_lyt"
-        layout="@layout/content_view_small_multi_line_msg" />
+        layout="@layout/content_view_small_single_line_msg" />
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="64dp"
+        android:layout_height="40dp"
         android:orientation="horizontal"
         android:padding="@dimen/five_cta_padding">
 

--- a/clevertap-pushtemplates/src/main/res/layout/rating.xml
+++ b/clevertap-pushtemplates/src/main/res/layout/rating.xml
@@ -29,40 +29,50 @@
             <ImageView
                 android:id="@+id/star1"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/rating_star"
+                android:layout_height="@dimen/rating_star_touch_target"
                 android:layout_weight="1"
+                android:paddingTop="@dimen/rating_star_padding"
+                android:paddingBottom="@dimen/rating_star_padding"
                 android:contentDescription="@string/rating_star_1"
                 android:src="@drawable/pt_star_outline" />
 
             <ImageView
                 android:id="@+id/star2"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/rating_star"
+                android:layout_height="@dimen/rating_star_touch_target"
                 android:layout_weight="1"
+                android:paddingTop="@dimen/rating_star_padding"
+                android:paddingBottom="@dimen/rating_star_padding"
                 android:src="@drawable/pt_star_outline"
                 android:contentDescription="@string/rating_star_2" />
 
             <ImageView
                 android:id="@+id/star3"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/rating_star"
+                android:layout_height="@dimen/rating_star_touch_target"
                 android:layout_weight="1"
+                android:paddingTop="@dimen/rating_star_padding"
+                android:paddingBottom="@dimen/rating_star_padding"
                 android:src="@drawable/pt_star_outline"
                 android:contentDescription="@string/rating_star_3" />
 
             <ImageView
                 android:id="@+id/star4"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/rating_star"
+                android:layout_height="@dimen/rating_star_touch_target"
                 android:layout_weight="1"
+                android:paddingTop="@dimen/rating_star_padding"
+                android:paddingBottom="@dimen/rating_star_padding"
                 android:src="@drawable/pt_star_outline"
                 android:contentDescription="@string/rating_star_4" />
 
             <ImageView
                 android:id="@+id/star5"
                 android:layout_width="0dp"
-                android:layout_height="@dimen/rating_star"
+                android:layout_height="@dimen/rating_star_touch_target"
                 android:layout_weight="1"
+                android:paddingTop="@dimen/rating_star_padding"
+                android:paddingBottom="@dimen/rating_star_padding"
                 android:src="@drawable/pt_star_outline"
                 android:contentDescription="@string/rating_star_5" />
 

--- a/clevertap-pushtemplates/src/main/res/values-sw300dp/dimens.xml
+++ b/clevertap-pushtemplates/src/main/res/values-sw300dp/dimens.xml
@@ -15,6 +15,7 @@
     <dimen name="five_cta_icon_margin">6dp</dimen>
 
     <dimen name="manual_carousel_arrow">36dp</dimen>
+    <dimen name="manual_carousel_arrow_padding">12dp</dimen>
 
     <dimen name="chronometer_font_size">20sp</dimen>
 

--- a/clevertap-pushtemplates/src/main/res/values-sw400dp/dimens.xml
+++ b/clevertap-pushtemplates/src/main/res/values-sw400dp/dimens.xml
@@ -19,8 +19,10 @@
     <dimen name="five_cta_icon_margin">8dp</dimen>
 
     <dimen name="manual_carousel_arrow">48dp</dimen>
+    <dimen name="manual_carousel_arrow_padding">0dp</dimen>
 
     <dimen name="rating_star">24dp</dimen>
+    <dimen name="rating_star_padding">12dp</dimen>
 
     <dimen name="chronometer_font_size">20sp</dimen>
 

--- a/clevertap-pushtemplates/src/main/res/values/dimens.xml
+++ b/clevertap-pushtemplates/src/main/res/values/dimens.xml
@@ -34,8 +34,14 @@
     <dimen name="five_cta_padding">6dp</dimen>
 
     <dimen name="manual_carousel_arrow">30dp</dimen>
+    <dimen name="manual_carousel_arrow_touch_target">48dp</dimen>
+    <!-- 48dp - manual_carousel_arrow visual width, applied on the side away from the screen edge -->
+    <dimen name="manual_carousel_arrow_padding">18dp</dimen>
 
     <dimen name="rating_star">20dp</dimen>
+    <dimen name="rating_star_touch_target">48dp</dimen>
+    <!-- (rating_star_touch_target - rating_star) / 2, kept symmetric so the star stays centered in its cell -->
+    <dimen name="rating_star_padding">14dp</dimen>
 
     <dimen name="chronometer_font_size">12sp</dimen>
 

--- a/clevertap-pushtemplates/src/main/res/values/strings.xml
+++ b/clevertap-pushtemplates/src/main/res/values/strings.xml
@@ -10,4 +10,9 @@
     <string name="rating_star_4">Rating Four Star</string>
     <string name="rating_star_5">Rating Five Star</string>
     <string name="pt_big_image_alt">Notification Image</string>
+    <string name="pt_five_icon_1">Notification Icon 1</string>
+    <string name="pt_five_icon_2">Notification Icon 2</string>
+    <string name="pt_five_icon_3">Notification Icon 3</string>
+    <string name="pt_five_icon_4">Notification Icon 4</string>
+    <string name="pt_five_icon_5">Notification Icon 5</string>
 </resources>

--- a/clevertap-pushtemplates/src/main/res/values/styles.xml
+++ b/clevertap-pushtemplates/src/main/res/values/styles.xml
@@ -24,15 +24,17 @@
     </style>
 
     <style name="ManualCarouselArrowRev" parent="android:Widget.TextView">
-        <item name="android:layout_width">@dimen/manual_carousel_arrow</item>
+        <item name="android:layout_width">@dimen/manual_carousel_arrow_touch_target</item>
         <item name="android:layout_height">50dp</item>
+        <item name="android:paddingEnd">@dimen/manual_carousel_arrow_padding</item>
         <item name="android:layout_centerVertical">true</item>
         <item name="android:src">@drawable/pt_arrow_back</item>
     </style>
 
     <style name="ManualCarouselArrowFwd" parent="android:Widget.TextView">
-        <item name="android:layout_width">@dimen/manual_carousel_arrow</item>
+        <item name="android:layout_width">@dimen/manual_carousel_arrow_touch_target</item>
         <item name="android:layout_height">50dp</item>
+        <item name="android:paddingStart">@dimen/manual_carousel_arrow_padding</item>
         <item name="android:layout_centerVertical">true</item>
         <item name="android:layout_alignParentEnd">true</item>
         <item name="android:layout_alignParentRight">true</item>

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
@@ -229,8 +229,8 @@ class TemplateDataFactoryTest {
         val fiveIconsData = result as FiveIconsTemplateData
         assertEquals(TemplateType.FIVE_ICONS, fiveIconsData.templateType)
         assertEquals(imageList, fiveIconsData.imageList)
-        assertEquals(deepLinkList, fiveIconsData.deepLinkList)
-        assertEquals(SAMPLE_TITLE, fiveIconsData.title)
+        assertEquals(deepLinkList, fiveIconsData.baseContent.deepLinkList)
+        assertEquals(SAMPLE_TITLE, fiveIconsData.baseContent.textData.title)
     }
 
     @Test
@@ -593,18 +593,31 @@ class TemplateDataFactoryTest {
     }
 
     @Test
-    fun `FiveIconsTemplateData_toBaseContent should create correct BaseContent`() {
+    fun `FiveIconsTemplateData should expose correct BaseContent`() {
+        // Given
+        val fiveIconsData = createSampleFiveIconsTemplateData()
+
+        // Then
+        assertEquals(SAMPLE_TITLE, fiveIconsData.baseContent.textData.title)
+        assertEquals(SAMPLE_SUBTITLE, fiveIconsData.baseContent.textData.subtitle)
+        assertEquals(SAMPLE_COLOR, fiveIconsData.baseContent.colorData.backgroundColor)
+        assertEquals(arrayListOf("dl1", "dl2"), fiveIconsData.baseContent.deepLinkList)
+    }
+
+    @Test
+    fun `FiveIconsTemplateData_toBasicTemplateData should create correct BasicTemplateData`() {
         // Given
         val fiveIconsData = createSampleFiveIconsTemplateData()
 
         // When
-        val baseContent = with(TemplateDataFactory) { fiveIconsData.toBaseContent() }
+        val basicData = with(TemplateDataFactory) { fiveIconsData.toBasicTemplateData() }
 
         // Then
-        assertEquals(fiveIconsData.title, baseContent.textData.title)
-        assertEquals(fiveIconsData.subtitle, baseContent.textData.subtitle)
-        assertEquals(fiveIconsData.backgroundColor, baseContent.colorData.backgroundColor)
-        assertEquals(fiveIconsData.deepLinkList, baseContent.deepLinkList)
+        assertEquals(TemplateType.BASIC, basicData.templateType)
+        assertEquals(fiveIconsData.baseContent, basicData.baseContent)
+        assertNull(basicData.actions)
+        assertNull(basicData.mediaData.bigImage.url)
+        assertNull(basicData.mediaData.gif.url)
     }
 
     @Test
@@ -893,12 +906,17 @@ class TemplateDataFactoryTest {
 
     private fun createSampleFiveIconsTemplateData(): FiveIconsTemplateData {
         return FiveIconsTemplateData(
+            baseContent = BaseContent(
+                textData = BaseTextData(
+                    title = SAMPLE_TITLE,
+                    subtitle = SAMPLE_SUBTITLE
+                ),
+                colorData = BaseColorData(backgroundColor = SAMPLE_COLOR),
+                iconData = IconData(),
+                deepLinkList = arrayListOf("dl1", "dl2"),
+                notificationBehavior = NotificationBehavior()
+            ),
             imageList = arrayListOf(),
-            deepLinkList = arrayListOf("dl1", "dl2"),
-            backgroundColor = SAMPLE_COLOR,
-            title = SAMPLE_TITLE,
-            subtitle = SAMPLE_SUBTITLE,
-            notificationBehavior = NotificationBehavior()
         )
     }
 
@@ -961,8 +979,8 @@ class TemplateDataFactoryTest {
         // Then
         assertTrue(result is FiveIconsTemplateData)
         val fiveIconsData = result as FiveIconsTemplateData
-        assertFalse(fiveIconsData.notificationBehavior.isSticky)
-        assertNull(fiveIconsData.notificationBehavior.dismissAfter)
+        assertFalse(fiveIconsData.baseContent.notificationBehavior.isSticky)
+        assertNull(fiveIconsData.baseContent.notificationBehavior.dismissAfter)
     }
 
     @Test
@@ -2410,7 +2428,8 @@ class TemplateDataFactoryTest {
 
         // Then
         assertNotNull(result.collapsedButtonData)
-        assertEquals(PT_BTN_BORDER_RADIUS_DEFAULT, result.collapsedButtonData!!.borderRadius)
-        assertEquals(PT_BTN_BORDER_WIDTH_DEFAULT, result.collapsedButtonData!!.borderWidth)
+        val collapsedButtonData = result.collapsedButtonData ?: error("collapsedButtonData should not be null")
+        assertEquals(PT_BTN_BORDER_RADIUS_DEFAULT, collapsedButtonData.borderRadius)
+        assertEquals(PT_BTN_BORDER_WIDTH_DEFAULT, collapsedButtonData.borderWidth)
     }
 }

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateRendererTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateRendererTest.kt
@@ -461,6 +461,7 @@ class TemplateRendererTest {
         fiveIconsBundle.putString(PTConstants.PT_ID, "pt_five_icons")
 
         val templateRendererLocal = TemplateRenderer(context, fiveIconsBundle, mockConfig)
+        val mockFiveIconsFallbackData = mockk<BasicTemplateData>(relaxed = true)
 
         // Arrange
         every {
@@ -474,6 +475,19 @@ class TemplateRendererTest {
         } returns mockFiveIconsTemplateData
         every { ValidatorFactory.getValidator(mockFiveIconsTemplateData) } returns mockContentValidator
         every { mockContentValidator.validate() } returns false
+        every { with(TemplateDataFactory) { mockFiveIconsTemplateData.toBasicTemplateData() } } returns mockFiveIconsFallbackData
+        every { ValidatorFactory.getValidator(mockFiveIconsFallbackData) } returns mockContentValidator
+        every { mockContentValidator.validate() } returnsMany listOf(false, true)
+
+        mockkConstructor(BasicStyle::class)
+        every {
+            anyConstructed<BasicStyle>().builderFromStyle(
+                any(),
+                fiveIconsBundle,
+                123,
+                mockNotificationBuilder
+            )
+        } returns mockNotificationBuilder
 
         // Act
         val result = templateRendererLocal.renderNotification(
@@ -485,7 +499,7 @@ class TemplateRendererTest {
         )
 
         // Assert
-        assertNull(result)
+        assertEquals(mockNotificationBuilder, result)
     }
 
     @Test
@@ -1120,6 +1134,7 @@ class TemplateRendererTest {
         fiveIconsBundle.putString(PTConstants.PT_ID, "pt_five_icons")
 
         val templateRendererLocal = TemplateRenderer(context, fiveIconsBundle, mockConfig)
+        val mockFiveIconsFallbackData = mockk<BasicTemplateData>(relaxed = true)
 
         every {
             TemplateDataFactory.createTemplateData(
@@ -1132,6 +1147,9 @@ class TemplateRendererTest {
         } returns mockFiveIconsTemplateData
         every { ValidatorFactory.getValidator(mockFiveIconsTemplateData) } returns mockContentValidator
         every { mockContentValidator.validate() } returns true
+        every { with(TemplateDataFactory) { mockFiveIconsTemplateData.toBasicTemplateData() } } returns mockFiveIconsFallbackData
+        every { ValidatorFactory.getValidator(mockFiveIconsFallbackData) } returns mockContentValidator
+        every { mockContentValidator.validate() } returnsMany listOf(true, true)
 
         val mockSmallContentView = mockk<FiveIconSmallContentView>()
         val mockBigContentView = mockk<FiveIconBigContentView>()
@@ -1149,6 +1167,15 @@ class TemplateRendererTest {
         } returns mockNotificationBuilder
         every { anyConstructed<FiveIconStyle>().fiveIconSmallContentView } returns mockSmallContentView
         every { anyConstructed<FiveIconStyle>().fiveIconBigContentView } returns mockBigContentView
+        mockkConstructor(BasicStyle::class)
+        every {
+            anyConstructed<BasicStyle>().builderFromStyle(
+                any(),
+                fiveIconsBundle,
+                123,
+                mockNotificationBuilder
+            )
+        } returns mockNotificationBuilder
 
         // Act
         val result = templateRendererLocal.renderNotification(
@@ -1159,7 +1186,7 @@ class TemplateRendererTest {
             123
         )
 
-        assertNull(result)
+        assertEquals(mockNotificationBuilder, result)
     }
 
 
@@ -1170,6 +1197,7 @@ class TemplateRendererTest {
         fiveIconsBundle.putString(PTConstants.PT_ID, "pt_five_icons")
 
         val templateRendererLocal = TemplateRenderer(context, fiveIconsBundle, mockConfig)
+        val mockFiveIconsFallbackData = mockk<BasicTemplateData>(relaxed = true)
 
         every {
             TemplateDataFactory.createTemplateData(
@@ -1182,6 +1210,9 @@ class TemplateRendererTest {
         } returns mockFiveIconsTemplateData
         every { ValidatorFactory.getValidator(mockFiveIconsTemplateData) } returns mockContentValidator
         every { mockContentValidator.validate() } returns true
+        every { with(TemplateDataFactory) { mockFiveIconsTemplateData.toBasicTemplateData() } } returns mockFiveIconsFallbackData
+        every { ValidatorFactory.getValidator(mockFiveIconsFallbackData) } returns mockContentValidator
+        every { mockContentValidator.validate() } returnsMany listOf(true, true)
 
         val mockSmallContentView = mockk<FiveIconSmallContentView>()
         val mockBigContentView = mockk<FiveIconBigContentView>()
@@ -1199,75 +1230,26 @@ class TemplateRendererTest {
         } returns mockNotificationBuilder
         every { anyConstructed<FiveIconStyle>().fiveIconSmallContentView } returns mockSmallContentView
         every { anyConstructed<FiveIconStyle>().fiveIconBigContentView } returns mockBigContentView
-
-        // Act
-        val result = templateRendererLocal.renderNotification(
-            fiveIconsBundle,
-            context,
-            mockNotificationBuilder,
-            mockConfig,
-            123
-        )
-
-        assertNull(result)
-    }
-
-    @Test
-    fun test_renderNotification_five_icons_template_invalid_unloaded_icons() {
-        // Arrange
-        val fiveIconsBundle = Bundle(testBundle)
-        fiveIconsBundle.putString(PTConstants.PT_ID, "pt_five_icons")
-
-        val templateRendererLocal = TemplateRenderer(context, fiveIconsBundle, mockConfig)
-
+        mockkConstructor(BasicStyle::class)
         every {
-            TemplateDataFactory.createTemplateData(
-                TemplateType.FIVE_ICONS,
-                fiveIconsBundle,
-                false,
-                any(),
-                any()
-            )
-        } returns mockFiveIconsTemplateData
-        every { ValidatorFactory.getValidator(mockFiveIconsTemplateData) } returns mockContentValidator
-        every { mockContentValidator.validate() } returns true
-
-        val mockSmallContentView = mockk<FiveIconSmallContentView>()
-        val mockBigContentView = mockk<FiveIconBigContentView>()
-        every { mockSmallContentView.getUnloadedFiveIconsCount() } returns 3 // More than 2
-        every { mockBigContentView.getUnloadedFiveIconsCount() } returns 1
-
-        mockkConstructor(FiveIconStyle::class)
-        every {
-            anyConstructed<FiveIconStyle>().builderFromStyle(
-                any(),
-                any(),
-                any(),
-                any()
-            )
-        } returns mockNotificationBuilder
-        every { anyConstructed<FiveIconStyle>().fiveIconSmallContentView } returns mockSmallContentView
-        every { anyConstructed<FiveIconStyle>().fiveIconBigContentView } returns mockBigContentView
-
-        // Act
-        val result = templateRendererLocal.renderNotification(
-            fiveIconsBundle,
-            context,
-            mockNotificationBuilder,
-            mockConfig,
-            123
-        )
-
-        // Assert
-        verify {
-            anyConstructed<FiveIconStyle>().builderFromStyle(
+            anyConstructed<BasicStyle>().builderFromStyle(
                 any(),
                 fiveIconsBundle,
                 123,
                 mockNotificationBuilder
             )
-        }
-        assertNull(result) // Should return null when too many unloaded icons
+        } returns mockNotificationBuilder
+
+        // Act
+        val result = templateRendererLocal.renderNotification(
+            fiveIconsBundle,
+            context,
+            mockNotificationBuilder,
+            mockConfig,
+            123
+        )
+
+        assertEquals(mockNotificationBuilder, result)
     }
 
     @Test

--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -1,11 +1,35 @@
 ## CleverTap Android SDK CHANGE LOG
+### Version 8.4.0 (July 28, 2026)
+
+#### New Features
+* **Split of Clicks:**
+    Adds per-element click attribution to In-Apps `Notification Clicked` event across all in-app templates. Also adds configurable 
+    swipe-to-dismiss gesture for In-Apps, and tracks these dismissals as Notification Clicked events.
+    
+#### Improvements
+* **Accessibility:**
+    Enhances accessibility across In-App notifications and App Inbox with dynamic text scaling, screen-reader announcements and 
+    content descriptions (close button, images, media controls), a larger 48dp dismiss-button tap area, and corrected carousel 
+    TalkBack navigation — helping apps meet accessibility standards.
+    
+#### Bug Fixes
+* **App Inbox on Android 6.0 – 10:** Fixes a critical issue where App Inbox messages were never saved on the device, leaving the inbox permanently empty on Android 6.0 through Android 10 (API 23 – 29). The SDK was using a SQLite statement (`UPSERT`) that needs SQLite 3.24.0 or newer, which Android only ships from Android 11 onwards, so every inbox write failed silently on older devices. Present in `v8.2.0` and `v8.3.0`.
+    * **Note:** This affects **every account using App Inbox**, not only those enabled for App Inbox Cross-Device Sync. Messages delivered the classic way and messages delivered through Cross-Device Sync are saved by the same code, so both were affected.
+    * **Note:** No code change or migration is required on your side. After updating, messages reappear automatically on the next inbox fetch.
+* **Crash while playing video on Android 6.0:** Fixes an `AbstractMethodError` crash seen when a Picture-in-Picture (PIP) In-App notification played a video on Android 6.0 (API 23). Media3's `Player.Listener` interface relies on Java 8 default methods, which Android 6.0 does not support at runtime, so any callback the SDK had not explicitly overridden crashed the app. The SDK's shared `Media3PlayerListener` now implements all of them. Only affects apps whose `minSdkVersion` is below 24.
+    * **Note:** This listener is shared by every Media3 video surface, so the fix also protects In-App video and App Inbox video playback on Android 6.0, not only PIP.
+
 ### Version 8.3.0 (June 2026)
+> ‼️ **NOTE**
+App Inbox messages are not saved on Android 6.0 – 10 (API 23 – 29) in this version, leaving the inbox empty on those devices. This affects every account using App Inbox, not only those enabled for App Inbox Cross-Device Sync. Please update to 8.4.0 or above.
 
 #### New Features
 * **Native Display Element Click:** New `pushDisplayUnitElementClickedEventForID(String unitID, HashMap<String, Object> additionalProperties)` on `CleverTapAPI` records a `Notification Clicked` event for a specific element within a Display Unit. Caller-supplied `additionalProperties` (including `wzrk_element_id` from the action's `metadata`) are merged first, then enriched with cached `wzrk_*` attribution fields from the unit — giving finer-grained click analytics for Native Display experiences.
 * **Display Unit Cache API:** New public interface `DisplayUnitCache` and `setDisplayUnitCache(DisplayUnitCache)` on `CleverTapAPI` let external SDKs (e.g. the Native Display SDK) inject a custom display-unit store. `getAllDisplayUnits()` and `getDisplayUnitForID()` now route through this cache. The default implementation (`CTDisplayUnitController`) remains active when no override is installed.
 
 ### Version 8.2.0 (May 20, 2026)
+> ‼️ **NOTE**
+App Inbox messages are not saved on Android 6.0 – 10 (API 23 – 29) in this version, leaving the inbox empty on those devices. This affects every account using App Inbox, not only those enabled for App Inbox Cross-Device Sync. Please update to 8.4.0 or above.
 
 #### New Features
 * **App Inbox Cross-Device Sync:** App Inbox messages now sync across a user's devices. If a user deletes or reads a message on one device, it is automatically reflected on their other devices.

--- a/docs/CTGEOFENCE.md
+++ b/docs/CTGEOFENCE.md
@@ -17,7 +17,7 @@ Add the following dependencies to the `build.gradle`
 
 ```Groovy
 implementation "com.clevertap.android:clevertap-geofence-sdk:1.4.0"
-implementation "com.clevertap.android:clevertap-android-sdk:8.3.0" // 3.9.0 and above
+implementation "com.clevertap.android:clevertap-android-sdk:8.4.0" // 3.9.0 and above
 implementation "com.google.android.gms:play-services-location:21.3.0"
 implementation "androidx.work:work-runtime:2.10.2" // required for FETCH_LAST_LOCATION_PERIODIC
 implementation "androidx.concurrent:concurrent-futures:1.2.0" // required for FETCH_LAST_LOCATION_PERIODIC

--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -147,11 +147,15 @@ pt_product_display_linear | Optional | `true`
 
 ## Five Icons Template
 
-Five icons template is a push notification with no text, just 5 icons which can help your users go directly to the functionality of their choice with a button's click.
+Five icons template is a push notification that can display a title and message above a row of up to 5 icons. It helps users go directly to the functionality of their choice with a button click.
 
-If at least 3 icons are not retrieved, the library doesn't render any notification. The bifurcation of each CTA is captured in the event Notification Clicked with in the property `wzrk_c2a`.
+`pt_title` and `pt_msg` are optional. On Android 12 and above, they are rendered above the icon row using `DecoratedCustomViewStyle`. On earlier Android versions, the notification uses a custom view and the title/message position may differ from standard notification chrome.
 
-If user clicks on any notification area except the five icons, then by default it will launch an activity intent.
+If the payload does not contain enough valid icon/deeplink data, or if 3 or more icon images are not retrieved at render time, the library falls back to a basic notification using the available title and message content.
+
+The CTA associated with each icon is captured in the `Notification Clicked` event under the `wzrk_c2a` property.
+
+If the user clicks anywhere outside the icon CTAs, the default notification click action launches the activity intent.
 
 <img src="https://github.com/CleverTap/clevertap-android-sdk/blob/master/static/fiveicon.png" width="412" height="100">
 
@@ -421,6 +425,8 @@ pt_json | Optional  | Above keys in JSON format
 Five Icons Template Keys | Required | Description
   ---:|:---:|:--- 
 pt_id | Required  | Value - `pt_five_icons`
+pt_title | Optional | Title rendered above icons
+pt_msg | Optional | Message rendered above icons
 pt_img1 | Required  | Icon One
 pt_img1_alt_text | Optional | Alt Text for Icon One
 pt_img2 | Required  | Icon Two

--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -20,8 +20,8 @@ CleverTap Push Templates SDK helps you engage with your users using fancy push n
 1. Add the dependencies to the `build.gradle`
 
 ```groovy
-implementation "com.clevertap.android:push-templates:2.4.0"
-implementation "com.clevertap.android:clevertap-android-sdk:8.3.0" // 4.4.0 and above
+implementation "com.clevertap.android:push-templates:2.5.0"
+implementation "com.clevertap.android:clevertap-android-sdk:8.4.0" // 4.4.0 and above
 ```
 
 2. Add the following line to your Application class before the `onCreate()`

--- a/docs/CTPUSHTEMPLATESCHANGELOG.md
+++ b/docs/CTPUSHTEMPLATESCHANGELOG.md
@@ -1,4 +1,18 @@
 ## CleverTap Push Templates SDK CHANGE LOG
+### Version 2.5.0 (July 28, 2026)
+
+#### New Features
+* **Five Icons Template:** Adds title and message text support to the `Five Icons` template, and a text-only fallback notification when the template cannot be rendered.
+* **Vertical Template:** Adds HTML formatting support for the `line1` and `line2` text fields of the `pt_vertical_image` template.
+
+#### Enhancements
+* Enhances accessibility for the `Manual Carousel` and `Rating` templates for BIS compliance.
+
+#### Bug Fixes
+* Fixes icon clipping in the collapsed view of the `Five Icons` template when a title or message is present, by using a shorter icon strip.
+* Fixes the chronometer color format and border rendering in the `Timer` template.
+* Fixes a crash (`SecurityException`) during the pre-download network check when the host app does not hold the `ACCESS_NETWORK_STATE` permission.
+
 ### Version 2.4.0 (April 13, 2026)
 
 #### New Features

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,11 +50,11 @@ lifecycleRuntimeTesting = "2.9.4"
 installreferrer = "2.2"
 
 #SDK Versions
-clevertap_android_sdk = "8.3.0"
+clevertap_android_sdk = "8.4.0"
 clevertap_rendermax_sdk = "1.0.3"
 clevertap_geofence_sdk = "1.4.0"
 clevertap_hms_sdk = "1.5.1"
-clevertap_push_templates_sdk = "2.4.0"
+clevertap_push_templates_sdk = "2.5.0"
 
 # Glide
 glide = "4.12.0"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -179,14 +179,14 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
     implementation "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.1.1"*/
 
-    remoteImplementation("com.clevertap.android:clevertap-android-sdk:8.2.0")
+    remoteImplementation("com.clevertap.android:clevertap-android-sdk:8.4.0")
     remoteImplementation("com.clevertap.android:clevertap-geofence-sdk:1.4.0")
-    remoteImplementation("com.clevertap.android:push-templates:2.4.0")
+    remoteImplementation("com.clevertap.android:push-templates:2.5.0")
     remoteImplementation("com.clevertap.android:clevertap-hms-sdk:1.5.1")
 
-    stagingImplementation("com.clevertap.android:clevertap-android-sdk:8.2.0")
+    stagingImplementation("com.clevertap.android:clevertap-android-sdk:8.4.0")
     stagingImplementation("com.clevertap.android:clevertap-geofence-sdk:1.4.0")
-    stagingImplementation("com.clevertap.android:push-templates:2.4.0")
+    stagingImplementation("com.clevertap.android:push-templates:2.5.0")
     stagingImplementation("com.clevertap.android:clevertap-hms-sdk:1.5.1")
 }
 

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -1,11 +1,35 @@
 ## CleverTap Android SDK CHANGE LOG
+### Version 8.4.0 (July 28, 2026)
+
+#### New Features
+* **Split of Clicks:**
+    Adds per-element click attribution to In-Apps `Notification Clicked` event across all in-app templates. Also adds configurable 
+    swipe-to-dismiss gesture for In-Apps, and tracks these dismissals as Notification Clicked events.
+    
+#### Improvements
+* **Accessibility:**
+    Enhances accessibility across In-App notifications and App Inbox with dynamic text scaling, screen-reader announcements and 
+    content descriptions (close button, images, media controls), a larger 48dp dismiss-button tap area, and corrected carousel 
+    TalkBack navigation — helping apps meet accessibility standards.
+    
+#### Bug Fixes
+* **App Inbox on Android 6.0 – 10:** Fixes a critical issue where App Inbox messages were never saved on the device, leaving the inbox permanently empty on Android 6.0 through Android 10 (API 23 – 29). The SDK was using a SQLite statement (`UPSERT`) that needs SQLite 3.24.0 or newer, which Android only ships from Android 11 onwards, so every inbox write failed silently on older devices. Present in `v8.2.0` and `v8.3.0`.
+    * **Note:** This affects **every account using App Inbox**, not only those enabled for App Inbox Cross-Device Sync. Messages delivered the classic way and messages delivered through Cross-Device Sync are saved by the same code, so both were affected.
+    * **Note:** No code change or migration is required on your side. After updating, messages reappear automatically on the next inbox fetch.
+* **Crash while playing video on Android 6.0:** Fixes an `AbstractMethodError` crash seen when a Picture-in-Picture (PIP) In-App notification played a video on Android 6.0 (API 23). Media3's `Player.Listener` interface relies on Java 8 default methods, which Android 6.0 does not support at runtime, so any callback the SDK had not explicitly overridden crashed the app. The SDK's shared `Media3PlayerListener` now implements all of them. Only affects apps whose `minSdkVersion` is below 24.
+    * **Note:** This listener is shared by every Media3 video surface, so the fix also protects In-App video and App Inbox video playback on Android 6.0, not only PIP.
+
 ### Version 8.3.0 (June 2026)
+> ‼️ **NOTE**
+App Inbox messages are not saved on Android 6.0 – 10 (API 23 – 29) in this version, leaving the inbox empty on those devices. This affects every account using App Inbox, not only those enabled for App Inbox Cross-Device Sync. Please update to 8.4.0 or above.
 
 #### New Features
 * **Native Display Element Click:** New `pushDisplayUnitElementClickedEventForID(String unitID, HashMap<String, Object> additionalProperties)` on `CleverTapAPI` records a `Notification Clicked` event for a specific element within a Display Unit. Caller-supplied `additionalProperties` (including `wzrk_element_id` from the action's `metadata`) are merged first, then enriched with cached `wzrk_*` attribution fields from the unit — giving finer-grained click analytics for Native Display experiences.
 * **Display Unit Cache API:** New public interface `DisplayUnitCache` and `setDisplayUnitCache(DisplayUnitCache)` on `CleverTapAPI` let external SDKs (e.g. the Native Display SDK) inject a custom display-unit store. `getAllDisplayUnits()` and `getDisplayUnitForID()` now route through this cache. The default implementation (`CTDisplayUnitController`) remains active when no override is installed.
 
 ### Version 8.2.0 (May 20, 2026)
+> ‼️ **NOTE**
+App Inbox messages are not saved on Android 6.0 – 10 (API 23 – 29) in this version, leaving the inbox empty on those devices. This affects every account using App Inbox, not only those enabled for App Inbox Cross-Device Sync. Please update to 8.4.0 or above.
 
 #### New Features
 * **App Inbox Cross-Device Sync:** App Inbox messages now sync across a user's devices. If a user deletes or reads a message on one device, it is automatically reflected on their other devices.

--- a/templates/CTPUSHTEMPLATES.md
+++ b/templates/CTPUSHTEMPLATES.md
@@ -147,11 +147,15 @@ pt_product_display_linear | Optional | `true`
 
 ## Five Icons Template
 
-Five icons template is a push notification with no text, just 5 icons which can help your users go directly to the functionality of their choice with a button's click.
+Five icons template is a push notification that can display a title and message above a row of up to 5 icons. It helps users go directly to the functionality of their choice with a button click.
 
-If at least 3 icons are not retrieved, the library doesn't render any notification. The bifurcation of each CTA is captured in the event Notification Clicked with in the property `wzrk_c2a`.
+`pt_title` and `pt_msg` are optional. On Android 12 and above, they are rendered above the icon row using `DecoratedCustomViewStyle`. On earlier Android versions, the notification uses a custom view and the title/message position may differ from standard notification chrome.
 
-If user clicks on any notification area except the five icons, then by default it will launch an activity intent.
+If the payload does not contain enough valid icon/deeplink data, or if 3 or more icon images are not retrieved at render time, the library falls back to a basic notification using the available title and message content.
+
+The CTA associated with each icon is captured in the `Notification Clicked` event under the `wzrk_c2a` property.
+
+If the user clicks anywhere outside the icon CTAs, the default notification click action launches the activity intent.
 
 <img src="https://github.com/CleverTap/clevertap-android-sdk/blob/master/static/fiveicon.png" width="412" height="100">
 
@@ -421,6 +425,8 @@ pt_json | Optional  | Above keys in JSON format
 Five Icons Template Keys | Required | Description
   ---:|:---:|:--- 
 pt_id | Required  | Value - `pt_five_icons`
+pt_title | Optional | Title rendered above icons
+pt_msg | Optional | Message rendered above icons
 pt_img1 | Required  | Icon One
 pt_img1_alt_text | Optional | Alt Text for Icon One
 pt_img2 | Required  | Icon Two

--- a/templates/CTPUSHTEMPLATESCHANGELOG.md
+++ b/templates/CTPUSHTEMPLATESCHANGELOG.md
@@ -1,4 +1,18 @@
 ## CleverTap Push Templates SDK CHANGE LOG
+### Version 2.5.0 (July 28, 2026)
+
+#### New Features
+* **Five Icons Template:** Adds title and message text support to the `Five Icons` template, and a text-only fallback notification when the template cannot be rendered.
+* **Vertical Template:** Adds HTML formatting support for the `line1` and `line2` text fields of the `pt_vertical_image` template.
+
+#### Enhancements
+* Enhances accessibility for the `Manual Carousel` and `Rating` templates for BIS compliance.
+
+#### Bug Fixes
+* Fixes icon clipping in the collapsed view of the `Five Icons` template when a title or message is present, by using a shorter icon strip.
+* Fixes the chronometer color format and border rendering in the `Timer` template.
+* Fixes a crash (`SecurityException`) during the pre-download network check when the host app does not hold the `ACCESS_NETWORK_STATE` permission.
+
 ### Version 2.4.0 (April 13, 2026)
 
 #### New Features


### PR DESCRIPTION
 ### Features
  - **Split of Clicks (SDK-5810)** — per-element in-app click tracking: clicked events now
    carry element identity + action descriptors; extended to PIP in-apps.
    (#1031, #1037)
  - **Accessibility / BIS compliance (in-app, App Inbox, Push Templates)** (#1025, #1039)
    - In-app close button touch target increased to 48dp + accessibility label.
    - Announce in-app message to screen readers (localized via string resource;
      uses `View.announceForAccessibility`).
    - `importantForAccessibility` set on in-app images based on content description.
    - Corrected carousel TalkBack behaviour; simplified pager a11y.
  - **Push Templates — Five Icons**: title/message support with basic fallback
    (+ docs update). (#1003, #1004)
  
  ### Fixes
  - **Timer push template**: correct chrono color format and border rendering. (#1019)
  - **In-app close icon (SDK-5897)**: load via static resource reference and ship the
    corresponding ProGuard/R8 keep rule.
  - **PIP playback (SDK-5951)**. (#1040)
  - In-app cover / half-interstitial landscape & tablet layout adjustments.
