### PR TITLE
feat(push-templates): add image border configurability across all push templates…

### DIFF
--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PTConstants.java
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PTConstants.java
@@ -226,6 +226,11 @@ public class PTConstants {
     public static final float PT_BTN_BORDER_RADIUS_DEFAULT = 4f;
     public static final float PT_BTN_BORDER_WIDTH_DEFAULT = 1f;
 
+    // Image border configuration (applies to the main notification image across templates)
+    public static final String PT_IMG_BORDER_CLR = "pt_img_border_clr";
+    public static final String PT_IMG_CORNER_RADIUS = "pt_img_corner_radius";
+    public static final String PT_IMG_BORDER_WIDTH = "pt_img_border_width";
+
     // Vertical Image Template - Collapsed button configuration
     public static final String PT_BTN_CLR_COLLAPSED = "pt_btn_clr_collapsed";
     public static final String PT_BTN_BORDER_CLR_COLLAPSED = "pt_btn_border_clr_collapsed";
@@ -256,6 +261,7 @@ public class PTConstants {
             PT_BTN_BORDER_CLR_COLLAPSED,
             PT_BTN_TEXT_CLR_COLLAPSED,
             PT_BTN_GRAD_CLR1_COLLAPSED,
-            PT_BTN_GRAD_CLR2_COLLAPSED);
+            PT_BTN_GRAD_CLR2_COLLAPSED,
+            PT_IMG_BORDER_CLR);
 
 }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PushTemplateReceiver.java
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PushTemplateReceiver.java
@@ -208,6 +208,11 @@ public class PushTemplateReceiver extends BroadcastReceiver {
             imageList = extras.getStringArrayList(PTConstants.PT_IMAGE_LIST);
             deepLinkList = extras.getStringArrayList(PTConstants.PT_DEEPLINK_LIST);
 
+            if (imageList == null || imageList.isEmpty()) {
+                PTLog.verbose("Manual Carousel image list is null or empty, skipping swipe");
+                return;
+            }
+
             int currPosition = extras.getInt(PTConstants.PT_MANUAL_CAROUSEL_CURRENT);
             int newPosition;
             if (rightSwipe) {

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PushTemplateReceiver.java
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/PushTemplateReceiver.java
@@ -231,14 +231,16 @@ public class PushTemplateReceiver extends BroadcastReceiver {
             }
             String dl = "";
 
-            if (deepLinkList != null && deepLinkList.size() == imageList.size()) {
-                dl = deepLinkList.get(newPosition);
-            } else if (deepLinkList != null && deepLinkList.size() == 1) {
-                dl = deepLinkList.get(0);
-            } else if (deepLinkList != null && deepLinkList.size() > newPosition) {
-                dl = deepLinkList.get(newPosition);
-            } else if (deepLinkList != null && deepLinkList.size() < newPosition) {
-                dl = deepLinkList.get(0);
+            if (deepLinkList != null && !deepLinkList.isEmpty()) {
+                if (deepLinkList.size() == imageList.size()) {
+                    dl = deepLinkList.get(newPosition);
+                } else if (deepLinkList.size() == 1) {
+                    dl = deepLinkList.get(0);
+                } else if (newPosition < deepLinkList.size()) {
+                    dl = deepLinkList.get(newPosition);
+                } else {
+                    dl = deepLinkList.get(0);
+                }
             }
 
             extras.putInt(PTConstants.PT_MANUAL_CAROUSEL_CURRENT, newPosition);

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
@@ -37,13 +37,16 @@ internal data class BaseTextData(
  * [borderColor] is already parsed into an Android colour int by [TemplateDataFactory], so an
  * unparseable colour from the payload lands here as null and [isActive] stays honest about
  * whether there is anything to draw.
+ *
+ * The two size values are percentages of the image's shortest side, not absolute pixels, because
+ * campaign images vary in resolution. See NotificationBitmapUtils.applyRoundedBorderToBitmap.
  */
 internal data class ImageBorderData(
     val borderColor: Int? = null,
-    val cornerRadius: Float = 0f,
-    val borderWidth: Float? = null,
+    val cornerRadiusPercent: Float = 0f,
+    val borderWidthPercent: Float? = null,
 ) {
-    val isActive: Boolean get() = cornerRadius > 0f || borderColor != null
+    val isActive: Boolean get() = cornerRadiusPercent > 0f || borderColor != null
 }
 
 /**

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
@@ -46,6 +46,21 @@ internal data class ImageBorderData(
     val isActive: Boolean get() = cornerRadius > 0f || borderColor != null
 }
 
+/**
+ * Rounded corners and borders are baked into the bitmap, so a CENTER_CROP image view would crop
+ * them away. Returns FIT_CENTER whenever a border is active, otherwise the requested scale type.
+ */
+internal fun ImageBorderData?.effectiveScaleType(requested: PTScaleType): PTScaleType {
+    if (this == null || !isActive) return requested
+    if (requested != PTScaleType.FIT_CENTER) {
+        PTLog.debug(
+            "Image border is active, overriding scale type $requested with FIT_CENTER so the " +
+                    "rounded corners and border stay visible"
+        )
+    }
+    return PTScaleType.FIT_CENTER
+}
+
 internal data class MediaData(
     val bigImage: ImageData,
     val gif: GifData,

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
@@ -31,10 +31,19 @@ internal data class BaseTextData(
     val subtitle: String? = null,
 )
 
+internal data class ImageBorderData(
+    val borderColor: String? = null,
+    val cornerRadius: Float = 0f,
+    val borderWidth: Float? = null,
+) {
+    val isActive: Boolean get() = cornerRadius > 0f || borderColor != null
+}
+
 internal data class MediaData(
     val bigImage: ImageData,
     val gif: GifData,
     val scaleType: PTScaleType = PTScaleType.CENTER_CROP,
+    val imageBorderData: ImageBorderData = ImageBorderData(),
 )
 
 internal data class IconData(
@@ -66,6 +75,7 @@ internal data class CarouselData(
     val actions: JSONArray? = null,
     val imageList: ArrayList<ImageData>,
     val scaleType: PTScaleType = PTScaleType.CENTER_CROP,
+    val imageBorderData: ImageBorderData = ImageBorderData(),
 )
 
 internal data class BasicTemplateData(
@@ -82,7 +92,8 @@ internal data class FiveIconsTemplateData(
     val backgroundColor: String? = null,
     val title: String? = null,
     val subtitle: String? = null,
-    val notificationBehavior: NotificationBehavior
+    val notificationBehavior: NotificationBehavior,
+    val imageBorderData: ImageBorderData = ImageBorderData(),
 ) : TemplateData()
 
 internal data class ManualCarouselTemplateData(
@@ -144,6 +155,7 @@ internal data class ProductTemplateData(
     val displayActionColor: String? = null,
     val displayActionTextColor: String? = null,
     val isLinear: Boolean = false,
+    val imageBorderData: ImageBorderData = ImageBorderData(),
 ) : TemplateData()
 
 internal data class InputBoxTemplateData(

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateData.kt
@@ -31,8 +31,15 @@ internal data class BaseTextData(
     val subtitle: String? = null,
 )
 
+/**
+ * Border/corner configuration for the main notification image.
+ *
+ * [borderColor] is already parsed into an Android colour int by [TemplateDataFactory], so an
+ * unparseable colour from the payload lands here as null and [isActive] stays honest about
+ * whether there is anything to draw.
+ */
 internal data class ImageBorderData(
-    val borderColor: String? = null,
+    val borderColor: Int? = null,
     val cornerRadius: Float = 0f,
     val borderWidth: Float? = null,
 ) {

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
@@ -376,8 +376,9 @@ internal object TemplateDataFactory {
         return ImageBorderData(
             // Parse here rather than at draw time so an invalid colour never marks the border active
             borderColor = colorMap[PT_IMG_BORDER_CLR]?.let { Utils.getColourOrNull(it) },
-            cornerRadius = extras.getString(PT_IMG_CORNER_RADIUS)?.toFloatOrNull() ?: 0f,
-            borderWidth = extras.getString(PT_IMG_BORDER_WIDTH)?.toFloatOrNull()
+            // Both values are percentages of the image's shortest side, clamped when drawn
+            cornerRadiusPercent = extras.getString(PT_IMG_CORNER_RADIUS)?.toFloatOrNull() ?: 0f,
+            borderWidthPercent = extras.getString(PT_IMG_BORDER_WIDTH)?.toFloatOrNull()
         )
     }
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
@@ -72,6 +72,9 @@ import com.clevertap.android.pushtemplates.PTConstants.PT_TITLE_COLOR
 import com.clevertap.android.pushtemplates.PTConstants.TEXT_ONLY
 import com.clevertap.android.pushtemplates.PTConstants.PT_CHRONO_BORDER_RADIUS
 import com.clevertap.android.pushtemplates.PTConstants.PT_CHRONO_BORDER_WIDTH
+import com.clevertap.android.pushtemplates.PTConstants.PT_IMG_BORDER_CLR
+import com.clevertap.android.pushtemplates.PTConstants.PT_IMG_BORDER_WIDTH
+import com.clevertap.android.pushtemplates.PTConstants.PT_IMG_CORNER_RADIUS
 import com.clevertap.android.pushtemplates.handlers.TimerTemplateHandler
 import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.Constants.WZRK_COLOR
@@ -175,7 +178,7 @@ internal object TemplateDataFactory {
     ): BasicTemplateData {
         return BasicTemplateData(
             baseContent = createBaseContent(extras, colorMap),
-            mediaData = createMediaData(extras, defaultAltText),
+            mediaData = createMediaData(extras, colorMap, defaultAltText),
             actions = Utils.getActionKeys(extras)
         )
     }
@@ -212,7 +215,7 @@ internal object TemplateDataFactory {
 
         return RatingTemplateData(
             baseContent = createBaseContent(extras, colorMap),
-            mediaData = createMediaData(extras, defaultAltText),
+            mediaData = createMediaData(extras, colorMap, defaultAltText),
             defaultDeepLink = defaultDeepLink
         )
     }
@@ -228,7 +231,8 @@ internal object TemplateDataFactory {
             backgroundColor = colorMap[PT_BG],
             title = getStringWithFallback(extras, PT_TITLE, Constants.NOTIF_TITLE),
             subtitle = getStringWithFallback(extras, PT_SUBTITLE, Constants.WZRK_SUBTITLE),
-            notificationBehavior = createNotificationBehaviorData(extras)
+            notificationBehavior = createNotificationBehaviorData(extras),
+            imageBorderData = createImageBorderData(extras, colorMap)
         )
     }
 
@@ -248,7 +252,8 @@ internal object TemplateDataFactory {
             displayActionColor = colorMap[PT_PRODUCT_DISPLAY_ACTION_COLOUR],
             displayActionTextColor = colorMap[PT_PRODUCT_DISPLAY_ACTION_TEXT_COLOUR],
             isLinear = extras.getString(PT_PRODUCT_DISPLAY_LINEAR)
-                ?.equals("true", ignoreCase = true) ?: false
+                ?.equals("true", ignoreCase = true) ?: false,
+            imageBorderData = createImageBorderData(extras, colorMap)
         )
     }
 
@@ -257,7 +262,7 @@ internal object TemplateDataFactory {
         colorMap: Map<String, String>,
         defaultAltText: String
     ): ZeroBezelTemplateData {
-        val mediaData = createMediaData(extras, defaultAltText)
+        val mediaData = createMediaData(extras, colorMap, defaultAltText)
         return ZeroBezelTemplateData(
             baseContent = createBaseContent(extras, colorMap),
             actions = Utils.getActionKeys(extras),
@@ -272,7 +277,7 @@ internal object TemplateDataFactory {
         colorMap: Map<String, String>,
         defaultAltText: String
     ): TimerTemplateData {
-        val mediaData = createMediaData(extras, defaultAltText)
+        val mediaData = createMediaData(extras, colorMap, defaultAltText)
         val timerEnd = Utils.getTimerEnd(extras, System.currentTimeMillis())
         val timerThreshold = Utils.getTimerThreshold(extras)
         val dismissAfter = TimerTemplateHandler.getDismissAfterMs(timerEnd, timerThreshold)
@@ -330,11 +335,11 @@ internal object TemplateDataFactory {
         colorMap: Map<String, String>,
         defaultAltText: String
     ): VerticalImageTemplateData {
-        val mediaData = createMediaData(extras, defaultAltText)
+        val mediaData = createMediaData(extras, colorMap, defaultAltText)
         return VerticalImageTemplateData(
             baseContent = createBaseContent(extras, colorMap),
             mediaData = mediaData,
-            collapsedMediaData = createCollapsedMediaDataWithoutFallback(extras, defaultAltText),
+            collapsedMediaData = createCollapsedMediaDataWithoutFallback(extras, defaultAltText, mediaData.imageBorderData),
             actions = Utils.getActionKeys(extras),
             text1 = extras.getString(PT_TEXT1),
             text2 = extras.getString(PT_TEXT2),
@@ -364,6 +369,14 @@ internal object TemplateDataFactory {
             gradientDirection = extras.getString(PT_BTN_GRAD_DIR + suffix)?.toDoubleOrNull() ?: PT_BTN_GRAD_DIR_DEFAULT,
             borderRadius = extras.getString(PT_BTN_BORDER_RADIUS + suffix)?.toFloatOrNull() ?: PT_BTN_BORDER_RADIUS_DEFAULT,
             borderWidth = extras.getString(PT_BTN_BORDER_WIDTH + suffix)?.toFloatOrNull() ?: PT_BTN_BORDER_WIDTH_DEFAULT,
+        )
+    }
+
+    private fun createImageBorderData(extras: Bundle, colorMap: Map<String, String>): ImageBorderData {
+        return ImageBorderData(
+            borderColor = colorMap[PT_IMG_BORDER_CLR],
+            cornerRadius = extras.getString(PT_IMG_CORNER_RADIUS)?.toFloatOrNull() ?: 0f,
+            borderWidth = extras.getString(PT_IMG_BORDER_WIDTH)?.toFloatOrNull()
         )
     }
 
@@ -402,7 +415,7 @@ internal object TemplateDataFactory {
         )
     }
 
-    private fun createMediaData(extras: Bundle, defaultAltText: String): MediaData {
+    private fun createMediaData(extras: Bundle, colorMap: Map<String, String>, defaultAltText: String): MediaData {
         val bigImage = getStringWithFallback(extras, PT_BIG_IMG, Constants.WZRK_BIG_PICTURE)
         val gif = extras.getString(PT_GIF)
 
@@ -415,7 +428,8 @@ internal object TemplateDataFactory {
                 url = gif,
                 numberOfFrames = extras.getString(PT_GIF_FRAMES)?.toIntOrNull() ?: 10
             ),
-            scaleType = PTScaleType.fromString(extras.getString(PT_SCALE_TYPE))
+            scaleType = PTScaleType.fromString(extras.getString(PT_SCALE_TYPE)),
+            imageBorderData = createImageBorderData(extras, colorMap)
         )
     }
 
@@ -450,11 +464,16 @@ internal object TemplateDataFactory {
                     PT_SCALE_TYPE_COLLAPSED,
                     defaultMediaData.scaleType.name
                 )
-            )
+            ),
+            imageBorderData = defaultMediaData.imageBorderData
         )
     }
 
-    private fun createCollapsedMediaDataWithoutFallback(extras: Bundle, defaultAltText: String): MediaData? {
+    private fun createCollapsedMediaDataWithoutFallback(
+        extras: Bundle,
+        defaultAltText: String,
+        imageBorderData: ImageBorderData = ImageBorderData()
+    ): MediaData? {
         val bigImageCollapsed = extras.getString(PT_BIG_IMG_COLLAPSED)?.takeIf { it.isNotBlank() }
         val gifCollapsed = extras.getString(PT_GIF_COLLAPSED)?.takeIf { it.isNotBlank() }
         if (bigImageCollapsed == null && gifCollapsed == null) return null
@@ -467,7 +486,8 @@ internal object TemplateDataFactory {
                 url = gifCollapsed,
                 numberOfFrames = extras.getString(PT_GIF_FRAMES_COLLAPSED)?.toIntOrNull() ?: 10
             ),
-            scaleType = PTScaleType.fromString(extras.getString(PT_SCALE_TYPE_COLLAPSED))
+            scaleType = PTScaleType.fromString(extras.getString(PT_SCALE_TYPE_COLLAPSED)),
+            imageBorderData = imageBorderData
         )
     }
 
@@ -485,7 +505,8 @@ internal object TemplateDataFactory {
             baseContent = createBaseContent(extras, colorMap),
             actions = Utils.getActionKeys(extras),
             imageList = Utils.getImageDataListFromExtras(extras, defaultAltText),
-            scaleType = PTScaleType.fromString(extras.getString(PT_SCALE_TYPE))
+            scaleType = PTScaleType.fromString(extras.getString(PT_SCALE_TYPE)),
+            imageBorderData = createImageBorderData(extras, colorMap)
         )
     }
 
@@ -523,7 +544,8 @@ internal object TemplateDataFactory {
                     PT_SCALE_TYPE_ALT,
                     defaultMediaData.scaleType.name
                 )
-            )
+            ),
+            imageBorderData = defaultMediaData.imageBorderData
         )
     }
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
@@ -339,7 +339,7 @@ internal object TemplateDataFactory {
         return VerticalImageTemplateData(
             baseContent = createBaseContent(extras, colorMap),
             mediaData = mediaData,
-            collapsedMediaData = createCollapsedMediaDataWithoutFallback(extras, defaultAltText, mediaData.imageBorderData),
+            collapsedMediaData = createCollapsedMediaDataWithoutFallback(extras, defaultAltText),
             actions = Utils.getActionKeys(extras),
             text1 = extras.getString(PT_TEXT1),
             text2 = extras.getString(PT_TEXT2),

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
@@ -339,7 +339,7 @@ internal object TemplateDataFactory {
         return VerticalImageTemplateData(
             baseContent = createBaseContent(extras, colorMap),
             mediaData = mediaData,
-            collapsedMediaData = createCollapsedMediaDataWithoutFallback(extras, defaultAltText),
+            collapsedMediaData = createCollapsedMediaDataWithoutFallback(extras, defaultAltText, mediaData.imageBorderData),
             actions = Utils.getActionKeys(extras),
             text1 = extras.getString(PT_TEXT1),
             text2 = extras.getString(PT_TEXT2),

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
@@ -374,7 +374,8 @@ internal object TemplateDataFactory {
 
     private fun createImageBorderData(extras: Bundle, colorMap: Map<String, String>): ImageBorderData {
         return ImageBorderData(
-            borderColor = colorMap[PT_IMG_BORDER_CLR],
+            // Parse here rather than at draw time so an invalid colour never marks the border active
+            borderColor = colorMap[PT_IMG_BORDER_CLR]?.let { Utils.getColourOrNull(it) },
             cornerRadius = extras.getString(PT_IMG_CORNER_RADIUS)?.toFloatOrNull() ?: 0f,
             borderWidth = extras.getString(PT_IMG_BORDER_WIDTH)?.toFloatOrNull()
         )

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/TemplateDataFactory.kt
@@ -377,8 +377,8 @@ internal object TemplateDataFactory {
             // Parse here rather than at draw time so an invalid colour never marks the border active
             borderColor = colorMap[PT_IMG_BORDER_CLR]?.let { Utils.getColourOrNull(it) },
             // Both values are percentages of the image's shortest side, clamped when drawn
-            cornerRadiusPercent = extras.getString(PT_IMG_CORNER_RADIUS)?.toFloatOrNull() ?: 0f,
-            borderWidthPercent = extras.getString(PT_IMG_BORDER_WIDTH)?.toFloatOrNull()
+            cornerRadiusPercent = extras.getString(PT_IMG_CORNER_RADIUS)?.toFloatOrNull()?.takeIf { it.isFinite() } ?: 0f,
+            borderWidthPercent = extras.getString(PT_IMG_BORDER_WIDTH)?.toFloatOrNull()?.takeIf { it.isFinite() }
         )
     }
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/Utils.java
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/Utils.java
@@ -104,7 +104,7 @@ public class Utils {
         ArrayList<ImageData> imageList = new ArrayList<>();
         int counter = 1;
         for (String key : extras.keySet()) {
-            if (key.contains("pt_img") && !key.endsWith(ALT_TEXT_SUFFIX)) {
+            if (key.startsWith("pt_img") && key.length() > 6 && Character.isDigit(key.charAt(6)) && !key.endsWith(ALT_TEXT_SUFFIX)) {
                 String imageUrl = extras.getString(key);
                 String altText = extras.getString(key + ALT_TEXT_SUFFIX, defaultAltText + counter);
                 imageList.add(new ImageData(imageUrl, altText));

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/AutoCarouselContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/AutoCarouselContentView.kt
@@ -56,7 +56,8 @@ internal class AutoCarouselContentView(
                 imageViewId,
                 imageUrl,
                 tempRemoteView,
-                altText
+                altText,
+                data.carouselData.imageBorderData
             )
 
             if (!fallback) {

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/AutoCarouselContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/AutoCarouselContentView.kt
@@ -40,7 +40,8 @@ internal class AutoCarouselContentView(
     }
 
     private fun setViewFlipper() {
-        val imageViewId = when (data.carouselData.scaleType) {
+        val effectiveScaleType = if (data.carouselData.imageBorderData?.isActive == true) PTScaleType.FIT_CENTER else data.carouselData.scaleType
+        val imageViewId = when (effectiveScaleType) {
             PTScaleType.FIT_CENTER -> R.id.big_image_fitCenter
             PTScaleType.CENTER_CROP -> R.id.big_image
         }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/AutoCarouselContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/AutoCarouselContentView.kt
@@ -6,6 +6,7 @@ import android.widget.RemoteViews
 import com.clevertap.android.pushtemplates.AutoCarouselTemplateData
 import com.clevertap.android.pushtemplates.PTLog
 import com.clevertap.android.pushtemplates.PTScaleType
+import com.clevertap.android.pushtemplates.effectiveScaleType
 import com.clevertap.android.pushtemplates.R
 import com.clevertap.android.pushtemplates.TemplateRenderer
 
@@ -40,8 +41,9 @@ internal class AutoCarouselContentView(
     }
 
     private fun setViewFlipper() {
-        val effectiveScaleType = if (data.carouselData.imageBorderData?.isActive == true) PTScaleType.FIT_CENTER else data.carouselData.scaleType
-        val imageViewId = when (effectiveScaleType) {
+        val imageViewId = when (
+            data.carouselData.imageBorderData.effectiveScaleType(data.carouselData.scaleType)
+        ) {
             PTScaleType.FIT_CENTER -> R.id.big_image_fitCenter
             PTScaleType.CENTER_CROP -> R.id.big_image
         }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/BigImageContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/BigImageContentView.kt
@@ -28,7 +28,8 @@ internal open class BigImageContentView(
             data.mediaData.bigImage.url,
             data.mediaData.scaleType,
             data.mediaData.bigImage.altText,
-            data.mediaData.gif.numberOfFrames
+            data.mediaData.gif.numberOfFrames,
+            data.mediaData.imageBorderData
         )
         setCustomContentViewLargeIcon(data.baseContent.iconData.largeIcon)
     }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ContentView.kt
@@ -203,7 +203,7 @@ internal open class ContentView(
             // safe here. Static images come from TemplateMediaManager's cache and must not be.
             val processedFrame = if (border != null) {
                 NotificationBitmapUtils.applyRoundedBorderToBitmap(
-                    frame, border.cornerRadius, border.borderColor, border.borderWidth
+                    frame, border.cornerRadiusPercent, border.borderColor, border.borderWidthPercent
                 ).also { frame.recycle() }
             } else frame
             val frameRemoteViews = RemoteViews(context.getPackageName(), layoutId)
@@ -251,7 +251,7 @@ internal open class ContentView(
             val border = imageBorderData?.takeIf { it.isActive }
             val image = if (border != null) {
                 NotificationBitmapUtils.applyRoundedBorderToBitmap(
-                    rawImage, border.cornerRadius, border.borderColor, border.borderWidth
+                    rawImage, border.cornerRadiusPercent, border.borderColor, border.borderWidthPercent
                 )
             } else rawImage
             remoteViews.setImageViewBitmap(imageViewID, image)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ContentView.kt
@@ -152,7 +152,9 @@ internal open class ContentView(
     ): Boolean {
         if (imageUrl.isNullOrBlank()) return false
 
-        val imageViewId = when (scaleType) {
+        // When border/radius is active, force fit_center so rounded corners are fully visible
+        val effectiveScaleType = if (imageBorderData?.isActive == true) PTScaleType.FIT_CENTER else scaleType
+        val imageViewId = when (effectiveScaleType) {
             PTScaleType.FIT_CENTER -> R.id.big_image_fitCenter
             PTScaleType.CENTER_CROP -> R.id.big_image
         }
@@ -190,7 +192,9 @@ internal open class ContentView(
         PTLog.debug("Total duration: " + duration + "ms")
         PTLog.debug("Flip interval: " + flipInterval + "ms")
 
-        val imageViewId = when (scaleType) {
+        // When border/radius is active, force fit_center so rounded corners are fully visible
+        val effectiveScaleType = if (imageBorderData?.isActive == true) PTScaleType.FIT_CENTER else scaleType
+        val imageViewId = when (effectiveScaleType) {
             PTScaleType.FIT_CENTER -> R.id.big_image_fitCenter
             PTScaleType.CENTER_CROP -> R.id.big_image
         }
@@ -202,7 +206,7 @@ internal open class ContentView(
             val processedFrame = if (applyBorder) {
                 NotificationBitmapUtils.applyRoundedBorderToBitmap(
                     frame, imageBorderData!!.cornerRadius, borderColor, imageBorderData.borderWidth
-                )
+                ).also { frame.recycle() }
             } else frame
             val frameRemoteViews = RemoteViews(context.getPackageName(), layoutId)
             frameRemoteViews.setImageViewBitmap(imageViewId, processedFrame)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ContentView.kt
@@ -9,6 +9,7 @@ import android.text.Html
 import android.text.TextUtils
 import android.view.View
 import android.widget.RemoteViews
+import com.clevertap.android.pushtemplates.ImageBorderData
 import com.clevertap.android.pushtemplates.PTConstants
 import com.clevertap.android.pushtemplates.PTLog
 import com.clevertap.android.pushtemplates.PTScaleType
@@ -133,33 +134,22 @@ internal open class ContentView(
         bigImageUrl: String?,
         scaleType: PTScaleType,
         altText: String,
-        gifFrames: Int
+        gifFrames: Int,
+        imageBorderData: ImageBorderData? = null
     ): Boolean {
         val isGifLoaded = setCustomContentViewGIF(
-            gifUrl,
-            altText,
-            scaleType,
-            gifFrames,
-            layoutId
+            gifUrl, altText, scaleType, gifFrames, layoutId, imageBorderData
         )
-
-        return if (isGifLoaded) {
-            true
-        } else {
-            setCustomContentViewBigImage(
-                imageUrl = bigImageUrl,
-                scaleType = scaleType,
-                altText = altText
-            )
-        }
+        return if (isGifLoaded) true
+        else setCustomContentViewBigImage(bigImageUrl, scaleType, altText, imageBorderData)
     }
 
     fun setCustomContentViewBigImage(
         imageUrl: String?,
         scaleType: PTScaleType,
-        altText: String
+        altText: String,
+        imageBorderData: ImageBorderData? = null
     ): Boolean {
-
         if (imageUrl.isNullOrBlank()) return false
 
         val imageViewId = when (scaleType) {
@@ -167,7 +157,7 @@ internal open class ContentView(
             PTScaleType.CENTER_CROP -> R.id.big_image
         }
 
-        val loaded = !loadImageURLIntoRemoteView(imageViewId, imageUrl, remoteView, altText)
+        val loaded = !loadImageURLIntoRemoteView(imageViewId, imageUrl, remoteView, altText, imageBorderData)
 
         if (loaded) {
             remoteView.setViewVisibility(imageViewId, View.VISIBLE)
@@ -178,7 +168,14 @@ internal open class ContentView(
         return loaded
     }
 
-    fun setCustomContentViewGIF(gifUrl: String?, altText: String, scaleType: PTScaleType, numberOfFrames: Int, layoutId: Int): Boolean {
+    fun setCustomContentViewGIF(
+        gifUrl: String?,
+        altText: String,
+        scaleType: PTScaleType,
+        numberOfFrames: Int,
+        layoutId: Int,
+        imageBorderData: ImageBorderData? = null
+    ): Boolean {
         val gifResult = templateMediaManager.getGifFrames(gifUrl, numberOfFrames)
 
         if (gifResult is GifResult.Error) {
@@ -188,7 +185,6 @@ internal open class ContentView(
 
         val (frames, duration) = gifResult as GifResult.Success
 
-        // Calculate timing for frame flipping
         val extractedFramesSize = frames.size
         val flipInterval = duration / extractedFramesSize
         PTLog.debug("Total duration: " + duration + "ms")
@@ -199,10 +195,17 @@ internal open class ContentView(
             PTScaleType.CENTER_CROP -> R.id.big_image
         }
 
-        // Add each frame to the ViewFlipper
+        val applyBorder = imageBorderData?.isActive == true
+        val borderColor = if (applyBorder) imageBorderData?.borderColor?.let { Utils.getColourOrNull(it) } else null
+
         for (frame in frames) {
+            val processedFrame = if (applyBorder) {
+                NotificationBitmapUtils.applyRoundedBorderToBitmap(
+                    frame, imageBorderData!!.cornerRadius, borderColor, imageBorderData.borderWidth
+                )
+            } else frame
             val frameRemoteViews = RemoteViews(context.getPackageName(), layoutId)
-            frameRemoteViews.setImageViewBitmap(imageViewId, frame)
+            frameRemoteViews.setImageViewBitmap(imageViewId, processedFrame)
             frameRemoteViews.setViewVisibility(imageViewId, View.VISIBLE)
             remoteView.addView(R.id.view_flipper, frameRemoteViews)
         }
@@ -220,29 +223,34 @@ internal open class ContentView(
     fun loadImageURLIntoRemoteView(
         imageViewID: Int, imageUrl: String?,
         remoteViews: RemoteViews
-    ): Boolean {
-        return loadImageURLIntoRemoteView(imageViewID, imageUrl, remoteViews, null)
-    }
+    ): Boolean = loadImageURLIntoRemoteView(imageViewID, imageUrl, remoteViews, null, null)
 
     /**
      * Loads an image URL into a RemoteView.
-     * 
-     * @param imageViewID The ID of the ImageView in the RemoteView
-     * @param imageUrl The URL of the image to load (nullable)
-     * @param remoteViews The RemoteViews to load the image into
-     * @param altText Alternative text for accessibility (nullable)
-     * @return true if fallback is needed (image loading failed), false if image was loaded successfully
-     * 
+     *
      * INVARIANT: When this method returns false, the imageUrl parameter is guaranteed to be non-null,
      * non-blank, and start with "https". This invariant is enforced by getImageBitmap validation.
      */
     fun loadImageURLIntoRemoteView(
         imageViewID: Int, imageUrl: String?,
         remoteViews: RemoteViews, altText: String?
-    ): Boolean {
-        val image = templateMediaManager.getImageBitmap(imageUrl)
+    ): Boolean = loadImageURLIntoRemoteView(imageViewID, imageUrl, remoteViews, altText, null)
 
-        if (image != null) {
+    fun loadImageURLIntoRemoteView(
+        imageViewID: Int,
+        imageUrl: String?,
+        remoteViews: RemoteViews,
+        altText: String?,
+        imageBorderData: ImageBorderData?
+    ): Boolean {
+        val rawImage = templateMediaManager.getImageBitmap(imageUrl)
+        if (rawImage != null) {
+            val image = if (imageBorderData?.isActive == true) {
+                val borderColor = imageBorderData.borderColor?.let { Utils.getColourOrNull(it) }
+                NotificationBitmapUtils.applyRoundedBorderToBitmap(
+                    rawImage, imageBorderData.cornerRadius, borderColor, imageBorderData.borderWidth
+                )
+            } else rawImage
             remoteViews.setImageViewBitmap(imageViewID, image)
             if (!TextUtils.isEmpty(altText)) {
                 remoteViews.setContentDescription(imageViewID, altText)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ContentView.kt
@@ -199,13 +199,14 @@ internal open class ContentView(
             PTScaleType.CENTER_CROP -> R.id.big_image
         }
 
-        val applyBorder = imageBorderData?.isActive == true
-        val borderColor = if (applyBorder) imageBorderData?.borderColor?.let { Utils.getColourOrNull(it) } else null
+        val border = imageBorderData?.takeIf { it.isActive }
 
         for (frame in frames) {
-            val processedFrame = if (applyBorder) {
+            // GIF frames are decoded fresh on every call, so recycling the pre-border frame is
+            // safe here. Static images come from TemplateMediaManager's cache and must not be.
+            val processedFrame = if (border != null) {
                 NotificationBitmapUtils.applyRoundedBorderToBitmap(
-                    frame, imageBorderData!!.cornerRadius, borderColor, imageBorderData.borderWidth
+                    frame, border.cornerRadius, border.borderColor, border.borderWidth
                 ).also { frame.recycle() }
             } else frame
             val frameRemoteViews = RemoteViews(context.getPackageName(), layoutId)
@@ -249,10 +250,11 @@ internal open class ContentView(
     ): Boolean {
         val rawImage = templateMediaManager.getImageBitmap(imageUrl)
         if (rawImage != null) {
-            val image = if (imageBorderData?.isActive == true) {
-                val borderColor = imageBorderData.borderColor?.let { Utils.getColourOrNull(it) }
+            // rawImage is owned by TemplateMediaManager's cache, so it is never recycled here
+            val border = imageBorderData?.takeIf { it.isActive }
+            val image = if (border != null) {
                 NotificationBitmapUtils.applyRoundedBorderToBitmap(
-                    rawImage, imageBorderData.cornerRadius, borderColor, imageBorderData.borderWidth
+                    rawImage, border.cornerRadius, border.borderColor, border.borderWidth
                 )
             } else rawImage
             remoteViews.setImageViewBitmap(imageViewID, image)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ContentView.kt
@@ -15,6 +15,7 @@ import com.clevertap.android.pushtemplates.PTLog
 import com.clevertap.android.pushtemplates.PTScaleType
 import com.clevertap.android.pushtemplates.R
 import com.clevertap.android.pushtemplates.Utils
+import com.clevertap.android.pushtemplates.effectiveScaleType
 import com.clevertap.android.pushtemplates.isNotNullAndEmpty
 import com.clevertap.android.pushtemplates.media.GifResult
 import com.clevertap.android.pushtemplates.media.TemplateMediaManager
@@ -152,9 +153,7 @@ internal open class ContentView(
     ): Boolean {
         if (imageUrl.isNullOrBlank()) return false
 
-        // When border/radius is active, force fit_center so rounded corners are fully visible
-        val effectiveScaleType = if (imageBorderData?.isActive == true) PTScaleType.FIT_CENTER else scaleType
-        val imageViewId = when (effectiveScaleType) {
+        val imageViewId = when (imageBorderData.effectiveScaleType(scaleType)) {
             PTScaleType.FIT_CENTER -> R.id.big_image_fitCenter
             PTScaleType.CENTER_CROP -> R.id.big_image
         }
@@ -192,9 +191,7 @@ internal open class ContentView(
         PTLog.debug("Total duration: " + duration + "ms")
         PTLog.debug("Flip interval: " + flipInterval + "ms")
 
-        // When border/radius is active, force fit_center so rounded corners are fully visible
-        val effectiveScaleType = if (imageBorderData?.isActive == true) PTScaleType.FIT_CENTER else scaleType
-        val imageViewId = when (effectiveScaleType) {
+        val imageViewId = when (imageBorderData.effectiveScaleType(scaleType)) {
             PTScaleType.FIT_CENTER -> R.id.big_image_fitCenter
             PTScaleType.CENTER_CROP -> R.id.big_image
         }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconBigContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconBigContentView.kt
@@ -35,7 +35,8 @@ internal class FiveIconBigContentView constructor(
                 viewId,
                 imageUrl,
                 remoteView,
-                altText
+                altText,
+                data.imageBorderData
             )
 
             if (fallback) {

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconSmallContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/FiveIconSmallContentView.kt
@@ -41,7 +41,8 @@ internal class FiveIconSmallContentView(
                 viewId,
                 imageUrl,
                 remoteView,
-                altText
+                altText,
+                data.imageBorderData
             )
 
             if (fallback) {

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
@@ -9,6 +9,7 @@ import com.clevertap.android.pushtemplates.ManualCarouselTemplateData
 import com.clevertap.android.pushtemplates.PTConstants
 import com.clevertap.android.pushtemplates.PTLog
 import com.clevertap.android.pushtemplates.PTScaleType
+import com.clevertap.android.pushtemplates.effectiveScaleType
 import com.clevertap.android.pushtemplates.R
 import com.clevertap.android.pushtemplates.TemplateRenderer
 import com.clevertap.android.sdk.Constants
@@ -30,7 +31,8 @@ internal class ManualCarouselContentView(
         val baseContent = data.carouselData.baseContent
         setupBaseContent(baseContent, renderer)
 
-        val scaleType = if (data.carouselData.imageBorderData?.isActive == true) PTScaleType.FIT_CENTER else data.carouselData.scaleType
+        val scaleType =
+            data.carouselData.imageBorderData.effectiveScaleType(data.carouselData.scaleType)
         val deepLinkList = baseContent.deepLinkList
 
         remoteView.setViewVisibility(R.id.leftArrowPos0, View.VISIBLE)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
@@ -54,7 +54,9 @@ internal class ManualCarouselContentView(
             val fallback = loadImageURLIntoRemoteView(
                 imageViewId,
                 imageUrl,
-                tempRemoteView
+                tempRemoteView,
+                null,
+                data.carouselData.imageBorderData
             )
 
             if (!fallback) {

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ManualCarouselContentView.kt
@@ -30,7 +30,7 @@ internal class ManualCarouselContentView(
         val baseContent = data.carouselData.baseContent
         setupBaseContent(baseContent, renderer)
 
-        val scaleType = data.carouselData.scaleType
+        val scaleType = if (data.carouselData.imageBorderData?.isActive == true) PTScaleType.FIT_CENTER else data.carouselData.scaleType
         val deepLinkList = baseContent.deepLinkList
 
         remoteView.setViewVisibility(R.id.leftArrowPos0, View.VISIBLE)
@@ -195,7 +195,7 @@ internal class ManualCarouselContentView(
             extras.putStringArrayList(PTConstants.PT_IMAGE_LIST, tempImageList)
             extras.putStringArrayList(PTConstants.PT_DEEPLINK_LIST, deepLinkList)
 
-            extras.putString(Constants.DEEP_LINK_KEY, deepLinkList[0])
+            if (deepLinkList.isNotEmpty()) extras.putString(Constants.DEEP_LINK_KEY, deepLinkList[0])
             extras.putInt(PTConstants.PT_MANUAL_CAROUSEL_FROM, 0)
             remoteView.setOnClickPendingIntent(
                 R.id.rightArrowPos0,

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
@@ -131,7 +131,7 @@ internal object NotificationBitmapUtils {
         val safeRadius = resolveCornerRadiusPx(minDimension, cornerRadiusPercent)
 
         val half = strokeWidth / 2f
-        val drawRect = RectF(half, half, width - half, height - half)
+        val strokeRect = RectF(half, half, width - half, height - half)
         val adjustedRadius = (safeRadius - half).coerceAtLeast(0f)
 
         PTLog.debug(
@@ -142,19 +142,24 @@ internal object NotificationBitmapUtils {
         val output = createBitmap(width, height)
         val canvas = Canvas(output)
 
-        // BitmapShader gives anti-aliased rounded corners without clipPath's jagged edges
+        // Draw the full image into the full bitmap area — BitmapShader maps canvas coords 1:1 to
+        // source coords, so using an inset rect would silently drop edge pixels from the source.
         val imagePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
             shader = BitmapShader(source, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
         }
-        canvas.drawRoundRect(drawRect, adjustedRadius, adjustedRadius, imagePaint)
+        canvas.drawRoundRect(
+            RectF(0f, 0f, width.toFloat(), height.toFloat()),
+            safeRadius, safeRadius, imagePaint
+        )
 
+        // Draw the border stroke on top, inset by half the stroke width so it stays within the bitmap.
         if (borderColor != null && strokeWidth > 0f) {
             val borderPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
                 style = Paint.Style.STROKE
                 this.strokeWidth = strokeWidth
                 color = borderColor
             }
-            canvas.drawRoundRect(drawRect, adjustedRadius, adjustedRadius, borderPaint)
+            canvas.drawRoundRect(strokeRect, adjustedRadius, adjustedRadius, borderPaint)
         }
 
         return output

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
@@ -9,6 +9,7 @@ import android.graphics.RadialGradient
 import android.graphics.RectF
 import android.graphics.Shader
 import androidx.core.graphics.createBitmap
+import com.clevertap.android.pushtemplates.PTLog
 import kotlin.math.cos
 import kotlin.math.sin
 
@@ -103,31 +104,40 @@ internal object NotificationBitmapUtils {
 
     private const val BORDER_STROKE_RATIO = 0.10f
 
+    /**
+     * Draws [source] into a new bitmap with rounded corners and an optional border.
+     *
+     * [cornerRadiusPercent] and [borderWidthPercent] are percentages of the image's shortest side,
+     * not absolute pixels. Notification images are supplied by the campaign, so their pixel
+     * dimensions vary; a percentage keeps the same payload value looking identical whether the
+     * image is 240x180 or 1200x800. This mirrors how in-app notifications size themselves from the
+     * `xp`/`yp` payload keys.
+     */
     fun applyRoundedBorderToBitmap(
         source: Bitmap,
-        cornerRadius: Float,
+        cornerRadiusPercent: Float,
         borderColor: Int?,
-        borderWidth: Float?
+        borderWidthPercent: Float?
     ): Bitmap {
         val width = source.width
         val height = source.height
         if (width <= 0 || height <= 0) return source
-        if (cornerRadius <= 0f && borderColor == null) return source
+        if (cornerRadiusPercent <= 0f && borderColor == null) return source
 
         val minDimension = minOf(width, height)
 
-        // coerceIn (not coerceAtMost) so a negative payload value can't disable the border or
-        // push drawRect outside the bitmap bounds
-        val strokeWidth = if (borderColor != null) {
-            (borderWidth ?: (minDimension * BORDER_STROKE_RATIO))
-                .coerceIn(0f, minDimension * MAX_BORDER_RATIO)
-        } else 0f
+        val strokeWidth =
+            if (borderColor != null) resolveBorderWidthPx(minDimension, borderWidthPercent) else 0f
+        val safeRadius = resolveCornerRadiusPx(minDimension, cornerRadiusPercent)
 
         val half = strokeWidth / 2f
         val drawRect = RectF(half, half, width - half, height - half)
-        // Cap at half the shortest side; beyond that the shape is already fully pill-shaped
-        val safeRadius = cornerRadius.coerceIn(0f, minDimension / 2f)
         val adjustedRadius = (safeRadius - half).coerceAtLeast(0f)
+
+        PTLog.debug(
+            "Image border on ${width}x$height bitmap: corner radius $cornerRadiusPercent% -> " +
+                    "${safeRadius}px, border width ${borderWidthPercent ?: DEFAULT_BORDER_WIDTH_PERCENT}% -> ${strokeWidth}px"
+        )
 
         val output = createBitmap(width, height)
         val canvas = Canvas(output)
@@ -151,4 +161,34 @@ internal object NotificationBitmapUtils {
     }
 
     private const val MAX_BORDER_RATIO = 0.25f
+
+    // Percentage equivalents of the ratios above, used by applyRoundedBorderToBitmap
+    internal const val DEFAULT_BORDER_WIDTH_PERCENT = BORDER_STROKE_RATIO * 100f
+    internal const val MAX_BORDER_WIDTH_PERCENT = MAX_BORDER_RATIO * 100f
+
+    // 50% of the shortest side is a full pill; anything beyond that has no visible effect
+    internal const val MAX_CORNER_RADIUS_PERCENT = 50f
+
+    /**
+     * Resolves [cornerRadiusPercent] against the image's shortest side.
+     *
+     * Kept separate from the drawing code so the conversion can be asserted directly; Canvas
+     * operations are no-ops under Robolectric's legacy graphics mode, so a test that only inspects
+     * the output bitmap cannot tell a percentage from a raw pixel count.
+     */
+    internal fun resolveCornerRadiusPx(minDimension: Int, cornerRadiusPercent: Float): Float =
+        minDimension * cornerRadiusPercent.coerceIn(0f, MAX_CORNER_RADIUS_PERCENT) / 100f
+
+    /**
+     * Resolves [borderWidthPercent] against the image's shortest side, falling back to
+     * [DEFAULT_BORDER_WIDTH_PERCENT] when the payload omits it.
+     *
+     * Clamped at both ends: a negative payload value must not produce a negative stroke, which
+     * would both drop the border and push the draw rect outside the bitmap bounds.
+     */
+    internal fun resolveBorderWidthPx(minDimension: Int, borderWidthPercent: Float?): Float {
+        val percent = (borderWidthPercent ?: DEFAULT_BORDER_WIDTH_PERCENT)
+            .coerceIn(0f, MAX_BORDER_WIDTH_PERCENT)
+        return minDimension * percent / 100f
+    }
 }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
@@ -114,14 +114,20 @@ internal object NotificationBitmapUtils {
         if (width <= 0 || height <= 0) return source
         if (cornerRadius <= 0f && borderColor == null) return source
 
+        val minDimension = minOf(width, height)
+
+        // coerceIn (not coerceAtMost) so a negative payload value can't disable the border or
+        // push drawRect outside the bitmap bounds
         val strokeWidth = if (borderColor != null) {
-            (borderWidth ?: (minOf(width, height) * BORDER_STROKE_RATIO))
-                .coerceAtMost(minOf(width, height) * MAX_BORDER_RATIO)
+            (borderWidth ?: (minDimension * BORDER_STROKE_RATIO))
+                .coerceIn(0f, minDimension * MAX_BORDER_RATIO)
         } else 0f
 
         val half = strokeWidth / 2f
         val drawRect = RectF(half, half, width - half, height - half)
-        val adjustedRadius = (cornerRadius - half).coerceAtLeast(0f)
+        // Cap at half the shortest side; beyond that the shape is already fully pill-shaped
+        val safeRadius = cornerRadius.coerceIn(0f, minDimension / 2f)
+        val adjustedRadius = (safeRadius - half).coerceAtLeast(0f)
 
         val output = createBitmap(width, height)
         val canvas = Canvas(output)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
@@ -4,6 +4,7 @@ import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.LinearGradient
 import android.graphics.Paint
+import android.graphics.Path
 import android.graphics.RadialGradient
 import android.graphics.RectF
 import android.graphics.Shader
@@ -101,4 +102,60 @@ internal object NotificationBitmapUtils {
     }
 
     private const val BORDER_STROKE_RATIO = 0.10f
+
+    /**
+     * Applies rounded corners and an optional border stroke to an existing image bitmap.
+     * Use this for main notification images (as opposed to the solid/gradient background
+     * utilities above which create new bitmaps from scratch).
+     *
+     * If neither [cornerRadius] > 0 nor [borderColor] is set, the source bitmap is returned
+     * unchanged to avoid unnecessary processing.
+     *
+     * @param source       The original downloaded image bitmap.
+     * @param cornerRadius Corner radius in pixels applied to the image clip.
+     * @param borderColor  ARGB color for the border stroke; null means no border.
+     * @param borderWidth  Stroke width in pixels; null defaults to 10 % of the smaller dimension.
+     */
+    fun applyRoundedBorderToBitmap(
+        source: Bitmap,
+        cornerRadius: Float,
+        borderColor: Int?,
+        borderWidth: Float?
+    ): Bitmap {
+        val width = source.width
+        val height = source.height
+        if (width <= 0 || height <= 0) return source
+
+        val output = createBitmap(width, height)
+        val canvas = Canvas(output)
+        val paint = Paint(Paint.ANTI_ALIAS_FLAG)
+
+        if (cornerRadius > 0f) {
+            val path = Path()
+            path.addRoundRect(
+                RectF(0f, 0f, width.toFloat(), height.toFloat()),
+                cornerRadius, cornerRadius,
+                Path.Direction.CW
+            )
+            canvas.clipPath(path)
+        }
+
+        canvas.drawBitmap(source, 0f, 0f, paint)
+
+        if (borderColor != null) {
+            val strokeWidth = borderWidth ?: (minOf(width, height) * BORDER_STROKE_RATIO)
+            val inset = strokeWidth / 2f
+            val borderPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = borderColor
+                style = Paint.Style.STROKE
+                this.strokeWidth = strokeWidth
+            }
+            canvas.drawRoundRect(
+                RectF(inset, inset, width - inset, height - inset),
+                cornerRadius, cornerRadius, borderPaint
+            )
+        }
+
+        return output
+    }
 }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtils.kt
@@ -1,10 +1,10 @@
 package com.clevertap.android.pushtemplates.content
 
 import android.graphics.Bitmap
+import android.graphics.BitmapShader
 import android.graphics.Canvas
 import android.graphics.LinearGradient
 import android.graphics.Paint
-import android.graphics.Path
 import android.graphics.RadialGradient
 import android.graphics.RectF
 import android.graphics.Shader
@@ -103,19 +103,6 @@ internal object NotificationBitmapUtils {
 
     private const val BORDER_STROKE_RATIO = 0.10f
 
-    /**
-     * Applies rounded corners and an optional border stroke to an existing image bitmap.
-     * Use this for main notification images (as opposed to the solid/gradient background
-     * utilities above which create new bitmaps from scratch).
-     *
-     * If neither [cornerRadius] > 0 nor [borderColor] is set, the source bitmap is returned
-     * unchanged to avoid unnecessary processing.
-     *
-     * @param source       The original downloaded image bitmap.
-     * @param cornerRadius Corner radius in pixels applied to the image clip.
-     * @param borderColor  ARGB color for the border stroke; null means no border.
-     * @param borderWidth  Stroke width in pixels; null defaults to 10 % of the smaller dimension.
-     */
     fun applyRoundedBorderToBitmap(
         source: Bitmap,
         cornerRadius: Float,
@@ -125,37 +112,37 @@ internal object NotificationBitmapUtils {
         val width = source.width
         val height = source.height
         if (width <= 0 || height <= 0) return source
+        if (cornerRadius <= 0f && borderColor == null) return source
+
+        val strokeWidth = if (borderColor != null) {
+            (borderWidth ?: (minOf(width, height) * BORDER_STROKE_RATIO))
+                .coerceAtMost(minOf(width, height) * MAX_BORDER_RATIO)
+        } else 0f
+
+        val half = strokeWidth / 2f
+        val drawRect = RectF(half, half, width - half, height - half)
+        val adjustedRadius = (cornerRadius - half).coerceAtLeast(0f)
 
         val output = createBitmap(width, height)
         val canvas = Canvas(output)
-        val paint = Paint(Paint.ANTI_ALIAS_FLAG)
 
-        if (cornerRadius > 0f) {
-            val path = Path()
-            path.addRoundRect(
-                RectF(0f, 0f, width.toFloat(), height.toFloat()),
-                cornerRadius, cornerRadius,
-                Path.Direction.CW
-            )
-            canvas.clipPath(path)
+        // BitmapShader gives anti-aliased rounded corners without clipPath's jagged edges
+        val imagePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            shader = BitmapShader(source, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
         }
+        canvas.drawRoundRect(drawRect, adjustedRadius, adjustedRadius, imagePaint)
 
-        canvas.drawBitmap(source, 0f, 0f, paint)
-
-        if (borderColor != null) {
-            val strokeWidth = borderWidth ?: (minOf(width, height) * BORDER_STROKE_RATIO)
-            val inset = strokeWidth / 2f
+        if (borderColor != null && strokeWidth > 0f) {
             val borderPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                color = borderColor
                 style = Paint.Style.STROKE
                 this.strokeWidth = strokeWidth
+                color = borderColor
             }
-            canvas.drawRoundRect(
-                RectF(inset, inset, width - inset, height - inset),
-                cornerRadius, cornerRadius, borderPaint
-            )
+            canvas.drawRoundRect(drawRect, adjustedRadius, adjustedRadius, borderPaint)
         }
 
         return output
     }
+
+    private const val MAX_BORDER_RATIO = 0.25f
 }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ProductDisplayLinearBigContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ProductDisplayLinearBigContentView.kt
@@ -124,13 +124,14 @@ internal open class ProductDisplayLinearBigContentView(
             val altText = imageData.altText
 
             loadImageURLIntoRemoteView(
-                smallImageLayoutIds[imageCounter], imageUrl, remoteView, altText
+                smallImageLayoutIds[imageCounter], imageUrl, remoteView, altText,
+                data.imageBorderData
             )
 
             val tempRemoteView =
                 RemoteViews(context.packageName, R.layout.image_view_dynamic_relative)
             val fallback =
-                loadImageURLIntoRemoteView(imageViewId, imageUrl, tempRemoteView, altText)
+                loadImageURLIntoRemoteView(imageViewId, imageUrl, tempRemoteView, altText, data.imageBorderData)
 
             if (!fallback) {
                 tempRemoteView.setViewVisibility(imageViewId, View.VISIBLE)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ProductDisplayLinearBigContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ProductDisplayLinearBigContentView.kt
@@ -114,7 +114,8 @@ internal open class ProductDisplayLinearBigContentView(
         smallImageLayoutIds.add(R.id.small_image2)
         smallImageLayoutIds.add(R.id.small_image3)
         val tempImageList = ArrayList<String>()
-        val imageViewId = when (scaleType) {
+        val effectiveScaleType = if (data.imageBorderData?.isActive == true) PTScaleType.FIT_CENTER else scaleType
+        val imageViewId = when (effectiveScaleType) {
             PTScaleType.FIT_CENTER -> R.id.big_image_fitCenter
             PTScaleType.CENTER_CROP -> R.id.big_image
         }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ProductDisplayLinearBigContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ProductDisplayLinearBigContentView.kt
@@ -9,6 +9,7 @@ import android.widget.RemoteViews
 import com.clevertap.android.pushtemplates.PTConstants
 import com.clevertap.android.pushtemplates.PTLog
 import com.clevertap.android.pushtemplates.PTScaleType
+import com.clevertap.android.pushtemplates.effectiveScaleType
 import com.clevertap.android.pushtemplates.ProductTemplateData
 import com.clevertap.android.pushtemplates.R
 import com.clevertap.android.pushtemplates.TemplateRenderer
@@ -114,8 +115,7 @@ internal open class ProductDisplayLinearBigContentView(
         smallImageLayoutIds.add(R.id.small_image2)
         smallImageLayoutIds.add(R.id.small_image3)
         val tempImageList = ArrayList<String>()
-        val effectiveScaleType = if (data.imageBorderData?.isActive == true) PTScaleType.FIT_CENTER else scaleType
-        val imageViewId = when (effectiveScaleType) {
+        val imageViewId = when (data.imageBorderData.effectiveScaleType(scaleType)) {
             PTScaleType.FIT_CENTER -> R.id.big_image_fitCenter
             PTScaleType.CENTER_CROP -> R.id.big_image
         }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/RatingContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/RatingContentView.kt
@@ -42,7 +42,8 @@ internal class RatingContentView(
             data.mediaData.bigImage.url,
             data.mediaData.scaleType,
             data.mediaData.bigImage.altText,
-            data.mediaData.gif.numberOfFrames
+            data.mediaData.gif.numberOfFrames,
+            data.mediaData.imageBorderData
         )
         setCustomContentViewLargeIcon(baseContent.iconData.largeIcon)
 

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/TimerBigContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/TimerBigContentView.kt
@@ -23,7 +23,8 @@ internal class TimerBigContentView(
             data.mediaData.bigImage.url,
             data.mediaData.scaleType,
             data.mediaData.bigImage.altText,
-            data.mediaData.gif.numberOfFrames
+            data.mediaData.gif.numberOfFrames,
+            data.mediaData.imageBorderData
         )
     }
 }

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/VerticalImageBigContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/VerticalImageBigContentView.kt
@@ -33,7 +33,8 @@ internal class VerticalImageBigContentView(
             data.mediaData.bigImage.url,
             data.mediaData.scaleType,
             data.mediaData.bigImage.altText,
-            data.mediaData.gif.numberOfFrames
+            data.mediaData.gif.numberOfFrames,
+            data.mediaData.imageBorderData
         )
 
         setAdditionalText(data.text1, R.id.vertical_img_text1, data.text1Color)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/VerticalImageSmallContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/VerticalImageSmallContentView.kt
@@ -31,7 +31,8 @@ internal class VerticalImageSmallContentView(
                 mediaData.bigImage.url,
                 mediaData.scaleType,
                 mediaData.bigImage.altText,
-                mediaData.gif.numberOfFrames
+                mediaData.gif.numberOfFrames,
+                mediaData.imageBorderData
             )
         } else {
             remoteView.setViewVisibility(R.id.big_media_configurable, View.GONE)

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ZeroBezelBigContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ZeroBezelBigContentView.kt
@@ -30,7 +30,8 @@ internal class ZeroBezelBigContentView(
             data.mediaData.bigImage.url,
             data.mediaData.scaleType,
             data.mediaData.bigImage.altText,
-            data.mediaData.gif.numberOfFrames
+            data.mediaData.gif.numberOfFrames,
+            data.mediaData.imageBorderData
         )
         if (!isMediaLoaded) {
             PTLog.debug("Download failed for all media in ZeroBezel Expanded Notification. Not showing the image")

--- a/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ZeroBezelSmallContentView.kt
+++ b/clevertap-pushtemplates/src/main/java/com/clevertap/android/pushtemplates/content/ZeroBezelSmallContentView.kt
@@ -22,7 +22,8 @@ internal open class ZeroBezelSmallContentView(
             data.collapsedMediaData.bigImage.url,
             data.collapsedMediaData.scaleType,
             data.collapsedMediaData.bigImage.altText,
-            data.collapsedMediaData.gif.numberOfFrames
+            data.collapsedMediaData.gif.numberOfFrames,
+            data.collapsedMediaData.imageBorderData
         )
         if (!isMediaLoaded) {
             if (data.showCollapsedBackgroundImage) {

--- a/clevertap-pushtemplates/src/main/res/layout-v31/vertical_image_big.xml
+++ b/clevertap-pushtemplates/src/main/res/layout-v31/vertical_image_big.xml
@@ -13,6 +13,7 @@
         android:id="@+id/vertical_img_body"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:paddingStart="@dimen/padding_horizontal"
         android:paddingEnd="@dimen/padding_horizontal">
 
         <!-- Left: Vertical/portrait product image -->
@@ -22,7 +23,9 @@
             android:layout_width="120dp"
             android:layout_height="180dp"
             android:layout_alignParentStart="true"
-            android:layout_alignParentTop="true" />
+            android:layout_alignParentTop="true"
+            android:layout_marginTop="@dimen/padding_micro"
+            android:layout_marginBottom="@dimen/padding_micro" />
 
         <!-- Top-right: title + message, anchored to top -->
         <LinearLayout

--- a/clevertap-pushtemplates/src/main/res/layout-v31/vertical_image_small.xml
+++ b/clevertap-pushtemplates/src/main/res/layout-v31/vertical_image_small.xml
@@ -7,7 +7,7 @@
     android:background="@android:color/transparent"
     android:orientation="horizontal"
     android:gravity="center_vertical"
-    android:paddingStart="4dp"
+    android:paddingStart="@dimen/padding_horizontal"
     android:paddingTop="@dimen/padding_micro"
     android:paddingBottom="@dimen/padding_micro">
 

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/TemplateDataFactoryTest.kt
@@ -2413,4 +2413,238 @@ class TemplateDataFactoryTest {
         assertEquals(PT_BTN_BORDER_RADIUS_DEFAULT, result.collapsedButtonData!!.borderRadius)
         assertEquals(PT_BTN_BORDER_WIDTH_DEFAULT, result.collapsedButtonData!!.borderWidth)
     }
+
+    // createImageBorderData tests
+
+    /** Adds the image border keys to the default colour map, which setUp() otherwise leaves out. */
+    private fun stubBorderColor(color: String?) {
+        every { Utils.createColorMap(any(), any()) } returns mapOf(
+            PT_TITLE_COLOR to SAMPLE_COLOR,
+            PT_MSG_COLOR to SAMPLE_COLOR,
+            PT_BG to SAMPLE_COLOR,
+            PT_IMG_BORDER_CLR to color
+        )
+    }
+
+    @Test
+    fun `createImageBorderData should parse corner radius border width and colour`() {
+        // Given
+        setupBasicMockBundle()
+        stubBorderColor(SAMPLE_COLOR)
+        every { Utils.getColourOrNull(SAMPLE_COLOR) } returns android.graphics.Color.RED
+        every { mockBundle.getString(PT_IMG_CORNER_RADIUS) } returns "12"
+        every { mockBundle.getString(PT_IMG_BORDER_WIDTH) } returns "6"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.BASIC,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as BasicTemplateData
+
+        // Then
+        val border = result.mediaData.imageBorderData
+        assertTrue(border.isActive)
+        assertEquals(android.graphics.Color.RED, border.borderColor)
+        assertEquals(12f, border.cornerRadiusPercent)
+        assertEquals(6f, border.borderWidthPercent)
+    }
+
+    @Test
+    fun `createImageBorderData should be inactive when no border keys are present`() {
+        // Given - a payload from before this feature existed
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_IMG_CORNER_RADIUS) } returns null
+        every { mockBundle.getString(PT_IMG_BORDER_WIDTH) } returns null
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.BASIC,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as BasicTemplateData
+
+        // Then - existing campaigns must render exactly as they did before
+        val border = result.mediaData.imageBorderData
+        assertFalse(border.isActive)
+        assertNull(border.borderColor)
+        assertEquals(0f, border.cornerRadiusPercent)
+        assertNull(border.borderWidthPercent)
+    }
+
+    @Test
+    fun `createImageBorderData should stay inactive when the colour cannot be parsed`() {
+        // Given - an unparseable colour with no corner radius. The raw string is present, so a
+        // check on the string alone would wrongly mark the border active and force fit_center.
+        setupBasicMockBundle()
+        stubBorderColor("not-a-colour")
+        every { Utils.getColourOrNull("not-a-colour") } returns null
+        every { mockBundle.getString(PT_IMG_CORNER_RADIUS) } returns null
+        every { mockBundle.getString(PT_IMG_BORDER_WIDTH) } returns null
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.BASIC,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as BasicTemplateData
+
+        // Then
+        val border = result.mediaData.imageBorderData
+        assertNull(border.borderColor)
+        assertFalse(border.isActive)
+    }
+
+    @Test
+    fun `createImageBorderData should default corner radius to zero for a non numeric value`() {
+        // Given
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_IMG_CORNER_RADIUS) } returns "abc"
+        every { mockBundle.getString(PT_IMG_BORDER_WIDTH) } returns "xyz"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.BASIC,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as BasicTemplateData
+
+        // Then - garbage in the payload must not crash the render
+        val border = result.mediaData.imageBorderData
+        assertEquals(0f, border.cornerRadiusPercent)
+        assertNull(border.borderWidthPercent)
+        assertFalse(border.isActive)
+    }
+
+    @Test
+    fun `createImageBorderData should be active with only a corner radius`() {
+        // Given - rounded corners without a border is a valid configuration
+        setupBasicMockBundle()
+        every { mockBundle.getString(PT_IMG_CORNER_RADIUS) } returns "20"
+        every { mockBundle.getString(PT_IMG_BORDER_WIDTH) } returns null
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.BASIC,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as BasicTemplateData
+
+        // Then
+        val border = result.mediaData.imageBorderData
+        assertTrue(border.isActive)
+        assertEquals(20f, border.cornerRadiusPercent)
+        assertNull(border.borderColor)
+    }
+
+    @Test
+    fun `createImageBorderData should use the dark mode colour when the device is in dark mode`() {
+        // Given - createColorMap resolves the _dark suffix, so the factory only sees the winner
+        setupBasicMockBundle()
+        stubBorderColor("#00FF00")
+        every { Utils.getColourOrNull("#00FF00") } returns android.graphics.Color.GREEN
+        every { mockBundle.getString(PT_IMG_CORNER_RADIUS) } returns "8"
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.BASIC,
+            extras = mockBundle,
+            isDarkMode = true,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as BasicTemplateData
+
+        // Then
+        assertEquals(android.graphics.Color.GREEN, result.mediaData.imageBorderData.borderColor)
+    }
+
+    @Test
+    fun `createImageBorderData should reach carousel five icon and product templates`() {
+        // Given - the same keys must be picked up by templates that build their own media data
+        setupBasicMockBundle()
+        stubBorderColor(SAMPLE_COLOR)
+        every { Utils.getColourOrNull(SAMPLE_COLOR) } returns android.graphics.Color.RED
+        every { mockBundle.getString(PT_IMG_CORNER_RADIUS) } returns "15"
+
+        // When
+        val carousel = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.AUTO_CAROUSEL,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as AutoCarouselTemplateData
+        val fiveIcons = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.FIVE_ICONS,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as FiveIconsTemplateData
+        val product = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.PRODUCT_DISPLAY,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as ProductTemplateData
+
+        // Then
+        assertEquals(15f, carousel.carouselData.imageBorderData.cornerRadiusPercent)
+        assertEquals(15f, fiveIcons.imageBorderData.cornerRadiusPercent)
+        assertEquals(15f, product.imageBorderData.cornerRadiusPercent)
+    }
+
+    @Test
+    fun `collapsed media data should inherit the border config from the expanded media`() {
+        // Given - collapsed views deliberately share the expanded border config rather than
+        // expecting a second set of keys in the payload
+        setupBasicMockBundle()
+        stubBorderColor(SAMPLE_COLOR)
+        every { Utils.getColourOrNull(SAMPLE_COLOR) } returns android.graphics.Color.RED
+        every { mockBundle.getString(PT_IMG_CORNER_RADIUS) } returns "18"
+        every { mockBundle.getString(PT_BIG_IMG_COLLAPSED) } returns SAMPLE_IMAGE_URL
+
+        // When
+        val result = TemplateDataFactory.createTemplateData(
+            templateType = TemplateType.ZERO_BEZEL,
+            extras = mockBundle,
+            isDarkMode = false,
+            defaultAltText = defaultAltText,
+            notificationIdsProvider = notificationIdsProvider
+        ) as ZeroBezelTemplateData
+
+        // Then
+        assertEquals(18f, result.mediaData.imageBorderData.cornerRadiusPercent)
+        assertEquals(18f, result.collapsedMediaData.imageBorderData.cornerRadiusPercent)
+        assertEquals(
+            android.graphics.Color.RED,
+            result.collapsedMediaData.imageBorderData.borderColor
+        )
+    }
+
+    @Test
+    fun `effectiveScaleType should force FIT_CENTER only while the border is active`() {
+        // Given
+        val active = ImageBorderData(cornerRadiusPercent = 10f)
+        val inactive = ImageBorderData()
+
+        // Then - a baked-in radius would be cropped away by a CENTER_CROP image view
+        assertEquals(PTScaleType.FIT_CENTER, active.effectiveScaleType(PTScaleType.CENTER_CROP))
+        assertEquals(PTScaleType.FIT_CENTER, active.effectiveScaleType(PTScaleType.FIT_CENTER))
+        assertEquals(PTScaleType.CENTER_CROP, inactive.effectiveScaleType(PTScaleType.CENTER_CROP))
+        assertEquals(PTScaleType.FIT_CENTER, inactive.effectiveScaleType(PTScaleType.FIT_CENTER))
+        // A null config behaves like an inactive one
+        assertEquals(PTScaleType.CENTER_CROP, null.effectiveScaleType(PTScaleType.CENTER_CROP))
+    }
 }

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/UtilsTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/UtilsTest.kt
@@ -856,7 +856,13 @@ class UtilsTest {
     @Test
     fun `getImageDataListFromExtras should return list of ImageData objects`() {
         // Given
-        val keys = setOf("pt_img1", "pt_img2", "other_key", "pt_img", "pt_img_alt_text", "pt_img1_alt_text")
+        // Only pt_img<digit> keys are carousel images. Bare "pt_img" and the pt_img_* border
+        // configuration keys must be ignored even though they all share the "pt_img" prefix.
+        val keys = setOf(
+            "pt_img1", "pt_img2", "other_key", "pt_img", "pt_img_alt_text", "pt_img1_alt_text",
+            PTConstants.PT_IMG_BORDER_CLR, PTConstants.PT_IMG_CORNER_RADIUS,
+            PTConstants.PT_IMG_BORDER_WIDTH
+        )
         val defaultAltText = "Default Image "
         every { mockBundle.keySet() } returns keys
         every { mockBundle.getString("pt_img1") } returns "https://example.com/img1.jpg"
@@ -870,8 +876,8 @@ class UtilsTest {
         val result = Utils.getImageDataListFromExtras(mockBundle, defaultAltText)
 
         // Then
-        assertEquals(3, result.size)
-        
+        assertEquals(2, result.size)
+
         // Find items by URL to verify they exist
         val img1Data = result.find { it.url == "https://example.com/img1.jpg" }
         val img2Data = result.find { it.url == "https://example.com/img2.jpg" }
@@ -885,6 +891,9 @@ class UtilsTest {
         // Verify no data for non-image key
         val nonImageData = result.find { it.url == "not_an_image" }
         assertNull(nonImageData)
+
+        // Bare "pt_img" has no index digit, so it is not a carousel image
+        assertNull(result.find { it.url == "https://example.com/large.jpg" })
     }
 
     @Test

--- a/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtilsTest.kt
+++ b/clevertap-pushtemplates/src/test/java/com/clevertap/android/pushtemplates/content/NotificationBitmapUtilsTest.kt
@@ -6,6 +6,8 @@ import android.os.Build
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotSame
+import org.junit.Assert.assertSame
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -267,5 +269,265 @@ class NotificationBitmapUtilsTest {
         assertNotNull(bitmap)
         assertEquals(width, bitmap.width)
         assertEquals(height, bitmap.height)
+    }
+
+    // resolveCornerRadiusPx / resolveBorderWidthPx tests
+    //
+    // These cover the percentage-to-pixel conversion directly. Canvas drawing is a no-op under
+    // Robolectric's legacy graphics mode, so asserting on the output bitmap cannot distinguish a
+    // percentage from a raw pixel count - only these assertions can.
+
+    @Test
+    fun `resolveCornerRadiusPx should scale with the shortest side`() {
+        // Given - the same payload value of 10 against differently sized images
+
+        // Then - 10% of the shortest side in each case, so the result stays proportional
+        assertEquals(18f, NotificationBitmapUtils.resolveCornerRadiusPx(180, 10f))
+        assertEquals(30f, NotificationBitmapUtils.resolveCornerRadiusPx(300, 10f))
+        assertEquals(80f, NotificationBitmapUtils.resolveCornerRadiusPx(800, 10f))
+    }
+
+    @Test
+    fun `resolveCornerRadiusPx should treat the value as a percentage and not as pixels`() {
+        // Given - a payload value that is deliberately larger than the shortest side
+
+        // Then - as pixels this would be 40px; as a percentage of 180 it is 72px
+        assertEquals(72f, NotificationBitmapUtils.resolveCornerRadiusPx(180, 40f))
+    }
+
+    @Test
+    fun `resolveCornerRadiusPx should cap at half the shortest side`() {
+        // Given - 50% is a full pill; anything beyond has no additional visible effect
+
+        // Then
+        assertEquals(90f, NotificationBitmapUtils.resolveCornerRadiusPx(180, 50f))
+        assertEquals(90f, NotificationBitmapUtils.resolveCornerRadiusPx(180, 80f))
+        assertEquals(90f, NotificationBitmapUtils.resolveCornerRadiusPx(180, 5000f))
+    }
+
+    @Test
+    fun `resolveCornerRadiusPx should clamp a negative percentage to zero`() {
+        // Then
+        assertEquals(0f, NotificationBitmapUtils.resolveCornerRadiusPx(180, -10f))
+        assertEquals(0f, NotificationBitmapUtils.resolveCornerRadiusPx(180, 0f))
+    }
+
+    @Test
+    fun `resolveBorderWidthPx should default to ten percent of the shortest side`() {
+        // Given - the payload omits pt_img_border_width
+
+        // Then
+        assertEquals(18f, NotificationBitmapUtils.resolveBorderWidthPx(180, null))
+        assertEquals(80f, NotificationBitmapUtils.resolveBorderWidthPx(800, null))
+    }
+
+    @Test
+    fun `resolveBorderWidthPx should scale an explicit percentage with the shortest side`() {
+        // Then
+        assertEquals(9f, NotificationBitmapUtils.resolveBorderWidthPx(180, 5f))
+        assertEquals(40f, NotificationBitmapUtils.resolveBorderWidthPx(800, 5f))
+    }
+
+    @Test
+    fun `resolveBorderWidthPx should cap at twenty five percent of the shortest side`() {
+        // Given - a border thicker than a quarter of the image would swallow the image
+
+        // Then
+        assertEquals(45f, NotificationBitmapUtils.resolveBorderWidthPx(180, 25f))
+        assertEquals(45f, NotificationBitmapUtils.resolveBorderWidthPx(180, 90f))
+        assertEquals(45f, NotificationBitmapUtils.resolveBorderWidthPx(180, 5000f))
+    }
+
+    @Test
+    fun `resolveBorderWidthPx should clamp a negative percentage to zero`() {
+        // Given - an unclamped negative value would both drop the border and push the draw rect
+        // outside the bitmap bounds
+
+        // Then
+        assertEquals(0f, NotificationBitmapUtils.resolveBorderWidthPx(180, -5f))
+    }
+
+    // applyRoundedBorderToBitmap tests
+
+    private fun sourceBitmap(w: Int = width, h: Int = height): Bitmap =
+        Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888).also { bitmapsToRecycle.add(it) }
+
+    @Test
+    fun `applyRoundedBorderToBitmap should return the source when radius is zero and no border color`() {
+        // Given
+        val source = sourceBitmap()
+
+        // When
+        val result = NotificationBitmapUtils.applyRoundedBorderToBitmap(
+            source = source,
+            cornerRadiusPercent = 0f,
+            borderColor = null,
+            borderWidthPercent = null
+        )
+
+        // Then - nothing to draw, so the cached source is reused instead of allocating a copy
+        assertSame(source, result)
+    }
+
+    @Test
+    fun `applyRoundedBorderToBitmap should return a new bitmap of the same size when radius is set`() {
+        // Given
+        val source = sourceBitmap()
+
+        // When
+        val result = NotificationBitmapUtils.applyRoundedBorderToBitmap(
+            source = source,
+            cornerRadiusPercent = 10f,
+            borderColor = null,
+            borderWidthPercent = null
+        ).also { bitmapsToRecycle.add(it) }
+
+        // Then
+        assertNotSame(source, result)
+        assertEquals(source.width, result.width)
+        assertEquals(source.height, result.height)
+    }
+
+    @Test
+    fun `applyRoundedBorderToBitmap should return a new bitmap when only a border color is set`() {
+        // Given - a border with no corner radius is still a border
+        val source = sourceBitmap()
+
+        // When
+        val result = NotificationBitmapUtils.applyRoundedBorderToBitmap(
+            source = source,
+            cornerRadiusPercent = 0f,
+            borderColor = borderColor,
+            borderWidthPercent = null
+        ).also { bitmapsToRecycle.add(it) }
+
+        // Then
+        assertNotSame(source, result)
+        assertEquals(source.width, result.width)
+        assertEquals(source.height, result.height)
+    }
+
+    @Test
+    fun `applyRoundedBorderToBitmap should preserve the dimensions of any source size`() {
+        // Given - a small and a large image. The percentage maths is asserted by the
+        // resolveCornerRadiusPx tests above; this only pins the output dimensions.
+        val small = sourceBitmap(240, 180)
+        val large = sourceBitmap(1200, 800)
+
+        // When
+        val smallResult = NotificationBitmapUtils.applyRoundedBorderToBitmap(
+            source = small,
+            cornerRadiusPercent = 10f,
+            borderColor = borderColor,
+            borderWidthPercent = 10f
+        ).also { bitmapsToRecycle.add(it) }
+        val largeResult = NotificationBitmapUtils.applyRoundedBorderToBitmap(
+            source = large,
+            cornerRadiusPercent = 10f,
+            borderColor = borderColor,
+            borderWidthPercent = 10f
+        ).also { bitmapsToRecycle.add(it) }
+
+        // Then - each output keeps its own dimensions; the radius is derived from them, so one
+        // payload value renders proportionally on both instead of being a fixed pixel count
+        assertEquals(240, smallResult.width)
+        assertEquals(180, smallResult.height)
+        assertEquals(1200, largeResult.width)
+        assertEquals(800, largeResult.height)
+    }
+
+    @Test
+    fun `applyRoundedBorderToBitmap should not fail for an oversized corner radius`() {
+        // Given - well beyond the 50 percent cap
+        val source = sourceBitmap()
+
+        // When
+        val result = NotificationBitmapUtils.applyRoundedBorderToBitmap(
+            source = source,
+            cornerRadiusPercent = 500f,
+            borderColor = borderColor,
+            borderWidthPercent = null
+        ).also { bitmapsToRecycle.add(it) }
+
+        // Then
+        assertNotNull(result)
+        assertEquals(source.width, result.width)
+        assertEquals(source.height, result.height)
+    }
+
+    @Test
+    fun `applyRoundedBorderToBitmap should not fail for an oversized border width`() {
+        // Given - well beyond the 25 percent cap
+        val source = sourceBitmap()
+
+        // When
+        val result = NotificationBitmapUtils.applyRoundedBorderToBitmap(
+            source = source,
+            cornerRadiusPercent = 10f,
+            borderColor = borderColor,
+            borderWidthPercent = 900f
+        ).also { bitmapsToRecycle.add(it) }
+
+        // Then
+        assertNotNull(result)
+        assertEquals(source.width, result.width)
+        assertEquals(source.height, result.height)
+    }
+
+    @Test
+    fun `applyRoundedBorderToBitmap should not fail for a negative border width`() {
+        // Given - the clamp itself is asserted by resolveBorderWidthPx; this only checks the draw
+        // path survives the value
+        val source = sourceBitmap()
+
+        // When
+        val result = NotificationBitmapUtils.applyRoundedBorderToBitmap(
+            source = source,
+            cornerRadiusPercent = 10f,
+            borderColor = borderColor,
+            borderWidthPercent = -5f
+        ).also { bitmapsToRecycle.add(it) }
+
+        // Then
+        assertNotSame(source, result)
+        assertEquals(source.width, result.width)
+        assertEquals(source.height, result.height)
+    }
+
+    @Test
+    fun `applyRoundedBorderToBitmap should ignore a negative corner radius`() {
+        // Given - a negative radius counts as no radius, so with no border color there is nothing
+        // to draw and the source is returned untouched
+        val source = sourceBitmap()
+
+        // When
+        val result = NotificationBitmapUtils.applyRoundedBorderToBitmap(
+            source = source,
+            cornerRadiusPercent = -10f,
+            borderColor = null,
+            borderWidthPercent = null
+        )
+
+        // Then
+        assertSame(source, result)
+    }
+
+    @Test
+    fun `applyRoundedBorderToBitmap should handle a single pixel bitmap`() {
+        // Given - the smallest bitmap the platform will hand us
+        val source = sourceBitmap(1, 1)
+
+        // When
+        val result = NotificationBitmapUtils.applyRoundedBorderToBitmap(
+            source = source,
+            cornerRadiusPercent = 50f,
+            borderColor = borderColor,
+            borderWidthPercent = 25f
+        ).also { bitmapsToRecycle.add(it) }
+
+        // Then
+        assertNotNull(result)
+        assertEquals(1, result.width)
+        assertEquals(1, result.height)
     }
 }

--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -281,6 +281,9 @@ pt_big_img_alt_text | Optional | Alt Text for Image
 pt_gif | Optional | GIF
 pt_gif_frames | Optional | Number of frames to extract from the GIF
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_ico | Optional | Large Icon
 pt_dl1 | Optional | One Deep Link (minimum)
 pt_title_clr | Optional | Title Color in HEX
@@ -309,6 +312,9 @@ pt_img3_alt_text | Optional | Alt Text for Image Three
 pt_img`n` | Optional | Image `N`
 pt_img`n`_alt_text | Optional | Alt Text for Image `N`
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_bg | Optional | Background Color in HEX
 pt_ico | Optional | Large Icon
 pt_title_clr | Optional | Title Color in HEX
@@ -339,6 +345,9 @@ pt_img3_alt_text | Optional | Alt Text for Image Three
 pt_img`n` | Optional | Image `N`
 pt_img`n`_alt_text | Optional | Alt Text for Image `N`
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_bg | Optional | Background Color in HEX
 pt_ico | Optional | Large Icon
 pt_title_clr | Optional | Title Color in HEX
@@ -361,6 +370,9 @@ pt_gif | Optional | GIF
 pt_gif_frames | Optional | Number of frames to extract from the GIF
 pt_big_img_alt_text | Optional | Alt Text for Image
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_msg_summary | Optional | Message line when Notification is expanded
 pt_subtitle | Optional | Subtitle
 pt_default_dl | Required  | Default Deep Link for Push Notification
@@ -393,6 +405,9 @@ pt_img2_alt_text | Optional | Alt Text for Image Two
 pt_img3 | Required  | Image Three
 pt_img3_alt_text | Optional | Alt Text for Image Three
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_bt1 | Required  | Big text for first image
 pt_bt2 | Required  | Big text for second image
 pt_bt3 | Required  | Big text for third image
@@ -438,6 +453,9 @@ pt_dl4 | Optional  | Deep Link for fourth icon
 pt_dl5 | Optional  | Deep Link for fifth icon
 pt_bg | Optional  | Background Color in HEX
 pt_small_icon_clr | Optional | Small Icon Color in HEX
+pt_img_corner_radius | Optional | Corner radius applied to each icon, as a percentage (`0`-`50`) of the icon's shortest side. Defaults to `0` (square corners)
+pt_img_border_clr | Optional | Border color applied to each icon in HEX
+pt_img_border_width | Optional | Border width applied to each icon, as a percentage (`0`-`25`) of the icon's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_sticky | Optional | Should the notification be sticky? ("true"/"false")
 pt_dismiss | Optional | Auto dismiss the notification after a set time (value in seconds)
 pt_json | Optional | Above keys in JSON format
@@ -460,6 +478,9 @@ pt_gif | Optional | GIF
 pt_gif_frames | Optional | Number of frames to extract from the GIF
 pt_big_img_alt_text | Optional | Alt Text for Image
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_big_img_alt | Optional | Image to show when timer expires
 pt_gif_alt | Optional | GIF to show when timer expires
 pt_gif_frames_alt | Optional | Number of frames to extract from the alternate GIF
@@ -498,6 +519,9 @@ pt_gif | Optional | GIF
 pt_gif_frames | Optional | Number of frames to extract from the GIF
 pt_big_img_alt_text | Optional | Alt Text for Image
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_big_img_collapsed | Optional | Image for the collapsed view
 pt_gif_collapsed | Optional | GIF for the collapsed view
 pt_gif_frames_collapsed | Optional | Number of frames to extract from the GIF for the collapsed view
@@ -603,6 +627,39 @@ Templates support **custom color definitions** that adapt to both themes for vis
 To use the Image scaling feature, ensure you are using Push Templates SDK version 2.1.0 and above.
 Android supports various image scaling options to control how images appear in push notifications. CleverTap optimizes image rendering to maintain visual consistency across devices while leveraging Android native scaling behavior. 
 To handle scaling in a Push template, you must add the key `pt_scale_type` key and the value is set as `fit_center` or `center_crop` based on the requirement. Refer [here](https://developer.clevertap.com/docs/android-push-templates#image-scaling) for more details
+
+## Image Border and Rounded Corners
+
+Templates that render an image support rounded corners and a border on that image. Add any of the
+following keys to the payload:
+
+| Key | Description |
+|:---|:---|
+| `pt_img_corner_radius` | Corner radius as a **percentage of the image's shortest side**, `0`-`50`. Defaults to `0` (square corners); `50` produces a fully rounded pill |
+| `pt_img_border_clr` | Border color in HEX, for example `#FF5722`. When omitted, no border is drawn |
+| `pt_img_border_width` | Border width as a **percentage of the image's shortest side**, `0`-`25`. Defaults to `10`. Only used when `pt_img_border_clr` is set |
+
+### Why percentages and not pixels
+
+Campaign images vary in resolution, so a fixed pixel value would look different on every image. A
+value of `10` renders as 18px on a 240x180 image and as 80px on a 1200x800 one, which is the same
+proportion and therefore the same result on screen. Set the value once and it stays consistent
+across every campaign, whatever the asset size.
+
+Note that this differs from `pt_btn_border_radius` and `pt_chrono_border_radius`, which are absolute
+values because the SDK draws those on a fixed-size canvas.
+
+### Notes
+
+* `pt_img_border_clr` supports the dark mode suffix, so `pt_img_border_clr_dark` is used when the
+  device is in dark mode. See [Dark Mode](#dark-mode).
+* Because the corners are baked into the bitmap, a `center_crop` image view would crop them away.
+  Whenever either key is active the SDK renders the image with `fit_center` and ignores
+  `pt_scale_type`.
+* Values outside the supported range are clamped, and invalid values are ignored: an unparseable
+  color, a non-numeric radius, or a negative width all fall back to the default as though the key
+  were absent.
+* The keys apply to GIFs as well as static images.
 
 ## Android 12 Trampoline restrictions
 

--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -656,9 +656,9 @@ values because the SDK draws those on a fixed-size canvas.
 * Because the corners are baked into the bitmap, a `center_crop` image view would crop them away.
   Whenever either key is active the SDK renders the image with `fit_center` and ignores
   `pt_scale_type`.
-* Values outside the supported range are clamped, and invalid values are ignored: an unparseable
-  color, a non-numeric radius, or a negative width all fall back to the default as though the key
-  were absent.
+* Values outside the supported range are clamped to the nearest valid value (for example a negative
+  radius becomes `0`). Truly invalid values — an unparseable color, a non-numeric radius or width,
+  NaN, or Infinity — are ignored as though the key were absent.
 * The keys apply to GIFs as well as static images.
 
 ## Android 12 Trampoline restrictions

--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -633,11 +633,11 @@ To handle scaling in a Push template, you must add the key `pt_scale_type` key a
 Templates that render an image support rounded corners and a border on that image. Add any of the
 following keys to the payload:
 
-| Key | Description |
-|:---|:---|
-| `pt_img_corner_radius` | Corner radius as a **percentage of the image's shortest side**, `0`-`50`. Defaults to `0` (square corners); `50` produces a fully rounded pill |
-| `pt_img_border_clr` | Border color in HEX, for example `#FF5722`. When omitted, no border is drawn |
-| `pt_img_border_width` | Border width as a **percentage of the image's shortest side**, `0`-`25`. Defaults to `10`. Only used when `pt_img_border_clr` is set |
+Key | Description
+:---|:---
+`pt_img_corner_radius` | Corner radius as a **percentage of the image's shortest side**, `0`-`50`. Defaults to `0` (square corners); `50` produces a fully rounded pill
+`pt_img_border_clr` | Border color in HEX, for example `#FF5722`. When omitted, no border is drawn
+`pt_img_border_width` | Border width as a **percentage of the image's shortest side**, `0`-`25`. Defaults to `10`. Only used when `pt_img_border_clr` is set
 
 ### Why percentages and not pixels
 

--- a/docs/CTPUSHTEMPLATESCHANGELOG.md
+++ b/docs/CTPUSHTEMPLATESCHANGELOG.md
@@ -1,4 +1,14 @@
 ## CleverTap Push Templates SDK CHANGE LOG
+### Version 2.5.0 (Unreleased)
+
+#### New Features
+* **Image Border and Rounded Corners:** Adds configurable corner radius (`pt_img_corner_radius`), border color (`pt_img_border_clr`), and border width (`pt_img_border_width`) for the notification image. The radius and width are percentages of the image's shortest side, so a single value renders consistently across images of any resolution across the `Basic`, `Auto Carousel`, `Manual Carousel`, `Rating`, `Product Catalog`, `Five Icons`, `Timer`, `Zero Bezel`, and `Image with CTA` templates. Also applies to GIFs. `pt_img_border_clr` honours the dark mode suffix (`pt_img_border_clr_dark`).
+
+#### Bug Fixes
+* Fixes a crash in the `Manual Carousel` template when navigating between images in a campaign that has no deep links configured.
+* Fixes image list detection so that keys such as `pt_img_border_clr` are no longer treated as carousel images. Only `pt_img<number>` keys are read as images.
+* Fixes the `Image with CTA` template layout so the image is no longer flush against the notification edge.
+
 ### Version 2.4.0 (April 13, 2026)
 
 #### New Features

--- a/templates/CTPUSHTEMPLATES.md
+++ b/templates/CTPUSHTEMPLATES.md
@@ -281,6 +281,9 @@ pt_big_img_alt_text | Optional | Alt Text for Image
 pt_gif | Optional | GIF
 pt_gif_frames | Optional | Number of frames to extract from the GIF
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_ico | Optional | Large Icon
 pt_dl1 | Optional | One Deep Link (minimum)
 pt_title_clr | Optional | Title Color in HEX
@@ -309,6 +312,9 @@ pt_img3_alt_text | Optional | Alt Text for Image Three
 pt_img`n` | Optional | Image `N`
 pt_img`n`_alt_text | Optional | Alt Text for Image `N`
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_bg | Optional | Background Color in HEX
 pt_ico | Optional | Large Icon
 pt_title_clr | Optional | Title Color in HEX
@@ -339,6 +345,9 @@ pt_img3_alt_text | Optional | Alt Text for Image Three
 pt_img`n` | Optional | Image `N`
 pt_img`n`_alt_text | Optional | Alt Text for Image `N`
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_bg | Optional | Background Color in HEX
 pt_ico | Optional | Large Icon
 pt_title_clr | Optional | Title Color in HEX
@@ -361,6 +370,9 @@ pt_gif | Optional | GIF
 pt_gif_frames | Optional | Number of frames to extract from the GIF
 pt_big_img_alt_text | Optional | Alt Text for Image
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_msg_summary | Optional | Message line when Notification is expanded
 pt_subtitle | Optional | Subtitle
 pt_default_dl | Required  | Default Deep Link for Push Notification
@@ -393,6 +405,9 @@ pt_img2_alt_text | Optional | Alt Text for Image Two
 pt_img3 | Required  | Image Three
 pt_img3_alt_text | Optional | Alt Text for Image Three
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_bt1 | Required  | Big text for first image
 pt_bt2 | Required  | Big text for second image
 pt_bt3 | Required  | Big text for third image
@@ -438,6 +453,9 @@ pt_dl4 | Optional  | Deep Link for fourth icon
 pt_dl5 | Optional  | Deep Link for fifth icon
 pt_bg | Optional  | Background Color in HEX
 pt_small_icon_clr | Optional | Small Icon Color in HEX
+pt_img_corner_radius | Optional | Corner radius applied to each icon, as a percentage (`0`-`50`) of the icon's shortest side. Defaults to `0` (square corners)
+pt_img_border_clr | Optional | Border color applied to each icon in HEX
+pt_img_border_width | Optional | Border width applied to each icon, as a percentage (`0`-`25`) of the icon's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_sticky | Optional | Should the notification be sticky? ("true"/"false")
 pt_dismiss | Optional | Auto dismiss the notification after a set time (value in seconds)
 pt_json | Optional | Above keys in JSON format
@@ -460,6 +478,9 @@ pt_gif | Optional | GIF
 pt_gif_frames | Optional | Number of frames to extract from the GIF
 pt_big_img_alt_text | Optional | Alt Text for Image
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_big_img_alt | Optional | Image to show when timer expires
 pt_gif_alt | Optional | GIF to show when timer expires
 pt_gif_frames_alt | Optional | Number of frames to extract from the alternate GIF
@@ -498,6 +519,9 @@ pt_gif | Optional | GIF
 pt_gif_frames | Optional | Number of frames to extract from the GIF
 pt_big_img_alt_text | Optional | Alt Text for Image
 pt_scale_type | Optional | ScaleType for the big image in the ImageView ("center_crop"/"fit_center")
+pt_img_corner_radius | Optional | Corner radius for the big image, as a percentage (`0`-`50`) of the image's shortest side. Defaults to `0` (square corners). Forces `pt_scale_type` to `fit_center` so the rounded corners stay visible
+pt_img_border_clr | Optional | Border color for the big image in HEX. Forces `pt_scale_type` to `fit_center` so the border stays visible
+pt_img_border_width | Optional | Border width for the big image, as a percentage (`0`-`25`) of the image's shortest side. Defaults to `10`. Requires `pt_img_border_clr`
 pt_big_img_collapsed | Optional | Image for the collapsed view
 pt_gif_collapsed | Optional | GIF for the collapsed view
 pt_gif_frames_collapsed | Optional | Number of frames to extract from the GIF for the collapsed view
@@ -603,6 +627,39 @@ Templates support **custom color definitions** that adapt to both themes for vis
 To use the Image scaling feature, ensure you are using Push Templates SDK version 2.1.0 and above.
 Android supports various image scaling options to control how images appear in push notifications. CleverTap optimizes image rendering to maintain visual consistency across devices while leveraging Android native scaling behavior. 
 To handle scaling in a Push template, you must add the key `pt_scale_type` key and the value is set as `fit_center` or `center_crop` based on the requirement. Refer [here](https://developer.clevertap.com/docs/android-push-templates#image-scaling) for more details
+
+## Image Border and Rounded Corners
+
+Templates that render an image support rounded corners and a border on that image. Add any of the
+following keys to the payload:
+
+| Key | Description |
+|:---|:---|
+| `pt_img_corner_radius` | Corner radius as a **percentage of the image's shortest side**, `0`-`50`. Defaults to `0` (square corners); `50` produces a fully rounded pill |
+| `pt_img_border_clr` | Border color in HEX, for example `#FF5722`. When omitted, no border is drawn |
+| `pt_img_border_width` | Border width as a **percentage of the image's shortest side**, `0`-`25`. Defaults to `10`. Only used when `pt_img_border_clr` is set |
+
+### Why percentages and not pixels
+
+Campaign images vary in resolution, so a fixed pixel value would look different on every image. A
+value of `10` renders as 18px on a 240x180 image and as 80px on a 1200x800 one, which is the same
+proportion and therefore the same result on screen. Set the value once and it stays consistent
+across every campaign, whatever the asset size.
+
+Note that this differs from `pt_btn_border_radius` and `pt_chrono_border_radius`, which are absolute
+values because the SDK draws those on a fixed-size canvas.
+
+### Notes
+
+* `pt_img_border_clr` supports the dark mode suffix, so `pt_img_border_clr_dark` is used when the
+  device is in dark mode. See [Dark Mode](#dark-mode).
+* Because the corners are baked into the bitmap, a `center_crop` image view would crop them away.
+  Whenever either key is active the SDK renders the image with `fit_center` and ignores
+  `pt_scale_type`.
+* Values outside the supported range are clamped, and invalid values are ignored: an unparseable
+  color, a non-numeric radius, or a negative width all fall back to the default as though the key
+  were absent.
+* The keys apply to GIFs as well as static images.
 
 ## Android 12 Trampoline restrictions
 

--- a/templates/CTPUSHTEMPLATES.md
+++ b/templates/CTPUSHTEMPLATES.md
@@ -656,9 +656,9 @@ values because the SDK draws those on a fixed-size canvas.
 * Because the corners are baked into the bitmap, a `center_crop` image view would crop them away.
   Whenever either key is active the SDK renders the image with `fit_center` and ignores
   `pt_scale_type`.
-* Values outside the supported range are clamped, and invalid values are ignored: an unparseable
-  color, a non-numeric radius, or a negative width all fall back to the default as though the key
-  were absent.
+* Values outside the supported range are clamped to the nearest valid value (for example a negative
+  radius becomes `0`). Truly invalid values — an unparseable color, a non-numeric radius or width,
+  NaN, or Infinity — are ignored as though the key were absent.
 * The keys apply to GIFs as well as static images.
 
 ## Android 12 Trampoline restrictions

--- a/templates/CTPUSHTEMPLATES.md
+++ b/templates/CTPUSHTEMPLATES.md
@@ -633,11 +633,11 @@ To handle scaling in a Push template, you must add the key `pt_scale_type` key a
 Templates that render an image support rounded corners and a border on that image. Add any of the
 following keys to the payload:
 
-| Key | Description |
-|:---|:---|
-| `pt_img_corner_radius` | Corner radius as a **percentage of the image's shortest side**, `0`-`50`. Defaults to `0` (square corners); `50` produces a fully rounded pill |
-| `pt_img_border_clr` | Border color in HEX, for example `#FF5722`. When omitted, no border is drawn |
-| `pt_img_border_width` | Border width as a **percentage of the image's shortest side**, `0`-`25`. Defaults to `10`. Only used when `pt_img_border_clr` is set |
+Key | Description
+:---|:---
+`pt_img_corner_radius` | Corner radius as a **percentage of the image's shortest side**, `0`-`50`. Defaults to `0` (square corners); `50` produces a fully rounded pill
+`pt_img_border_clr` | Border color in HEX, for example `#FF5722`. When omitted, no border is drawn
+`pt_img_border_width` | Border width as a **percentage of the image's shortest side**, `0`-`25`. Defaults to `10`. Only used when `pt_img_border_clr` is set
 
 ### Why percentages and not pixels
 

--- a/templates/CTPUSHTEMPLATESCHANGELOG.md
+++ b/templates/CTPUSHTEMPLATESCHANGELOG.md
@@ -1,4 +1,14 @@
 ## CleverTap Push Templates SDK CHANGE LOG
+### Version 2.5.0 (Unreleased)
+
+#### New Features
+* **Image Border and Rounded Corners:** Adds configurable corner radius (`pt_img_corner_radius`), border color (`pt_img_border_clr`), and border width (`pt_img_border_width`) for the notification image. The radius and width are percentages of the image's shortest side, so a single value renders consistently across images of any resolution across the `Basic`, `Auto Carousel`, `Manual Carousel`, `Rating`, `Product Catalog`, `Five Icons`, `Timer`, `Zero Bezel`, and `Image with CTA` templates. Also applies to GIFs. `pt_img_border_clr` honours the dark mode suffix (`pt_img_border_clr_dark`).
+
+#### Bug Fixes
+* Fixes a crash in the `Manual Carousel` template when navigating between images in a campaign that has no deep links configured.
+* Fixes image list detection so that keys such as `pt_img_border_clr` are no longer treated as carousel images. Only `pt_img<number>` keys are read as images.
+* Fixes the `Image with CTA` template layout so the image is no longer flush against the notification edge.
+
 ### Version 2.4.0 (April 13, 2026)
 
 #### New Features


### PR DESCRIPTION
…h templates

New JSON keys: pt_img_border_clr, pt_img_corner_radius, pt_img_border_width

Templates updated:
- Basic (BigImageContentView)
- Auto Carousel (AutoCarouselContentView)
- Manual Carousel (ManualCarouselContentView)
- Rating (RatingContentView)
- Five Icons (FiveIconBigContentView, FiveIconSmallContentView)
- Product Display (ProductDisplayLinearBigContentView)
- Zero Bezel (ZeroBezelBigContentView, ZeroBezelSmallContentView)
- Timer (TimerBigContentView)
- Vertical Image (VerticalImageBigContentView, VerticalImageSmallContentView)

Border processing via bitmap post-processing (Canvas clipPath + drawRoundRect) to work within RemoteViews constraints. All params optional with safe defaults for full backward compatibility. GIF frames processed individually. pt_img_border_clr registered in COLOR_KEYS for dark mode adaptation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable rounded corners and borders for notification images, including GIFs, carousels, media, product, and timer templates.
  - Supports percentage-based styling, color formats, dark-mode colors, and automatic scale handling.

- **Bug Fixes**
  - Prevented Manual Carousel crashes with missing images or deep links.
  - Improved carousel image-key detection and Image with CTA spacing.

- **Documentation**
  - Updated styling limits, supported formats, defaults, and template support details.
  - Clarified that Five Icons does not support image styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->