### PR TITLE
feat(SDK-5976): render custom-HTML header/footer in-apps on non-FragmentActivity hosts

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CTWebInterface.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CTWebInterface.java
@@ -4,7 +4,7 @@ import android.os.Bundle;
 import android.webkit.JavascriptInterface;
 import androidx.annotation.RestrictTo;
 import com.clevertap.android.sdk.inapp.CTInAppAction;
-import com.clevertap.android.sdk.inapp.fragment.CTInAppBaseFragment;
+import com.clevertap.android.sdk.inapp.InAppWebInteraction;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -20,7 +20,7 @@ public class CTWebInterface {
 
     private WeakReference<CleverTapAPI> cleverTapWr = new WeakReference<>(null);
 
-    private WeakReference<CTInAppBaseFragment> fragmentWr = new WeakReference<>(null);
+    private WeakReference<InAppWebInteraction> hostWr = new WeakReference<>(null);
 
     public CTWebInterface(CleverTapAPI instance) {
         this.cleverTapWr = new WeakReference<>(instance);
@@ -34,9 +34,9 @@ public class CTWebInterface {
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    public CTWebInterface(CleverTapAPI instance, CTInAppBaseFragment inAppBaseFragment) {
+    public CTWebInterface(CleverTapAPI instance, InAppWebInteraction host) {
         this.cleverTapWr = new WeakReference<>(instance);
-        this.fragmentWr = new WeakReference<>(inAppBaseFragment);
+        this.hostWr = new WeakReference<>(host);
     }
 
     /**
@@ -65,9 +65,9 @@ public class CTWebInterface {
             Logger.d("CleverTap Instance is null.");
         } else {
             //Dismisses current IAM and proceeds to call promptForPushPermission()
-            CTInAppBaseFragment fragment = fragmentWr.get();
-            if (fragment != null) {
-                fragment.didDismiss(null);
+            InAppWebInteraction host = hostWr.get();
+            if (host != null) {
+                host.didDismiss(null);
             }
         }
     }
@@ -404,9 +404,9 @@ public class CTWebInterface {
             return;
         }
 
-        CTInAppBaseFragment fragment = fragmentWr.get();
-        if (fragment == null) {
-            Logger.d("CTWebInterface Fragment is null");
+        InAppWebInteraction host = hostWr.get();
+        if (host == null) {
+            Logger.d("CTWebInterface host is null");
             return;
         }
 
@@ -428,7 +428,7 @@ public class CTWebInterface {
                 actionData.putString(Constants.KEY_WZRK_ELEMENT_ID, buttonId);
             }
 
-            fragment.triggerAction(action, callToAction, actionData);
+            host.triggerAction(action, callToAction, actionData);
         } catch (JSONException je) {
             Logger.d("CTWebInterface invalid action JSON: " + actionJson);
         }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/ManifestInfo.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/ManifestInfo.java
@@ -44,6 +44,11 @@ public class ManifestInfo {
 
     private static final String LABEL_ENCRYPTION_IN_TRANSIT = "CLEVERTAP_ENCRYPTION_IN_TRANSIT";
 
+    // Opt-in (default off) that lets custom-html header/footer in-apps render via a WindowManager
+    // overlay when the host Activity is not a FragmentActivity. Enabled by the gaming wrapper SDKs
+    // (Unreal/Unity) via their merged manifest; regular integrations never set it.
+    private static final String LABEL_INAPP_FRAGMENTLESS_BANNERS = "CLEVERTAP_INAPP_FRAGMENTLESS_BANNERS";
+
     private static ManifestInfo instance; // singleton
 
     public synchronized static ManifestInfo getInstance(Context context) {
@@ -105,6 +110,7 @@ public class ManifestInfo {
     private final String fcmSenderId;
     private final String packageName;
     private final boolean beta;
+    private final boolean fragmentlessInAppBanners;
     private final String intentServiceName;
     private final String devDefaultPushChannelId;
     private final String[] profileKeys;
@@ -172,6 +178,7 @@ public class ManifestInfo {
 
         packageName = _getManifestStringValueForKey(metaData, ManifestInfo.LABEL_PACKAGE_NAME);
         beta = "1".equals(_getManifestStringValueForKey(metaData, ManifestInfo.LABEL_BETA));
+        fragmentlessInAppBanners = "1".equals(_getManifestStringValueForKey(metaData, ManifestInfo.LABEL_INAPP_FRAGMENTLESS_BANNERS));
         intentServiceName = _getManifestStringValueForKey(metaData, ManifestInfo.LABEL_INTENT_SERVICE);
         devDefaultPushChannelId = _getManifestStringValueForKey(metaData, ManifestInfo.LABEL_DEFAULT_CHANNEL_ID);
         profileKeys = parseProfileKeys(metaData);
@@ -224,6 +231,8 @@ public class ManifestInfo {
         this.fcmSenderId = fcmSenderId;
         this.packageName = packageName;
         this.beta = beta;
+        // Not exposed through this explicit constructor; only set via the manifest flag.
+        this.fragmentlessInAppBanners = false;
         this.intentServiceName = intentServiceName;
         this.devDefaultPushChannelId = devDefaultPushChannelId;
         this.profileKeys = profileKeys;
@@ -305,6 +314,17 @@ public class ManifestInfo {
 
     boolean isBackgroundSync() {
         return backgroundSync;
+    }
+
+    /**
+     * Whether custom-html header/footer in-apps may fall back to a WindowManager overlay when the
+     * host Activity is not a {@link androidx.fragment.app.FragmentActivity}. Opt-in (default false),
+     * enabled by the gaming wrapper SDKs via the {@code CLEVERTAP_INAPP_FRAGMENTLESS_BANNERS}
+     * manifest flag.
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    public boolean isFragmentlessInAppBannersEnabled() {
+        return fragmentlessInAppBanners;
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridge.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridge.kt
@@ -17,12 +17,18 @@ internal class CTHtmlBannerCallbacksBridge(
     private val notification: CTInAppNotification,
     private val config: CleverTapInstanceConfig,
     private val inAppListener: InAppListener
-) : CTInAppHtmlBannerOverlay.Callbacks {
+) : CTInAppHtmlBannerOverlay.Callbacks, InAppDisplayListener {
 
     /** Set by the caller immediately after constructing the overlay. */
     var overlay: CTInAppHtmlBannerOverlay? = null
 
     private var pendingDismissData: Bundle? = null
+
+    // ----- InAppDisplayListener (external hide, e.g. discardInApps/suspend) -----
+
+    override fun hideInApp() {
+        didDismiss(null)
+    }
 
     // ----- CTInAppHtmlBannerOverlay.Callbacks (banner lifecycle) -----
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridge.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridge.kt
@@ -1,0 +1,66 @@
+package com.clevertap.android.sdk.inapp
+
+import android.os.Bundle
+import com.clevertap.android.sdk.CleverTapInstanceConfig
+import com.clevertap.android.sdk.Constants
+
+/**
+ * Adapts [CTInAppHtmlBannerOverlay]'s UI callbacks and its [CTInAppWebView] interactions to the
+ * SDK's [InAppListener], mirroring how [PIPInAppCallbacksBridge] adapts the PIP renderer's
+ * callbacks. This keeps the overlay renderer free of analytics/action semantics.
+ *
+ * The action-triggered result (the dismiss data) is remembered in [pendingDismissData] and
+ * reported via [InAppListener.inAppNotificationDidDismiss] only once the overlay is actually
+ * removed, matching the fragment flow where dismissal follows the action.
+ */
+internal class CTHtmlBannerCallbacksBridge(
+    private val notification: CTInAppNotification,
+    private val config: CleverTapInstanceConfig,
+    private val inAppListener: InAppListener
+) : CTInAppHtmlBannerOverlay.Callbacks {
+
+    /** Set by the caller immediately after constructing the overlay. */
+    var overlay: CTInAppHtmlBannerOverlay? = null
+
+    private var pendingDismissData: Bundle? = null
+
+    // ----- CTInAppHtmlBannerOverlay.Callbacks (banner lifecycle) -----
+
+    override fun onBannerShown() {
+        inAppListener.inAppNotificationDidShow(notification, null)
+    }
+
+    override fun onBannerSwipeDismissed() {
+        triggerAction(CTInAppAction.createCloseAction(), Constants.INAPP_CTA_SWIPE_DISMISS, null)
+    }
+
+    override fun onBannerRemoved() {
+        inAppListener.inAppNotificationDidDismiss(notification, pendingDismissData)
+        pendingDismissData = null
+    }
+
+    // ----- InAppWebInteraction (WebView url loads + JS bridge) -----
+
+    override fun openActionUrl(url: String) {
+        triggerAction(CTInAppAction.createOpenUrlAction(url), null, null)
+    }
+
+    override fun triggerAction(
+        action: CTInAppAction, callToAction: String?, additionalData: Bundle?
+    ) {
+        val parsed = InAppActionParser.parse(action, callToAction, additionalData, config)
+        pendingDismissData = inAppListener.inAppNotificationActionTriggered(
+            notification,
+            parsed.action,
+            parsed.callToAction ?: "",
+            parsed.additionalData,
+            overlay?.activity
+        )
+        overlay?.dismiss()
+    }
+
+    override fun didDismiss(data: Bundle?) {
+        pendingDismissData = data
+        overlay?.dismiss()
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
@@ -7,23 +7,19 @@ import android.graphics.PixelFormat
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.GestureDetector
-import android.view.GestureDetector.SimpleOnGestureListener
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import android.view.animation.AlphaAnimation
-import android.view.animation.Animation
-import android.view.animation.AnimationSet
-import android.view.animation.TranslateAnimation
 import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.CTWebInterface
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.CleverTapInstanceConfig
+import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.task.MainLooperHandler
 import java.lang.ref.WeakReference
-import kotlin.math.abs
 
 /**
  * Renders *custom-html* "header" and "footer" [CTInAppNotification]s in a [WindowManager] overlay,
@@ -64,9 +60,6 @@ internal class CTInAppHtmlBannerOverlay(
     }
 
     companion object {
-        private const val SWIPE_MIN_DISTANCE = 120
-        private const val SWIPE_THRESHOLD_VELOCITY = 200
-
         fun canDisplay(type: CTInAppType?): Boolean {
             return type == CTInAppType.CTInAppTypeFooterHTML || type == CTInAppType.CTInAppTypeHeaderHTML
         }
@@ -75,7 +68,14 @@ internal class CTInAppHtmlBannerOverlay(
     private val activityWeakRef = WeakReference(activity)
     private val isJsEnabled = notification.isJsEnabled
     private val mainHandler = MainLooperHandler()
-    private val gd = GestureDetector(activity, GestureListener())
+    private val gestureListener = PartialHtmlInAppGestureListener(
+        scaledPixels = ::getScaledPixels,
+        // Mark dismissing so the follow-up dismiss() from the close action removes immediately
+        // instead of re-animating.
+        onSwipeStart = { animatingDismiss = true },
+        onSwipeDismiss = { host.onBannerSwipeDismissed() }
+    )
+    private val gd = GestureDetector(activity, gestureListener)
 
     private var wm: WindowManager? = null
     private var overlayRoot: View? = null
@@ -121,6 +121,7 @@ internal class CTInAppHtmlBannerOverlay(
                 notification.aspectRatio
             )
             this.webView = webView
+            gestureListener.webView = webView
             webView.setWebViewClient(InAppWebViewClient(host))
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no
             // close button, matching CTInAppBasePartialHtmlFragment.
@@ -160,6 +161,11 @@ internal class CTInAppHtmlBannerOverlay(
             wmlp.token = activity.window.decorView.windowToken // tie to this activity
             wm = activity.windowManager
             wm?.addView(root, wmlp)
+
+            // Announce the banner to accessibility services (parity with CTInAppBaseFragment).
+            ViewCompat.setAccessibilityPaneTitle(
+                root, activity.getString(R.string.ct_inapp_message_shown)
+            )
 
             // Tear down the overlay if the host Activity is destroyed, so the window is not leaked
             // and the in-app display queue is not left wedged (a Fragment gets this for free).
@@ -278,55 +284,6 @@ internal class CTInAppHtmlBannerOverlay(
             Gravity.BOTTOM
         } else {
             Gravity.TOP
-        }
-    }
-
-    private inner class GestureListener : SimpleOnGestureListener() {
-        override fun onFling(
-            e1: MotionEvent?,
-            e2: MotionEvent,
-            velocityX: Float,
-            velocityY: Float
-        ): Boolean {
-            if (e1 != null) {
-                if (e1.x - e2.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Right to left
-                    return remove(false)
-                } else if (e2.x - e1.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Left to right
-                    return remove(true)
-                }
-            }
-            return false
-        }
-
-        private fun remove(ltr: Boolean): Boolean {
-            val webView = webView ?: return false
-            // Mark dismissing so the follow-up dismiss() from the close action removes immediately
-            // instead of re-animating.
-            animatingDismiss = true
-            val animSet = AnimationSet(true)
-            val anim = if (ltr) {
-                TranslateAnimation(0f, getScaledPixels(50).toFloat(), 0f, 0f)
-            } else {
-                TranslateAnimation(0f, -getScaledPixels(50).toFloat(), 0f, 0f)
-            }
-            animSet.addAnimation(anim)
-            animSet.addAnimation(AlphaAnimation(1f, 0f))
-            animSet.duration = 300
-            animSet.fillAfter = true
-            animSet.isFillEnabled = true
-            animSet.setAnimationListener(object : Animation.AnimationListener {
-                override fun onAnimationEnd(animation: Animation?) {
-                    host.onBannerSwipeDismissed()
-                }
-
-                override fun onAnimationRepeat(animation: Animation?) {}
-
-                override fun onAnimationStart(animation: Animation?) {}
-            })
-            webView.startAnimation(animSet)
-            return true
         }
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
@@ -2,7 +2,9 @@ package com.clevertap.android.sdk.inapp
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.app.Application
 import android.graphics.PixelFormat
+import android.os.Bundle
 import android.util.TypedValue
 import android.view.GestureDetector
 import android.view.GestureDetector.SimpleOnGestureListener
@@ -79,6 +81,8 @@ internal class CTInAppHtmlBannerOverlay(
     private var overlayRoot: View? = null
     private var webView: CTInAppWebView? = null
     private var animatingDismiss = false
+    private var removed = false
+    private var application: Application? = null
 
     /** The host activity, or null if collected. Used as the action activity-context. */
     val activity: Activity? get() = activityWeakRef.get()
@@ -157,21 +161,20 @@ internal class CTInAppHtmlBannerOverlay(
             wm = activity.windowManager
             wm?.addView(root, wmlp)
 
+            // Tear down the overlay if the host Activity is destroyed, so the window is not leaked
+            // and the in-app display queue is not left wedged (a Fragment gets this for free).
+            application = activity.application
+            application?.registerActivityLifecycleCallbacks(lifecycleCallbacks)
+
             webView.updateDimension()
             webView.loadInAppHtml(html)
             host.onBannerShown()
         } catch (t: Throwable) {
             config.logger.debug(config.accountId, "CTInAppHtmlBannerOverlay: failed to show", t)
-            // addView may have already attached the overlay before a later statement threw; detach
-            // it best-effort so the window is not leaked.
-            try {
-                wm?.removeViewImmediate(overlayRoot)
-            } catch (e: Exception) {
-                // no-op; the view may not have been added yet
-            }
-            overlayRoot = null
-            cleanupWebView()
-            host.onBannerRemoved()
+            // addView may have already attached the overlay before a later statement threw;
+            // finishDismiss detaches it best-effort and reports the dismiss (guarded, so a later
+            // teardown will not double-report).
+            finishDismiss()
         }
     }
 
@@ -212,6 +215,15 @@ internal class CTInAppHtmlBannerOverlay(
     }
 
     private fun finishDismiss() {
+        // One-shot: guards against a double removal (e.g. a re-entrant dismiss racing the fade's
+        // withEndAction, a build() failure, or an activity-destroy teardown after a user dismiss)
+        // reporting the dismiss twice.
+        if (removed) {
+            return
+        }
+        removed = true
+        application?.unregisterActivityLifecycleCallbacks(lifecycleCallbacks)
+        application = null
         try {
             wm?.removeViewImmediate(overlayRoot)
         } catch (e: Exception) {
@@ -221,6 +233,23 @@ internal class CTInAppHtmlBannerOverlay(
             cleanupWebView()
             host.onBannerRemoved()
         }
+    }
+
+    private val lifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
+        override fun onActivityDestroyed(destroyed: Activity) {
+            if (destroyed === activityWeakRef.get()) {
+                // Host Activity is gone: remove the window (best-effort) and report the dismiss so
+                // the controller clears currentlyDisplayingInApp and can show the next in-app.
+                finishDismiss()
+            }
+        }
+
+        override fun onActivityCreated(a: Activity, b: Bundle?) {}
+        override fun onActivityStarted(a: Activity) {}
+        override fun onActivityResumed(a: Activity) {}
+        override fun onActivityPaused(a: Activity) {}
+        override fun onActivityStopped(a: Activity) {}
+        override fun onActivitySaveInstanceState(a: Activity, b: Bundle) {}
     }
 
     private fun cleanupWebView() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
@@ -69,6 +69,7 @@ internal class CTInAppHtmlBannerOverlay(
     private val isJsEnabled = notification.isJsEnabled
     private val mainHandler = MainLooperHandler()
     private val gestureListener = PartialHtmlInAppGestureListener(
+        webViewProvider = { webView },
         scaledPixels = ::getScaledPixels,
         // Mark dismissing so the follow-up dismiss() from the close action removes immediately
         // instead of re-animating.
@@ -121,7 +122,6 @@ internal class CTInAppHtmlBannerOverlay(
                 notification.aspectRatio
             )
             this.webView = webView
-            gestureListener.webView = webView
             webView.setWebViewClient(InAppWebViewClient(host))
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no
             // close button, matching CTInAppBasePartialHtmlFragment.

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
@@ -1,0 +1,295 @@
+package com.clevertap.android.sdk.inapp
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.graphics.PixelFormat
+import android.util.TypedValue
+import android.view.GestureDetector
+import android.view.GestureDetector.SimpleOnGestureListener
+import android.view.Gravity
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import android.view.animation.AlphaAnimation
+import android.view.animation.Animation
+import android.view.animation.AnimationSet
+import android.view.animation.TranslateAnimation
+import android.widget.FrameLayout
+import com.clevertap.android.sdk.CTWebInterface
+import com.clevertap.android.sdk.CleverTapAPI
+import com.clevertap.android.sdk.CleverTapInstanceConfig
+import com.clevertap.android.sdk.task.MainLooperHandler
+import java.lang.ref.WeakReference
+import kotlin.math.abs
+
+/**
+ * Renders *custom-html* "header" and "footer" [CTInAppNotification]s in a [WindowManager] overlay,
+ * used when the current Activity is not a [androidx.fragment.app.FragmentActivity] and the
+ * fragment-based banner can therefore not be shown.
+ *
+ * **Why a WindowManager overlay and not the content view (as PIP does):** the hosts that need this
+ * path are non-FragmentActivity surfaces such as game engines (Unreal/Unity), whose content view
+ * is a `SurfaceView` driving a GL surface. A sibling view added to `android.R.id.content`
+ * composites unreliably against a SurfaceView (z-ordering punches through), whereas a separate
+ * overlay window sits cleanly above it.
+ *
+ * This class is UI-only. All analytics/action semantics are delegated to [host] (a
+ * [CTHtmlBannerCallbacksBridge]), mirroring how the PIP renderer delegates to
+ * [PIPInAppCallbacksBridge].
+ */
+internal class CTInAppHtmlBannerOverlay(
+    private val notification: CTInAppNotification,
+    private val config: CleverTapInstanceConfig,
+    private val host: Callbacks,
+    activity: Activity
+) : View.OnTouchListener, View.OnLongClickListener {
+
+    /**
+     * The contract the overlay's host must satisfy. Extends [InAppWebInteraction] so the same
+     * object drives the [CTInAppWebView]'s [InAppWebViewClient]/[CTWebInterface] and receives the
+     * banner lifecycle callbacks below.
+     */
+    internal interface Callbacks : InAppWebInteraction {
+        /** The overlay has been attached to the window. */
+        fun onBannerShown()
+
+        /** The user swiped the banner away; the host should run the close action. */
+        fun onBannerSwipeDismissed()
+
+        /** The overlay has been detached from the window; the host should report the dismiss. */
+        fun onBannerRemoved()
+    }
+
+    companion object {
+        private const val SWIPE_MIN_DISTANCE = 120
+        private const val SWIPE_THRESHOLD_VELOCITY = 200
+
+        fun canDisplay(type: CTInAppType?): Boolean {
+            return type == CTInAppType.CTInAppTypeFooterHTML || type == CTInAppType.CTInAppTypeHeaderHTML
+        }
+    }
+
+    private val activityWeakRef = WeakReference(activity)
+    private val isJsEnabled = notification.isJsEnabled
+    private val mainHandler = MainLooperHandler()
+    private val gd = GestureDetector(activity, GestureListener())
+
+    private var wm: WindowManager? = null
+    private var overlayRoot: View? = null
+    private var webView: CTInAppWebView? = null
+    private var animatingDismiss = false
+
+    /** The host activity, or null if collected. Used as the action activity-context. */
+    val activity: Activity? get() = activityWeakRef.get()
+
+    fun show() {
+        mainHandler.post(this::build)
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun build() {
+        // This is partially based on CTInAppBasePartialHtmlFragment.displayHTMLView().
+        val activity = activityWeakRef.get()
+        val html = notification.html
+        if (activity == null || html == null) {
+            config.logger.debug(
+                config.accountId,
+                "CTInAppHtmlBannerOverlay: cannot show, activity or html is null"
+            )
+            // Unblock the controller's display queue.
+            host.onBannerRemoved()
+            return
+        }
+
+        try {
+            val root = FrameLayout(activity)
+            root.isClickable = true
+            root.isFocusable = true
+            overlayRoot = root
+
+            val webView = CTInAppWebView(
+                activity,
+                notification.width,
+                notification.height,
+                notification.widthPercentage,
+                notification.heightPercentage,
+                notification.aspectRatio
+            )
+            this.webView = webView
+            webView.setWebViewClient(InAppWebViewClient(host))
+            // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no
+            // close button, matching CTInAppBasePartialHtmlFragment.
+            if (isSwipeToDismissEnabled()) {
+                webView.setOnTouchListener(this)
+            }
+            webView.setOnLongClickListener(this)
+
+            if (isJsEnabled) {
+                val instance = CleverTapAPI.instanceWithConfig(activity, config)
+                webView.setJavaScriptInterface(CTWebInterface(instance, host))
+            }
+
+            config.logger.verbose(
+                config.accountId,
+                "CTInAppHtmlBannerOverlay CTInAppNotification HTML:\n$html"
+            )
+
+            val lp = FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                gravity()
+            )
+            root.addView(webView, lp)
+
+            // A separate overlay window above the activity (see class docs for the rationale).
+            val wmlp = WindowManager.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT, // fit the webview
+                WindowManager.LayoutParams.TYPE_APPLICATION_PANEL, // sit above with own input stream
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+                        or WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL
+                        or WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN,
+                PixelFormat.TRANSLUCENT
+            )
+            wmlp.gravity = gravity() // TOP or BOTTOM
+            wmlp.token = activity.window.decorView.windowToken // tie to this activity
+            wm = activity.windowManager
+            wm?.addView(root, wmlp)
+
+            webView.updateDimension()
+            webView.loadInAppHtml(html)
+            host.onBannerShown()
+        } catch (t: Throwable) {
+            config.logger.debug(config.accountId, "CTInAppHtmlBannerOverlay: failed to show", t)
+            cleanupWebView()
+            host.onBannerRemoved()
+        }
+    }
+
+    override fun onLongClick(v: View): Boolean {
+        return true
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouch(v: View, event: MotionEvent): Boolean {
+        return gd.onTouchEvent(event) || (event.action == MotionEvent.ACTION_MOVE)
+    }
+
+    /**
+     * Removes the overlay from the window. Safe to call from any thread (the JS bridge calls this
+     * off the main thread). Reports [Callbacks.onBannerRemoved] once the view is detached.
+     */
+    fun dismiss() {
+        mainHandler.post {
+            val root = overlayRoot
+            if (root == null || wm == null) {
+                config.logger.debug(
+                    config.accountId,
+                    "CTInAppHtmlBannerOverlay.dismiss() - nothing to remove"
+                )
+                return@post
+            }
+            if (!animatingDismiss) {
+                animatingDismiss = true
+                root.animate()
+                    .alpha(0f)
+                    .setDuration(250)
+                    .withEndAction(this::finishDismiss)
+                    .start()
+            } else {
+                finishDismiss()
+            }
+        }
+    }
+
+    private fun finishDismiss() {
+        try {
+            wm?.removeViewImmediate(overlayRoot)
+        } catch (e: Exception) {
+            config.logger.debug(config.accountId, "CTInAppHtmlBannerOverlay: removing failed", e)
+        } finally {
+            overlayRoot = null
+            cleanupWebView()
+            host.onBannerRemoved()
+        }
+    }
+
+    private fun cleanupWebView() {
+        try {
+            webView?.cleanup(isJsEnabled)
+        } catch (e: Exception) {
+            config.logger.debug(config.accountId, "CTInAppHtmlBannerOverlay: cleanup crash", e)
+            // no-op; we are anyway destroying everything. This is just for safety.
+        } finally {
+            webView = null
+        }
+    }
+
+    private fun isSwipeToDismissEnabled(): Boolean =
+        !notification.isShowClose && notification.swipeToDismiss
+
+    private fun getScaledPixels(raw: Int): Int {
+        val activity = activityWeakRef.get() ?: return raw
+        return TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP, raw.toFloat(), activity.resources.displayMetrics
+        ).toInt()
+    }
+
+    private fun gravity(): Int {
+        return if (notification.inAppType == CTInAppType.CTInAppTypeFooterHTML) {
+            Gravity.BOTTOM
+        } else {
+            Gravity.TOP
+        }
+    }
+
+    private inner class GestureListener : SimpleOnGestureListener() {
+        override fun onFling(
+            e1: MotionEvent?,
+            e2: MotionEvent,
+            velocityX: Float,
+            velocityY: Float
+        ): Boolean {
+            if (e1 != null) {
+                if (e1.x - e2.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
+                    // Right to left
+                    return remove(false)
+                } else if (e2.x - e1.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
+                    // Left to right
+                    return remove(true)
+                }
+            }
+            return false
+        }
+
+        private fun remove(ltr: Boolean): Boolean {
+            val webView = webView ?: return false
+            // Mark dismissing so the follow-up dismiss() from the close action removes immediately
+            // instead of re-animating.
+            animatingDismiss = true
+            val animSet = AnimationSet(true)
+            val anim = if (ltr) {
+                TranslateAnimation(0f, getScaledPixels(50).toFloat(), 0f, 0f)
+            } else {
+                TranslateAnimation(0f, -getScaledPixels(50).toFloat(), 0f, 0f)
+            }
+            animSet.addAnimation(anim)
+            animSet.addAnimation(AlphaAnimation(1f, 0f))
+            animSet.duration = 300
+            animSet.fillAfter = true
+            animSet.isFillEnabled = true
+            animSet.setAnimationListener(object : Animation.AnimationListener {
+                override fun onAnimationEnd(animation: Animation?) {
+                    host.onBannerSwipeDismissed()
+                }
+
+                override fun onAnimationRepeat(animation: Animation?) {}
+
+                override fun onAnimationStart(animation: Animation?) {}
+            })
+            webView.startAnimation(animSet)
+            return true
+        }
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
@@ -162,6 +162,14 @@ internal class CTInAppHtmlBannerOverlay(
             host.onBannerShown()
         } catch (t: Throwable) {
             config.logger.debug(config.accountId, "CTInAppHtmlBannerOverlay: failed to show", t)
+            // addView may have already attached the overlay before a later statement threw; detach
+            // it best-effort so the window is not leaked.
+            try {
+                wm?.removeViewImmediate(overlayRoot)
+            } catch (e: Exception) {
+                // no-op; the view may not have been added yet
+            }
+            overlayRoot = null
             cleanupWebView()
             host.onBannerRemoved()
         }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppWebView.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppWebView.kt
@@ -72,7 +72,9 @@ internal class CTInAppWebView @SuppressLint("ResourceType") constructor(
 
         val style =
             "<style>body{width: ${mWidth}px; height: ${mHeight}px; margin: 0; padding:0;}</style>"
-        val inAppHtml = html.replaceFirst("<head>".toRegex(), "<head>$style")
+        // Literal (non-regex) replacement: avoids compiling a Regex per render and avoids treating
+        // any $/\ in the replacement as regex back-references.
+        val inAppHtml = html.replaceFirst("<head>", "<head>$style")
         Logger.v("Density appears to be $d")
 
         setInitialScale((d * 100).toInt())

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppWebView.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppWebView.kt
@@ -11,6 +11,7 @@ import android.webkit.WebView
 import androidx.annotation.Px
 import androidx.annotation.RequiresApi
 import com.clevertap.android.sdk.CTWebInterface
+import com.clevertap.android.sdk.Logger
 
 @SuppressLint("ViewConstructor")
 internal class CTInAppWebView @SuppressLint("ResourceType") constructor(
@@ -57,6 +58,25 @@ internal class CTInAppWebView @SuppressLint("ResourceType") constructor(
         super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         updateDimension()
         setMeasuredDimension(dim.x, dim.y)
+    }
+
+    /**
+     * Injects a body sizing style based on the current measured [dim] and loads the in-app html.
+     * Shared by the fragment-hosted partial/full html in-apps and the non-fragment
+     * [CTInAppHtmlBannerOverlay]. Callers must ensure [updateDimension] has run first.
+     */
+    fun loadInAppHtml(html: String) {
+        val d = resources.displayMetrics.density
+        val mHeight = (dim.y / d).toInt()
+        val mWidth = (dim.x / d).toInt()
+
+        val style =
+            "<style>body{width: ${mWidth}px; height: ${mHeight}px; margin: 0; padding:0;}</style>"
+        val inAppHtml = html.replaceFirst("<head>".toRegex(), "<head>$style")
+        Logger.v("Density appears to be $d")
+
+        setInitialScale((d * 100).toInt())
+        loadDataWithBaseURL(null, inAppHtml, "text/html", "utf-8", null)
     }
 
     fun updateDimension() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppActionParser.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppActionParser.kt
@@ -1,0 +1,77 @@
+package com.clevertap.android.sdk.inapp
+
+import android.os.Bundle
+import com.clevertap.android.sdk.CleverTapInstanceConfig
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.utils.UriHelper
+import java.net.URLDecoder
+
+/**
+ * Stateless parser for in-app actions triggered from an HTML/WebView surface.
+ *
+ * For [InAppActionType.OPEN_URL] actions the url can carry:
+ *  - tracking parameters, which are surfaced as `additionalData`
+ *  - a `wzrk_c2a` ([Constants.KEY_C2A]) parameter that supplies the call-to-action, and which may
+ *    itself embed a deep link using the [Constants.URL_PARAM_DL_SEPARATOR] (`__dl__`) separator.
+ *
+ * This logic is shared by the fragment-hosted in-apps
+ * ([com.clevertap.android.sdk.inapp.fragment.CTInAppBaseFragment]) and the non-fragment
+ * [CTInAppHtmlBannerOverlay] path so that both resolve actions identically.
+ */
+internal object InAppActionParser {
+
+    data class ParsedAction(
+        val action: CTInAppAction,
+        val callToAction: String?,
+        val additionalData: Bundle?
+    )
+
+    fun parse(
+        action: CTInAppAction,
+        callToAction: String?,
+        additionalData: Bundle?,
+        config: CleverTapInstanceConfig
+    ): ParsedAction {
+        if (action.type != InAppActionType.OPEN_URL) {
+            return ParsedAction(action, callToAction, additionalData)
+        }
+
+        var resolvedAction = action
+        var resolvedCallToAction = callToAction
+
+        // All URL parameters should be tracked as additional data
+        val urlActionData = UriHelper.getAllKeyValuePairs(action.actionUrl, false)
+
+        // callToAction is handled as a parameter
+        var callToActionUrlParam = urlActionData.getString(Constants.KEY_C2A)
+        // no need to keep it in the data bundle
+        urlActionData.remove(Constants.KEY_C2A)
+
+        // add all additional params, overriding the url params if there is a collision
+        if (additionalData != null) {
+            urlActionData.putAll(additionalData)
+        }
+
+        if (callToActionUrlParam != null) {
+            // check if there is a deeplink within the callToAction param
+            val parts = callToActionUrlParam.split(Constants.URL_PARAM_DL_SEPARATOR)
+            if (parts.size == 2) {
+                // Decode it here as it is not decoded by UriHelper
+                try {
+                    // Extract the actual callToAction value
+                    callToActionUrlParam = URLDecoder.decode(parts[0], "UTF-8")
+                } catch (e: Exception) {
+                    config.logger.debug("Error parsing c2a param", e)
+                }
+                // use the url from the callToAction param
+                resolvedAction = CTInAppAction.createOpenUrlAction(parts[1])
+            }
+        }
+        if (resolvedCallToAction == null) {
+            // Use the url param value only if no other value is passed
+            resolvedCallToAction = callToActionUrlParam
+        }
+
+        return ParsedAction(resolvedAction, resolvedCallToAction, urlActionData)
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppActionParser.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppActionParser.kt
@@ -67,10 +67,8 @@ internal object InAppActionParser {
                 resolvedAction = CTInAppAction.createOpenUrlAction(parts[1])
             }
         }
-        if (resolvedCallToAction == null) {
-            // Use the url param value only if no other value is passed
-            resolvedCallToAction = callToActionUrlParam
-        }
+        // Use the url param value only if no other value is passed
+        resolvedCallToAction = resolvedCallToAction ?: callToActionUrlParam
 
         return ParsedAction(resolvedAction, resolvedCallToAction, urlActionData)
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -9,6 +9,7 @@ import android.os.Looper
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
+import androidx.fragment.app.FragmentActivity
 import com.clevertap.android.sdk.AnalyticsManager
 import com.clevertap.android.sdk.BaseCallbackManager
 import com.clevertap.android.sdk.CleverTapInstanceConfig
@@ -141,6 +142,10 @@ internal class InAppController(
     private var inAppState = InAppState.RESUMED
 
     private val inAppExcludedActivityNames = getExcludedActivitiesSet(manifestInfo)
+
+    // Opt-in (default off) for rendering custom-html header/footer in-apps via a WindowManager
+    // overlay when the host Activity is not a FragmentActivity. Enabled by the gaming wrapper SDKs.
+    private val fragmentlessInAppBannersEnabled = manifestInfo.isFragmentlessInAppBannersEnabled
 
     /**
      * Schedule multiple delayed in-apps for display after their respective delays
@@ -1046,11 +1051,25 @@ internal class InAppController(
             }
 
             CTInAppTypeFooterHTML -> {
-                inAppFragment = CTInAppHtmlFooterFragment()
+                if (activity is FragmentActivity) {
+                    inAppFragment = CTInAppHtmlFooterFragment()
+                } else if (activity != null && fragmentlessInAppBannersEnabled) {
+                    // Non-FragmentActivity host (e.g. game engines) with the opt-in enabled:
+                    // fall back to the WindowManager overlay.
+                    showHtmlBannerOverlay(inAppNotification, activity)
+                    return
+                }
             }
 
             CTInAppTypeHeaderHTML -> {
-                inAppFragment = CTInAppHtmlHeaderFragment()
+                if (activity is FragmentActivity) {
+                    inAppFragment = CTInAppHtmlHeaderFragment()
+                } else if (activity != null && fragmentlessInAppBannersEnabled) {
+                    // Non-FragmentActivity host (e.g. game engines) with the opt-in enabled:
+                    // fall back to the WindowManager overlay.
+                    showHtmlBannerOverlay(inAppNotification, activity)
+                    return
+                }
             }
 
             CTInAppTypeFooter -> {
@@ -1113,6 +1132,14 @@ internal class InAppController(
         if (!showFragmentSuccess) {
             currentlyDisplayingInApp = null
         }
+    }
+
+    private fun showHtmlBannerOverlay(inAppNotification: CTInAppNotification, activity: Activity) {
+        logger.debug("Displaying In-App as overlay: ${inAppNotification.jsonDescription}")
+        val bridge = CTHtmlBannerCallbacksBridge(inAppNotification, config, this)
+        val overlay = CTInAppHtmlBannerOverlay(inAppNotification, config, bridge, activity)
+        bridge.overlay = overlay
+        overlay.show()
     }
 
     private fun presentTemplate(inAppNotification: CTInAppNotification) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -1149,6 +1149,8 @@ internal class InAppController(
         val bridge = CTHtmlBannerCallbacksBridge(inAppNotification, config, this)
         val overlay = CTInAppHtmlBannerOverlay(inAppNotification, config, bridge, activity)
         bridge.overlay = overlay
+        // Allow the overlay to be hidden externally (discardInApps/suspend), like the fragment path.
+        registerInAppDisplayListener(bridge)
         overlay.show()
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -1135,6 +1135,16 @@ internal class InAppController(
     }
 
     private fun showHtmlBannerOverlay(inAppNotification: CTInAppNotification, activity: Activity) {
+        // Defensive guard: the overlay renders an HTML WebView, so it only supports the custom-html
+        // header/footer types. Today the when-dispatch only routes those two types here, but this
+        // keeps the invariant explicit and safe if the dispatch is ever refactored.
+        if (!CTInAppHtmlBannerOverlay.canDisplay(inAppNotification.inAppType)) {
+            logger.debug(
+                "Overlay banner not supported for type ${inAppNotification.inAppType}; skipping"
+            )
+            currentlyDisplayingInApp = null
+            return
+        }
         logger.debug("Displaying In-App as overlay: ${inAppNotification.jsonDescription}")
         val bridge = CTHtmlBannerCallbacksBridge(inAppNotification, config, this)
         val overlay = CTInAppHtmlBannerOverlay(inAppNotification, config, bridge, activity)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppWebInteraction.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppWebInteraction.kt
@@ -1,0 +1,26 @@
+package com.clevertap.android.sdk.inapp
+
+import android.os.Bundle
+
+/**
+ * Thin contract for a surface that hosts an in-app [CTInAppWebView] and reacts to its interactions
+ * (url loads, JS-driven actions and dismissals).
+ *
+ * Implemented by:
+ *  - [com.clevertap.android.sdk.inapp.fragment.CTInAppBaseFragment] for fragment-hosted in-apps, and
+ *  - [CTHtmlBannerCallbacksBridge] for the non-fragment [CTInAppHtmlBannerOverlay] path.
+ *
+ * It lets [com.clevertap.android.sdk.CTWebInterface] and [InAppWebViewClient] drive either host
+ * without knowing which one is backing the WebView.
+ */
+internal interface InAppWebInteraction {
+
+    /** Triggered when the WebView attempts to load an action url (see [InAppWebViewClient]). */
+    fun openActionUrl(url: String)
+
+    /** Triggered from the JS bridge ([com.clevertap.android.sdk.CTWebInterface.triggerInAppAction]). */
+    fun triggerAction(action: CTInAppAction, callToAction: String?, additionalData: Bundle?)
+
+    /** Triggered from the JS bridge ([com.clevertap.android.sdk.CTWebInterface.dismissInAppNotification]). */
+    fun didDismiss(data: Bundle?)
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppWebViewClient.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppWebViewClient.kt
@@ -7,15 +7,14 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import com.clevertap.android.sdk.Logger
-import com.clevertap.android.sdk.inapp.fragment.CTInAppBaseFragment
 import java.lang.ref.WeakReference
 
-internal class InAppWebViewClient(fragment: CTInAppBaseFragment) : WebViewClient() {
-    private val fragmentWr = WeakReference(fragment)
+internal class InAppWebViewClient(host: InAppWebInteraction) : WebViewClient() {
+    private val hostWr = WeakReference(host)
 
     @Deprecated("Deprecated in Java")
     override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
-        fragmentWr.get()?.openActionUrl(url) ?: Logger.v("InAppWebViewClient : Android view is gone, not opening url")
+        hostWr.get()?.openActionUrl(url) ?: Logger.v("InAppWebViewClient : Android view is gone, not opening url")
         return true
     }
 
@@ -23,7 +22,7 @@ internal class InAppWebViewClient(fragment: CTInAppBaseFragment) : WebViewClient
     @TargetApi(Build.VERSION_CODES.N)
     override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
         request.url?.toString()?.let { url ->
-            fragmentWr.get()?.openActionUrl(url) ?: Logger.v("InAppWebViewClient : Android view is gone, not opening url")
+            hostWr.get()?.openActionUrl(url) ?: Logger.v("InAppWebViewClient : Android view is gone, not opening url")
         } ?: Logger.v("InAppWebViewClient : Url to open is null; not processing")
         return true
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
@@ -13,17 +13,20 @@ import kotlin.math.abs
  * fragment-hosted [com.clevertap.android.sdk.inapp.fragment.CTInAppBasePartialHtmlFragment] and the
  * non-fragment [CTInAppHtmlBannerOverlay].
  *
- * On a horizontal fling it slides + fades the [webView] out, then invokes [onSwipeDismiss].
+ * On a horizontal fling it slides + fades the current WebView out, then invokes [onSwipeDismiss].
  * [onSwipeStart] runs when the dismiss animation begins — the overlay uses it to coordinate its own
  * removal animation. [scaledPixels] converts dp to px in the host's context.
+ *
+ * The target is read through [webViewProvider] rather than held as state, so it always reflects the
+ * host's live field (and becomes null once the host cleans up) — no stale reference to a destroyed
+ * WebView.
  */
 internal class PartialHtmlInAppGestureListener(
+    private val webViewProvider: () -> CTInAppWebView?,
     private val scaledPixels: (Int) -> Int,
     private val onSwipeStart: () -> Unit = {},
     private val onSwipeDismiss: () -> Unit
 ) : SimpleOnGestureListener() {
-
-    var webView: CTInAppWebView? = null
 
     override fun onFling(
         e1: MotionEvent?,
@@ -44,7 +47,7 @@ internal class PartialHtmlInAppGestureListener(
     }
 
     private fun remove(ltr: Boolean): Boolean {
-        val webView = webView ?: return false
+        val webView = webViewProvider() ?: return false
         onSwipeStart()
         val animSet = AnimationSet(true)
         val anim = if (ltr) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
@@ -1,0 +1,77 @@
+package com.clevertap.android.sdk.inapp
+
+import android.view.GestureDetector.SimpleOnGestureListener
+import android.view.MotionEvent
+import android.view.animation.AlphaAnimation
+import android.view.animation.Animation
+import android.view.animation.AnimationSet
+import android.view.animation.TranslateAnimation
+import kotlin.math.abs
+
+/**
+ * Shared swipe-to-dismiss gesture for partial (header/footer) HTML in-apps, used by both the
+ * fragment-hosted [com.clevertap.android.sdk.inapp.fragment.CTInAppBasePartialHtmlFragment] and the
+ * non-fragment [CTInAppHtmlBannerOverlay].
+ *
+ * On a horizontal fling it slides + fades the [webView] out, then invokes [onSwipeDismiss].
+ * [onSwipeStart] runs when the dismiss animation begins — the overlay uses it to coordinate its own
+ * removal animation. [scaledPixels] converts dp to px in the host's context.
+ */
+internal class PartialHtmlInAppGestureListener(
+    private val scaledPixels: (Int) -> Int,
+    private val onSwipeStart: () -> Unit = {},
+    private val onSwipeDismiss: () -> Unit
+) : SimpleOnGestureListener() {
+
+    var webView: CTInAppWebView? = null
+
+    override fun onFling(
+        e1: MotionEvent?,
+        e2: MotionEvent,
+        velocityX: Float,
+        velocityY: Float
+    ): Boolean {
+        if (e1 != null) {
+            if (e1.x - e2.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
+                // Right to left
+                return remove(false)
+            } else if (e2.x - e1.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
+                // Left to right
+                return remove(true)
+            }
+        }
+        return false
+    }
+
+    private fun remove(ltr: Boolean): Boolean {
+        val webView = webView ?: return false
+        onSwipeStart()
+        val animSet = AnimationSet(true)
+        val anim = if (ltr) {
+            TranslateAnimation(0f, scaledPixels(50).toFloat(), 0f, 0f)
+        } else {
+            TranslateAnimation(0f, -scaledPixels(50).toFloat(), 0f, 0f)
+        }
+        animSet.addAnimation(anim)
+        animSet.addAnimation(AlphaAnimation(1f, 0f))
+        animSet.duration = 300
+        animSet.fillAfter = true
+        animSet.isFillEnabled = true
+        animSet.setAnimationListener(object : Animation.AnimationListener {
+            override fun onAnimationEnd(animation: Animation?) {
+                onSwipeDismiss()
+            }
+
+            override fun onAnimationRepeat(animation: Animation?) {}
+
+            override fun onAnimationStart(animation: Animation?) {}
+        })
+        webView.startAnimation(animSet)
+        return true
+    }
+
+    companion object {
+        const val SWIPE_MIN_DISTANCE = 120
+        const val SWIPE_THRESHOLD_VELOCITY = 200
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFragment.kt
@@ -18,17 +18,17 @@ import com.clevertap.android.sdk.customviews.CloseImageView
 import com.clevertap.android.sdk.inapp.CTInAppAction
 import com.clevertap.android.sdk.inapp.CTInAppNotification
 import com.clevertap.android.sdk.inapp.CTInAppNotificationButton
+import com.clevertap.android.sdk.inapp.InAppActionParser
 import com.clevertap.android.sdk.inapp.InAppActionType
 import com.clevertap.android.sdk.inapp.InAppListener
+import com.clevertap.android.sdk.inapp.InAppWebInteraction
 import com.clevertap.android.sdk.inapp.images.FileResourceProvider
 import com.clevertap.android.sdk.inapp.media.InAppMediaHandler
 import com.clevertap.android.sdk.inapp.media.NoOpMediaHandler
-import com.clevertap.android.sdk.utils.UriHelper
 
 import java.lang.ref.WeakReference
-import java.net.URLDecoder
 
-internal abstract class CTInAppBaseFragment : Fragment() {
+internal abstract class CTInAppBaseFragment : Fragment(), InAppWebInteraction {
 
     companion object {
         private const val KEY_ACTIVE_MEDIA_URL = "ct_active_media_url"
@@ -130,52 +130,15 @@ internal abstract class CTInAppBaseFragment : Fragment() {
         setArguments(bundle)
     }
 
-    fun triggerAction(
+    override fun triggerAction(
         action: CTInAppAction, callToAction: String?, additionalData: Bundle?
     ) {
-        var additionalData = additionalData
-        var action = action
-        var callToAction = callToAction
-        if (action.type == InAppActionType.OPEN_URL) {
-            //All URL parameters should be tracked as additional data
-            val urlActionData = UriHelper.getAllKeyValuePairs(action.actionUrl, false)
-
-            // callToAction is handled as a parameter
-            var callToActionUrlParam = urlActionData.getString(Constants.KEY_C2A)
-            // no need to keep it in the data bundle
-            urlActionData.remove(Constants.KEY_C2A)
-
-            // add all additional params, overriding the url params if there is a collision
-            if (additionalData != null) {
-                urlActionData.putAll(additionalData)
-            }
-            // Use the merged data for the action
-            additionalData = urlActionData
-            if (callToActionUrlParam != null) {
-                // check if there is a deeplink within the callToAction param
-                val parts = callToActionUrlParam.split(Constants.URL_PARAM_DL_SEPARATOR)
-                if (parts.size == 2) {
-                    // Decode it here as it is not decoded by UriHelper
-                    try {
-                        // Extract the actual callToAction value
-                        callToActionUrlParam = URLDecoder.decode(parts[0], "UTF-8")
-                    } catch (e: Exception) {
-                        config.logger.debug("Error parsing c2a param", e)
-                    }
-                    // use the url from the callToAction param
-                    action = CTInAppAction.CREATOR.createOpenUrlAction(parts[1])
-                }
-            }
-            if (callToAction == null) {
-                // Use the url param value only if no other value is passed
-                callToAction = callToActionUrlParam
-            }
-        }
-        val actionData = notifyActionTriggered(action, callToAction ?: "", additionalData)
+        val parsed = InAppActionParser.parse(action, callToAction, additionalData, config)
+        val actionData = notifyActionTriggered(parsed.action, parsed.callToAction ?: "", parsed.additionalData)
         didDismiss(actionData)
     }
 
-    fun openActionUrl(url: String) {
+    override fun openActionUrl(url: String) {
         triggerAction(CTInAppAction.CREATOR.createOpenUrlAction(url), null, null)
     }
 
@@ -209,7 +172,7 @@ internal abstract class CTInAppBaseFragment : Fragment() {
     protected fun isSwipeToDismissEnabled(): Boolean =
         !inAppNotification.isShowClose && inAppNotification.swipeToDismiss
 
-    fun didDismiss(data: Bundle?) {
+    override fun didDismiss(data: Bundle?) {
         cleanup()
         getListener()?.inAppNotificationDidDismiss(inAppNotification, data)
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBaseFullHtmlFragment.kt
@@ -13,7 +13,6 @@ import android.widget.RelativeLayout
 import com.clevertap.android.sdk.CTWebInterface
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.Constants
-import com.clevertap.android.sdk.Logger
 import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.customviews.CloseImageView
 import com.clevertap.android.sdk.inapp.CTInAppWebView
@@ -142,22 +141,8 @@ internal abstract class CTInAppBaseFullHtmlFragment : CTInAppBaseFullFragment() 
 
         val customUrl = inAppNotification.customInAppUrl
         if (customUrl.isNullOrEmpty()) {
-            var mHeight = webView.dim.y
-            var mWidth = webView.dim.x
-
-            val d = resources.displayMetrics.density
-            mHeight = (mHeight / d).toInt()
-            mWidth = (mWidth / d).toInt()
-
-            var html = inAppNotification.html ?: return
-
-            val style =
-                "<style>body{width: ${mWidth}px; height: ${mHeight}px; margin: 0; padding:0;}</style>"
-            html = html.replaceFirst("<head>".toRegex(), "<head>$style")
-            Logger.v("Density appears to be $d")
-
-            webView.setInitialScale((d * 100).toInt())
-            webView.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+            val html = inAppNotification.html ?: return
+            webView.loadInAppHtml(html)
         } else {
             webView.setWebViewClient(WebViewClient())
             webView.loadUrl(customUrl)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -18,7 +18,6 @@ import android.view.animation.AnimationSet
 import android.view.animation.TranslateAnimation
 import com.clevertap.android.sdk.CTWebInterface
 import com.clevertap.android.sdk.CleverTapAPI
-import com.clevertap.android.sdk.Logger
 import com.clevertap.android.sdk.inapp.CTInAppWebView
 import com.clevertap.android.sdk.inapp.InAppWebViewClient
 import kotlin.math.abs
@@ -168,23 +167,8 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
     private fun reDrawInApp() {
         val webView = this.webView ?: return
         webView.updateDimension()
-
-        var mHeight = webView.dim.y
-        var mWidth = webView.dim.x
-
-        val d = resources.displayMetrics.density
-        mHeight = (mHeight / d).toInt()
-        mWidth = (mWidth / d).toInt()
-
-        var html = inAppNotification.html ?: return
-
-        val style =
-            "<style>body{width: ${mWidth}px; height: ${mHeight}px; margin: 0; padding:0;}</style>"
-        html = html.replaceFirst("<head>".toRegex(), "<head>$style")
-        Logger.v("Density appears to be $d")
-
-        webView.setInitialScale((d * 100).toInt())
-        webView.loadDataWithBaseURL(null, html, "text/html", "utf-8", null)
+        val html = inAppNotification.html ?: return
+        webView.loadInAppHtml(html)
     }
 
     companion object {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -5,75 +5,24 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.GestureDetector
-import android.view.GestureDetector.SimpleOnGestureListener
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnLongClickListener
 import android.view.View.OnTouchListener
 import android.view.ViewGroup
-import android.view.animation.AlphaAnimation
-import android.view.animation.Animation
-import android.view.animation.AnimationSet
-import android.view.animation.TranslateAnimation
 import com.clevertap.android.sdk.CTWebInterface
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.inapp.CTInAppWebView
 import com.clevertap.android.sdk.inapp.InAppWebViewClient
-import kotlin.math.abs
+import com.clevertap.android.sdk.inapp.PartialHtmlInAppGestureListener
 
 internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragment(),
     OnTouchListener,
     OnLongClickListener {
 
-    private inner class GestureListener : SimpleOnGestureListener() {
-        override fun onFling(
-            e1: MotionEvent?,
-            e2: MotionEvent,
-            velocityX: Float,
-            velocityY: Float
-        ): Boolean {
-            if (e1 != null) {
-                if (e1.x - e2.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Right to left
-                    return remove(false)
-                } else if (e2.x - e1.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Left to right
-                    return remove(true)
-                }
-            }
-            return false
-        }
-
-        fun remove(ltr: Boolean): Boolean {
-            val animSet = AnimationSet(true)
-            val anim = if (ltr) {
-                TranslateAnimation(0f, getScaledPixels(50).toFloat(), 0f, 0f)
-            } else {
-                TranslateAnimation(0f, -getScaledPixels(50).toFloat(), 0f, 0f)
-            }
-            animSet.addAnimation(anim)
-            animSet.addAnimation(AlphaAnimation(1f, 0f))
-            animSet.setDuration(300)
-            animSet.setFillAfter(true)
-            animSet.isFillEnabled = true
-            animSet.setAnimationListener(object : Animation.AnimationListener {
-                override fun onAnimationEnd(animation: Animation?) {
-                    triggerSwipeDismissAction()
-                }
-
-                override fun onAnimationRepeat(animation: Animation?) {
-                }
-
-                override fun onAnimationStart(animation: Animation?) {
-                }
-            })
-            webView?.startAnimation(animSet)
-            return true
-        }
-    }
-
     private lateinit var gd: GestureDetector
+    private lateinit var gestureListener: PartialHtmlInAppGestureListener
 
     private var webView: CTInAppWebView? = null
 
@@ -84,7 +33,11 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        gd = GestureDetector(context, GestureListener())
+        gestureListener = PartialHtmlInAppGestureListener(
+            scaledPixels = ::getScaledPixels,
+            onSwipeDismiss = ::triggerSwipeDismissAction
+        )
+        gd = GestureDetector(context, gestureListener)
     }
 
     override fun onCreateView(
@@ -141,6 +94,7 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
                 inAppNotification.aspectRatio
             )
             this.webView = webView
+            gestureListener.webView = webView
             val webViewClient = InAppWebViewClient(this)
             webView.setWebViewClient(webViewClient)
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no close
@@ -169,10 +123,5 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
         webView.updateDimension()
         val html = inAppNotification.html ?: return
         webView.loadInAppHtml(html)
-    }
-
-    companion object {
-        private const val SWIPE_MIN_DISTANCE = 120
-        private const val SWIPE_THRESHOLD_VELOCITY = 200
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -22,7 +22,6 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
     OnLongClickListener {
 
     private lateinit var gd: GestureDetector
-    private lateinit var gestureListener: PartialHtmlInAppGestureListener
 
     private var webView: CTInAppWebView? = null
 
@@ -33,7 +32,7 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        gestureListener = PartialHtmlInAppGestureListener(
+        val gestureListener = PartialHtmlInAppGestureListener(
             webViewProvider = { webView },
             scaledPixels = ::getScaledPixels,
             onSwipeDismiss = ::triggerSwipeDismissAction

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -34,6 +34,7 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
     override fun onAttach(context: Context) {
         super.onAttach(context)
         gestureListener = PartialHtmlInAppGestureListener(
+            webViewProvider = { webView },
             scaledPixels = ::getScaledPixels,
             onSwipeDismiss = ::triggerSwipeDismissAction
         )
@@ -94,7 +95,6 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
                 inAppNotification.aspectRatio
             )
             this.webView = webView
-            gestureListener.webView = webView
             val webViewClient = InAppWebViewClient(this)
             webView.setWebViewClient(webViewClient)
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no close

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/CTWebInterfaceTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/CTWebInterfaceTest.kt
@@ -1,6 +1,6 @@
 package com.clevertap.android.sdk
 
-import com.clevertap.android.sdk.inapp.fragment.CTInAppBaseFragment
+import com.clevertap.android.sdk.inapp.InAppWebInteraction
 import com.clevertap.android.sdk.inapp.InAppActionType.CLOSE
 import com.clevertap.android.sdk.inapp.InAppActionType.CUSTOM_CODE
 import com.clevertap.android.shared.test.BaseTestCase
@@ -403,9 +403,9 @@ class CTWebInterfaceTest : BaseTestCase() {
     }
 
     @Test
-    fun `triggerAction should call InAppBaseFragment when provided correct parameters`() {
-        val fragmentMock = mockk<CTInAppBaseFragment>(relaxed = true)
-        val webInterface = CTWebInterface(mockk<CleverTapAPI>(relaxed = true), fragmentMock)
+    fun `triggerAction should call host when provided correct parameters`() {
+        val hostMock = mockk<InAppWebInteraction>(relaxed = true)
+        val webInterface = CTWebInterface(mockk<CleverTapAPI>(relaxed = true), hostMock)
 
         val closeActionJson = """{
             "type":"$CLOSE",
@@ -417,8 +417,8 @@ class CTWebInterfaceTest : BaseTestCase() {
         }"""
 
         webInterface.triggerInAppAction(closeActionJson, "close", null)
-        verify { fragmentMock.triggerAction(match { it.type == CLOSE }, "close", any()) }
-        clearMocks(fragmentMock)
+        verify { hostMock.triggerAction(match { it.type == CLOSE }, "close", any()) }
+        clearMocks(hostMock)
 
         val customTemplateAction = """{
             "type": "$CUSTOM_CODE",
@@ -432,29 +432,29 @@ class CTWebInterfaceTest : BaseTestCase() {
             "templateDescription": "Description"
         }"""
         webInterface.triggerInAppAction(customTemplateAction, "function-a", "buttonId")
-        verify { fragmentMock.triggerAction(match { it.type == CUSTOM_CODE }, "function-a", any()) }
+        verify { hostMock.triggerAction(match { it.type == CUSTOM_CODE }, "function-a", any()) }
     }
 
     @Test
-    fun `triggerAction should not call InAppBaseFragment when provided invalid params`() {
-        val fragmentMock = mockk<CTInAppBaseFragment>(relaxed = true)
-        val webInterface = CTWebInterface(mockk<CleverTapAPI>(relaxed = true), fragmentMock)
+    fun `triggerAction should not call host when provided invalid params`() {
+        val hostMock = mockk<InAppWebInteraction>(relaxed = true)
+        val webInterface = CTWebInterface(mockk<CleverTapAPI>(relaxed = true), hostMock)
 
         webInterface.triggerInAppAction("close", "action", null)
-        verify { fragmentMock wasNot called }
+        verify { hostMock wasNot called }
 
         webInterface.triggerInAppAction(null, null, null)
-        verify { fragmentMock wasNot called }
+        verify { hostMock wasNot called }
     }
 
     @Test
-    fun `triggerAction should do nothing when CleverTapAPI or InAppBaseFragment is null`() {
+    fun `triggerAction should do nothing when CleverTapAPI or host is null`() {
         CTWebInterface(null, null).triggerInAppAction(null, null, null)
         CTWebInterface(mockk(), null).triggerInAppAction(null, null, null)
 
-        val fragmentMock = mockk<CTInAppBaseFragment>(relaxed = true)
-        CTWebInterface(null, fragmentMock).triggerInAppAction(null, null, null)
-        verify { fragmentMock wasNot called }
+        val hostMock = mockk<InAppWebInteraction>(relaxed = true)
+        CTWebInterface(null, hostMock).triggerInAppAction(null, null, null)
+        verify { hostMock wasNot called }
     }
 
 }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridgeTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridgeTest.kt
@@ -1,0 +1,94 @@
+package com.clevertap.android.sdk.inapp
+
+import android.net.Uri
+import android.os.Bundle
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.utils.configMock
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CTHtmlBannerCallbacksBridgeTest {
+
+    private val listener = mockk<InAppListener>(relaxed = true)
+    private val overlay = mockk<CTInAppHtmlBannerOverlay>(relaxed = true)
+    private val notification = mockk<CTInAppNotification>(relaxed = true)
+
+    private lateinit var bridge: CTHtmlBannerCallbacksBridge
+
+    @Before
+    fun setUp() {
+        bridge = CTHtmlBannerCallbacksBridge(notification, configMock(), listener)
+        bridge.overlay = overlay
+    }
+
+    @Test
+    fun `onBannerShown reports did-show`() {
+        bridge.onBannerShown()
+        verify(exactly = 1) { listener.inAppNotificationDidShow(notification, null) }
+    }
+
+    @Test
+    fun `openActionUrl triggers open-url action then dismisses the overlay`() {
+        val url = Uri.parse("https://clevertap.com").buildUpon()
+            .appendQueryParameter("param1", "value")
+            .build().toString()
+
+        bridge.openActionUrl(url)
+
+        verifyOrder {
+            listener.inAppNotificationActionTriggered(
+                notification,
+                match { it.type == InAppActionType.OPEN_URL && it.actionUrl == url },
+                any(),
+                match { it.getString("param1") == "value" },
+                any()
+            )
+            overlay.dismiss()
+        }
+    }
+
+    @Test
+    fun `onBannerSwipeDismissed triggers a close action with swipe c2a then dismisses`() {
+        bridge.onBannerSwipeDismissed()
+
+        verifyOrder {
+            listener.inAppNotificationActionTriggered(
+                notification,
+                match { it.type == InAppActionType.CLOSE },
+                Constants.INAPP_CTA_SWIPE_DISMISS,
+                any(),
+                any()
+            )
+            overlay.dismiss()
+        }
+    }
+
+    @Test
+    fun `didDismiss dismisses the overlay`() {
+        bridge.didDismiss(null)
+        verify(exactly = 1) { overlay.dismiss() }
+    }
+
+    @Test
+    fun `dismiss data resolved by the action is reported only once the overlay is removed`() {
+        val resolved = Bundle().apply { putString("resolved", "yes") }
+        every {
+            listener.inAppNotificationActionTriggered(any(), any(), any(), any(), any())
+        } returns resolved
+
+        bridge.openActionUrl("https://clevertap.com")
+        // No dismiss reported yet — only the action has fired.
+        verify(exactly = 0) { listener.inAppNotificationDidDismiss(any(), any()) }
+
+        // The overlay signals it has been removed from the window.
+        bridge.onBannerRemoved()
+        verify(exactly = 1) { listener.inAppNotificationDidDismiss(notification, resolved) }
+    }
+}

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridgeTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridgeTest.kt
@@ -77,6 +77,12 @@ class CTHtmlBannerCallbacksBridgeTest {
     }
 
     @Test
+    fun `hideInApp dismisses the overlay for external hide`() {
+        bridge.hideInApp()
+        verify(exactly = 1) { overlay.dismiss() }
+    }
+
+    @Test
     fun `dismiss data resolved by the action is reported only once the overlay is removed`() {
         val resolved = Bundle().apply { putString("resolved", "yes") }
         every {

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppActionParserTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppActionParserTest.kt
@@ -1,0 +1,110 @@
+package com.clevertap.android.sdk.inapp
+
+import android.net.Uri
+import android.os.Bundle
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.utils.configMock
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class InAppActionParserTest {
+
+    private val config = configMock()
+
+    @Test
+    fun `parse returns action unchanged for non open-url action`() {
+        val action = CTInAppAction.createCloseAction()
+        val data = Bundle().apply { putString("k", "v") }
+
+        val parsed = InAppActionParser.parse(action, "cta", data, config)
+
+        assertEquals(action, parsed.action)
+        assertEquals("cta", parsed.callToAction)
+        assertEquals(data, parsed.additionalData)
+    }
+
+    @Test
+    fun `parse surfaces url parameters as additionalData`() {
+        val url = Uri.parse("https://clevertap.com").buildUpon()
+            .appendQueryParameter("param1", "value")
+            .appendQueryParameter("param2", "value 2")
+            .appendQueryParameter("param3", "5")
+            .build().toString()
+
+        val parsed = InAppActionParser.parse(CTInAppAction.createOpenUrlAction(url), null, null, config)
+
+        assertEquals(InAppActionType.OPEN_URL, parsed.action.type)
+        assertEquals(url, parsed.action.actionUrl)
+        val data = parsed.additionalData!!
+        assertEquals("value", data.getString("param1"))
+        assertEquals("value 2", data.getString("param2"))
+        assertEquals("5", data.getString("param3"))
+    }
+
+    @Test
+    fun `parse merges url parameters with provided additionalData preferring additionalData`() {
+        val url = Uri.parse("https://clevertap.com").buildUpon()
+            .appendQueryParameter("param1", "value")
+            .appendQueryParameter("param2", "value 2")
+            .appendQueryParameter("param3", "5")
+            .build().toString()
+        val data = Bundle().apply {
+            putString("param1", "dataValue")
+            putString("param2", "data value 2")
+        }
+
+        val parsed = InAppActionParser.parse(CTInAppAction.createOpenUrlAction(url), null, data, config)
+
+        val out = parsed.additionalData!!
+        assertEquals("dataValue", out.getString("param1"))
+        assertEquals("data value 2", out.getString("param2"))
+        assertEquals("5", out.getString("param3"))
+    }
+
+    @Test
+    fun `parse uses c2a url param when no callToAction argument is provided`() {
+        val url = Uri.parse("https://clevertap.com").buildUpon()
+            .appendQueryParameter(Constants.KEY_C2A, "c2aParam")
+            .build().toString()
+
+        val parsed = InAppActionParser.parse(CTInAppAction.createOpenUrlAction(url), null, null, config)
+
+        assertEquals("c2aParam", parsed.callToAction)
+        // c2a is a control param and should not remain in the tracked data
+        assertNull(parsed.additionalData!!.getString(Constants.KEY_C2A))
+    }
+
+    @Test
+    fun `parse prefers callToAction argument over c2a url param`() {
+        val url = Uri.parse("https://clevertap.com").buildUpon()
+            .appendQueryParameter(Constants.KEY_C2A, "c2aParam")
+            .build().toString()
+
+        val parsed =
+            InAppActionParser.parse(CTInAppAction.createOpenUrlAction(url), "argument", null, config)
+
+        assertEquals("argument", parsed.callToAction)
+    }
+
+    @Test
+    fun `parse extracts deeplink from c2a __dl__ param and tracks only original url params`() {
+        val dl = "https://deeplink.com?param1=asd&param2=value2"
+        val url = Uri.parse("https://clevertap.com").buildUpon()
+            .appendQueryParameter(Constants.KEY_C2A, "c2aParam__dl__$dl")
+            .appendQueryParameter("param1", "value")
+            .build().toString()
+
+        val parsed = InAppActionParser.parse(CTInAppAction.createOpenUrlAction(url), null, null, config)
+
+        // the open-url action should target the url after __dl__
+        assertEquals(dl, parsed.action.actionUrl)
+        assertEquals("c2aParam", parsed.callToAction)
+        val data = parsed.additionalData!!
+        assertEquals(1, data.size())
+        assertEquals("value", data.getString("param1"))
+    }
+}

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
@@ -32,9 +32,11 @@ import com.clevertap.android.sdk.task.MockCTExecutors
 import com.clevertap.android.sdk.toList
 import com.clevertap.android.sdk.utils.FakeClock
 import com.clevertap.android.sdk.utils.configMock
+import androidx.fragment.app.FragmentActivity
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.runs
@@ -77,7 +79,8 @@ class InAppControllerTest {
     fun setUp() {
         mockkStatic(CoreMetaData::class)
         every { CoreMetaData.isAppForeground() } returns true
-        every { CoreMetaData.getCurrentActivity() } returns mockk(relaxed = true)
+        // Default to a FragmentActivity — the normal host for header/footer in-apps.
+        every { CoreMetaData.getCurrentActivity() } returns mockk<FragmentActivity>(relaxed = true)
 
         mockkStatic(InAppNotificationActivity::class)
         every {
@@ -116,6 +119,7 @@ class InAppControllerTest {
 
         mockManifestInfo = mockk()
         every { mockManifestInfo.excludedActivities } returns EXCLUDED_ACTIVITY_NAME
+        every { mockManifestInfo.isFragmentlessInAppBannersEnabled } returns false
 
         mockAnalyticsManager = mockk()
         every {
@@ -539,6 +543,54 @@ class InAppControllerTest {
     }
 
     @Test
+    fun `HTML header in-app uses the fragment path on a FragmentActivity`() {
+        every { CoreMetaData.getCurrentActivity() } returns mockk<FragmentActivity>(relaxed = true)
+        val inAppController = createInAppController()
+
+        inAppController.addInAppNotificationsToQueue(
+            JSONArray("[${InAppFixtures.TYPE_CUSTOM_HTML_HEADER_WITH_KV}]").toList()
+        )
+
+        verify(exactly = 1) {
+            CTInAppBaseFragment.showOnActivity(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `HTML header in-app is dropped on a non-FragmentActivity when fragmentless banners are disabled`() {
+        // Plain Activity host (not a FragmentActivity); flag defaults to false.
+        every { CoreMetaData.getCurrentActivity() } returns mockk<Activity>(relaxed = true)
+        val inAppController = createInAppController()
+
+        inAppController.addInAppNotificationsToQueue(
+            JSONArray("[${InAppFixtures.TYPE_CUSTOM_HTML_HEADER_WITH_KV}]").toList()
+        )
+
+        verify(exactly = 0) {
+            CTInAppBaseFragment.showOnActivity(any(), any(), any(), any(), any())
+        }
+        assertNull(InAppController.currentlyDisplayingInApp)
+    }
+
+    @Test
+    fun `HTML header in-app shows the overlay on a non-FragmentActivity when fragmentless banners are enabled`() {
+        every { CoreMetaData.getCurrentActivity() } returns mockk<Activity>(relaxed = true)
+        every { mockManifestInfo.isFragmentlessInAppBannersEnabled } returns true
+        mockkConstructor(CTInAppHtmlBannerOverlay::class)
+        every { anyConstructed<CTInAppHtmlBannerOverlay>().show() } just runs
+
+        val inAppController = createInAppController()
+        inAppController.addInAppNotificationsToQueue(
+            JSONArray("[${InAppFixtures.TYPE_CUSTOM_HTML_HEADER_WITH_KV}]").toList()
+        )
+
+        verify(exactly = 1) { anyConstructed<CTInAppHtmlBannerOverlay>().show() }
+        verify(exactly = 0) {
+            CTInAppBaseFragment.showOnActivity(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
     fun `suspendInApps should pause inapps until resumeInApps is called`() {
         val inAppController = createInAppController()
         inAppController.suspendInApps()
@@ -816,7 +868,7 @@ class InAppControllerTest {
             JSONArray("[${InAppFixtures.TYPE_INTERSTITIAL_WITH_MEDIA},${InAppFixtures.TYPE_CUSTOM_HTML_HEADER_WITH_KV}]")
         fakeInAppQueue.enqueueAll(inApps.toList())
 
-        val mockActivity = mockk<Activity>()
+        val mockActivity = mockk<FragmentActivity>()
         every { mockActivity.localClassName } returns EXCLUDED_ACTIVITY_NAME
         every { CoreMetaData.getCurrentActivity() } returns mockActivity
 

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
@@ -1,8 +1,12 @@
 package com.clevertap.android.sdk.inapp
 
 import android.view.MotionEvent
+import android.view.animation.Animation
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -74,5 +78,35 @@ class PartialHtmlInAppGestureListenerTest {
 
         assertFalse(consumed)
         assertEquals(0, swipeStartCount)
+    }
+
+    @Test
+    fun `swipe dismiss fires at animation end, strictly after swipe start`() {
+        val order = mutableListOf<String>()
+        val gestureListener = PartialHtmlInAppGestureListener(
+            webViewProvider = { webView },
+            scaledPixels = { it },
+            onSwipeStart = { order += "start" },
+            onSwipeDismiss = { order += "dismiss" }
+        )
+        val animSlot = slot<Animation>()
+        every { webView.startAnimation(capture(animSlot)) } just runs
+
+        val consumed = gestureListener.onFling(event(200f), event(0f), -201f, 0f)
+
+        // onSwipeStart ran synchronously; onSwipeDismiss has NOT fired yet.
+        assertTrue(consumed)
+        assertEquals(listOf("start"), order)
+
+        // Drive the captured animation to completion -> onSwipeDismiss fires, strictly after start.
+        animationListenerOf(animSlot.captured).onAnimationEnd(animSlot.captured)
+        assertEquals(listOf("start", "dismiss"), order)
+    }
+
+    /** Reads the [Animation.AnimationListener] the gesture attached to its [AnimationSet]. */
+    private fun animationListenerOf(animation: Animation): Animation.AnimationListener {
+        val field = Animation::class.java.getDeclaredField("mListener")
+        field.isAccessible = true
+        return field.get(animation) as Animation.AnimationListener
     }
 }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
@@ -1,0 +1,78 @@
+package com.clevertap.android.sdk.inapp
+
+import android.view.MotionEvent
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PartialHtmlInAppGestureListenerTest {
+
+    private val webView = mockk<CTInAppWebView>(relaxed = true)
+    private var swipeStartCount = 0
+    private var swipeDismissCount = 0
+
+    private fun listener(
+        webViewProvider: () -> CTInAppWebView? = { webView }
+    ) = PartialHtmlInAppGestureListener(
+        webViewProvider = webViewProvider,
+        scaledPixels = { it },
+        onSwipeStart = { swipeStartCount++ },
+        onSwipeDismiss = { swipeDismissCount++ }
+    )
+
+    private fun event(x: Float) = mockk<MotionEvent>(relaxed = true).also { every { it.x } returns x }
+
+    @Test
+    fun `horizontal fling beyond both thresholds starts the swipe dismiss`() {
+        // dx = 200 (> 120), |velocity| = 201 (> 200)
+        val consumed = listener().onFling(event(200f), event(0f), -201f, 0f)
+
+        assertTrue(consumed)
+        assertEquals(1, swipeStartCount)
+        verify(exactly = 1) { webView.startAnimation(any()) }
+        // onSwipeDismiss fires only at animation end, not synchronously.
+        assertEquals(0, swipeDismissCount)
+    }
+
+    @Test
+    fun `fling below the distance threshold is ignored`() {
+        // dx = 119 (< 120), velocity well past its threshold
+        val consumed = listener().onFling(event(119f), event(0f), -400f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+        verify(exactly = 0) { webView.startAnimation(any()) }
+    }
+
+    @Test
+    fun `fling below the velocity threshold is ignored`() {
+        // dx well past its threshold, |velocity| = 199 (< 200)
+        val consumed = listener().onFling(event(200f), event(0f), -199f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+    }
+
+    @Test
+    fun `null first event is ignored`() {
+        val consumed = listener().onFling(null, event(0f), -400f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+    }
+
+    @Test
+    fun `a null webView aborts before the swipe starts`() {
+        val consumed = listener(webViewProvider = { null }).onFling(event(200f), event(0f), -400f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+    }
+}

--- a/gradle-scripts/jacoco_root.gradle
+++ b/gradle-scripts/jacoco_root.gradle
@@ -43,6 +43,7 @@ ext.excludes = [
         'com/clevertap/android/sdk/inapp/InAppWebViewClient*.*',
         'com/clevertap/android/sdk/inapp/fragment/**',
         'com/clevertap/android/sdk/inapp/CTInAppWebView*.*',
+        'com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay*.*',
         'com/clevertap/android/sdk/inbox/CTInboxTabAdapter*.*',
         'com/clevertap/android/sdk/inbox/CTCarouselViewPager*.*',
         'com/clevertap/android/sdk/inbox/CTInboxMessageAdapter*.*',

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -104,6 +104,9 @@
             android:name="CLEVERTAP_ACTIVITY_EXCLUDE"
             android:value="HomeScreenActivity" />
         <meta-data
+            android:name="CLEVERTAP_INAPP_FRAGMENTLESS_BANNERS"
+            android:value="0" /> <!-- Set to 1 to let custom-html header/footer in-apps render via a WindowManager overlay when the host Activity is not a FragmentActivity (e.g. game engines). Default 0 (disabled); intended for the Unreal/Unity wrapper SDKs. -->
+        <meta-data
             android:name="CLEVERTAP_ENCRYPTION_LEVEL"
             android:value="2" /> <!-- Add meta and set to 1 enable encryption of PII data -->
 


### PR DESCRIPTION
## SDK-5976

Renders custom-HTML **header/footer** in-app notifications when the host Activity is not a `FragmentActivity` (e.g. Unreal/Unity game engines), via a `WindowManager` overlay. Reimplements the intent of old PR #841 on top of current `develop`.

### Gated — no behavior change for existing integrations
Behind an opt-in manifest flag `CLEVERTAP_INAPP_FRAGMENTLESS_BANNERS` (default off). Only the gaming wrapper SDKs set it in their merged manifest; every other app/SDK keeps the pre-change behavior (non-FragmentActivity HTML header/footer shows nothing).

### Design
Mirrors develop's existing PIP non-fragment rendering pattern:
- **`CTInAppHtmlBannerOverlay`** — UI-only `WindowManager` overlay renderer (top/bottom gravity, swipe-to-dismiss, JS interface). WindowManager (not content-view attach like PIP) because game engines back their content view with a `SurfaceView`, which composites unreliably with sibling views.
- **`CTHtmlBannerCallbacksBridge`** — translates renderer callbacks + web interactions to `InAppListener` (mirrors `PIPInAppCallbacksBridge`).
- **`InAppActionParser`** — shared stateless OPEN_URL/`wzrk_c2a`/`__dl__` parsing, reused by the fragment path and the bridge.
- **`InAppWebInteraction`** — thin seam so `CTWebInterface`/`InAppWebViewClient` work with either the fragment or the bridge.
- **`CTInAppWebView.loadInAppHtml`** — consolidates html-loading duplicated across the partial/full html fragments.

### Scope
HTML header/footer only. Native header/footer still require a `FragmentActivity`.

### Tests
`InAppActionParserTest` (6), `CTHtmlBannerCallbacksBridgeTest` (5), updated `CTWebInterfaceTest`. Compiles and the affected `inapp`/`inapp.fragment` suites pass.

### Follow-up (separate stacked PR)
Known parity gaps tracked separately: activity-lifecycle teardown (leak/wedge on activity destroy), external hide on `discardInApps`, `finishDismiss` re-entrancy guard, and a controller-dispatch test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added opt-in support for displaying HTML header and footer banners on non-fragment Android activities.
  - HTML banners now support JavaScript, swipe-to-dismiss gestures, animated dismissal, action URLs, deep links, and custom action data.
  - Added configuration support for enabling fragmentless banners.
  - Improved HTML sizing and scaling across screen densities and display dimensions.

- **Bug Fixes**
  - Improved banner lifecycle handling, dismissal reporting, action processing, and resilience when web interactions are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->