### PR TITLE
fix(SDK-5977): harden non-FragmentActivity HTML banner lifecycle and dismissal

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridge.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridge.kt
@@ -17,12 +17,18 @@ internal class CTHtmlBannerCallbacksBridge(
     private val notification: CTInAppNotification,
     private val config: CleverTapInstanceConfig,
     private val inAppListener: InAppListener
-) : CTInAppHtmlBannerOverlay.Callbacks {
+) : CTInAppHtmlBannerOverlay.Callbacks, InAppDisplayListener {
 
     /** Set by the caller immediately after constructing the overlay. */
     var overlay: CTInAppHtmlBannerOverlay? = null
 
     private var pendingDismissData: Bundle? = null
+
+    // ----- InAppDisplayListener (external hide, e.g. discardInApps/suspend) -----
+
+    override fun hideInApp() {
+        didDismiss(null)
+    }
 
     // ----- CTInAppHtmlBannerOverlay.Callbacks (banner lifecycle) -----
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
@@ -7,23 +7,19 @@ import android.graphics.PixelFormat
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.GestureDetector
-import android.view.GestureDetector.SimpleOnGestureListener
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import android.view.animation.AlphaAnimation
-import android.view.animation.Animation
-import android.view.animation.AnimationSet
-import android.view.animation.TranslateAnimation
 import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.CTWebInterface
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.CleverTapInstanceConfig
+import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.task.MainLooperHandler
 import java.lang.ref.WeakReference
-import kotlin.math.abs
 
 /**
  * Renders *custom-html* "header" and "footer" [CTInAppNotification]s in a [WindowManager] overlay,
@@ -64,9 +60,6 @@ internal class CTInAppHtmlBannerOverlay(
     }
 
     companion object {
-        private const val SWIPE_MIN_DISTANCE = 120
-        private const val SWIPE_THRESHOLD_VELOCITY = 200
-
         fun canDisplay(type: CTInAppType?): Boolean {
             return type == CTInAppType.CTInAppTypeFooterHTML || type == CTInAppType.CTInAppTypeHeaderHTML
         }
@@ -75,7 +68,14 @@ internal class CTInAppHtmlBannerOverlay(
     private val activityWeakRef = WeakReference(activity)
     private val isJsEnabled = notification.isJsEnabled
     private val mainHandler = MainLooperHandler()
-    private val gd = GestureDetector(activity, GestureListener())
+    private val gestureListener = PartialHtmlInAppGestureListener(
+        scaledPixels = ::getScaledPixels,
+        // Mark dismissing so the follow-up dismiss() from the close action removes immediately
+        // instead of re-animating.
+        onSwipeStart = { animatingDismiss = true },
+        onSwipeDismiss = { host.onBannerSwipeDismissed() }
+    )
+    private val gd = GestureDetector(activity, gestureListener)
 
     private var wm: WindowManager? = null
     private var overlayRoot: View? = null
@@ -121,6 +121,7 @@ internal class CTInAppHtmlBannerOverlay(
                 notification.aspectRatio
             )
             this.webView = webView
+            gestureListener.webView = webView
             webView.setWebViewClient(InAppWebViewClient(host))
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no
             // close button, matching CTInAppBasePartialHtmlFragment.
@@ -160,6 +161,11 @@ internal class CTInAppHtmlBannerOverlay(
             wmlp.token = activity.window.decorView.windowToken // tie to this activity
             wm = activity.windowManager
             wm?.addView(root, wmlp)
+
+            // Announce the banner to accessibility services (parity with CTInAppBaseFragment).
+            ViewCompat.setAccessibilityPaneTitle(
+                root, activity.getString(R.string.ct_inapp_message_shown)
+            )
 
             // Tear down the overlay if the host Activity is destroyed, so the window is not leaked
             // and the in-app display queue is not left wedged (a Fragment gets this for free).
@@ -278,55 +284,6 @@ internal class CTInAppHtmlBannerOverlay(
             Gravity.BOTTOM
         } else {
             Gravity.TOP
-        }
-    }
-
-    private inner class GestureListener : SimpleOnGestureListener() {
-        override fun onFling(
-            e1: MotionEvent?,
-            e2: MotionEvent,
-            velocityX: Float,
-            velocityY: Float
-        ): Boolean {
-            if (e1 != null) {
-                if (e1.x - e2.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Right to left
-                    return remove(false)
-                } else if (e2.x - e1.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Left to right
-                    return remove(true)
-                }
-            }
-            return false
-        }
-
-        private fun remove(ltr: Boolean): Boolean {
-            val webView = webView ?: return false
-            // Mark dismissing so the follow-up dismiss() from the close action removes immediately
-            // instead of re-animating.
-            animatingDismiss = true
-            val animSet = AnimationSet(true)
-            val anim = if (ltr) {
-                TranslateAnimation(0f, getScaledPixels(50).toFloat(), 0f, 0f)
-            } else {
-                TranslateAnimation(0f, -getScaledPixels(50).toFloat(), 0f, 0f)
-            }
-            animSet.addAnimation(anim)
-            animSet.addAnimation(AlphaAnimation(1f, 0f))
-            animSet.duration = 300
-            animSet.fillAfter = true
-            animSet.isFillEnabled = true
-            animSet.setAnimationListener(object : Animation.AnimationListener {
-                override fun onAnimationEnd(animation: Animation?) {
-                    host.onBannerSwipeDismissed()
-                }
-
-                override fun onAnimationRepeat(animation: Animation?) {}
-
-                override fun onAnimationStart(animation: Animation?) {}
-            })
-            webView.startAnimation(animSet)
-            return true
         }
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
@@ -2,7 +2,9 @@ package com.clevertap.android.sdk.inapp
 
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.app.Application
 import android.graphics.PixelFormat
+import android.os.Bundle
 import android.util.TypedValue
 import android.view.GestureDetector
 import android.view.GestureDetector.SimpleOnGestureListener
@@ -79,6 +81,8 @@ internal class CTInAppHtmlBannerOverlay(
     private var overlayRoot: View? = null
     private var webView: CTInAppWebView? = null
     private var animatingDismiss = false
+    private var removed = false
+    private var application: Application? = null
 
     /** The host activity, or null if collected. Used as the action activity-context. */
     val activity: Activity? get() = activityWeakRef.get()
@@ -157,21 +161,20 @@ internal class CTInAppHtmlBannerOverlay(
             wm = activity.windowManager
             wm?.addView(root, wmlp)
 
+            // Tear down the overlay if the host Activity is destroyed, so the window is not leaked
+            // and the in-app display queue is not left wedged (a Fragment gets this for free).
+            application = activity.application
+            application?.registerActivityLifecycleCallbacks(lifecycleCallbacks)
+
             webView.updateDimension()
             webView.loadInAppHtml(html)
             host.onBannerShown()
         } catch (t: Throwable) {
             config.logger.debug(config.accountId, "CTInAppHtmlBannerOverlay: failed to show", t)
-            // addView may have already attached the overlay before a later statement threw; detach
-            // it best-effort so the window is not leaked.
-            try {
-                wm?.removeViewImmediate(overlayRoot)
-            } catch (e: Exception) {
-                // no-op; the view may not have been added yet
-            }
-            overlayRoot = null
-            cleanupWebView()
-            host.onBannerRemoved()
+            // addView may have already attached the overlay before a later statement threw;
+            // finishDismiss detaches it best-effort and reports the dismiss (guarded, so a later
+            // teardown will not double-report).
+            finishDismiss()
         }
     }
 
@@ -212,6 +215,15 @@ internal class CTInAppHtmlBannerOverlay(
     }
 
     private fun finishDismiss() {
+        // One-shot: guards against a double removal (e.g. a re-entrant dismiss racing the fade's
+        // withEndAction, a build() failure, or an activity-destroy teardown after a user dismiss)
+        // reporting the dismiss twice.
+        if (removed) {
+            return
+        }
+        removed = true
+        application?.unregisterActivityLifecycleCallbacks(lifecycleCallbacks)
+        application = null
         try {
             wm?.removeViewImmediate(overlayRoot)
         } catch (e: Exception) {
@@ -221,6 +233,23 @@ internal class CTInAppHtmlBannerOverlay(
             cleanupWebView()
             host.onBannerRemoved()
         }
+    }
+
+    private val lifecycleCallbacks = object : Application.ActivityLifecycleCallbacks {
+        override fun onActivityDestroyed(destroyed: Activity) {
+            if (destroyed === activityWeakRef.get()) {
+                // Host Activity is gone: remove the window (best-effort) and report the dismiss so
+                // the controller clears currentlyDisplayingInApp and can show the next in-app.
+                finishDismiss()
+            }
+        }
+
+        override fun onActivityCreated(a: Activity, b: Bundle?) {}
+        override fun onActivityStarted(a: Activity) {}
+        override fun onActivityResumed(a: Activity) {}
+        override fun onActivityPaused(a: Activity) {}
+        override fun onActivityStopped(a: Activity) {}
+        override fun onActivitySaveInstanceState(a: Activity, b: Bundle) {}
     }
 
     private fun cleanupWebView() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
@@ -69,6 +69,7 @@ internal class CTInAppHtmlBannerOverlay(
     private val isJsEnabled = notification.isJsEnabled
     private val mainHandler = MainLooperHandler()
     private val gestureListener = PartialHtmlInAppGestureListener(
+        webViewProvider = { webView },
         scaledPixels = ::getScaledPixels,
         // Mark dismissing so the follow-up dismiss() from the close action removes immediately
         // instead of re-animating.
@@ -121,7 +122,6 @@ internal class CTInAppHtmlBannerOverlay(
                 notification.aspectRatio
             )
             this.webView = webView
-            gestureListener.webView = webView
             webView.setWebViewClient(InAppWebViewClient(host))
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no
             // close button, matching CTInAppBasePartialHtmlFragment.

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -1149,6 +1149,8 @@ internal class InAppController(
         val bridge = CTHtmlBannerCallbacksBridge(inAppNotification, config, this)
         val overlay = CTInAppHtmlBannerOverlay(inAppNotification, config, bridge, activity)
         bridge.overlay = overlay
+        // Allow the overlay to be hidden externally (discardInApps/suspend), like the fragment path.
+        registerInAppDisplayListener(bridge)
         overlay.show()
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
@@ -13,17 +13,20 @@ import kotlin.math.abs
  * fragment-hosted [com.clevertap.android.sdk.inapp.fragment.CTInAppBasePartialHtmlFragment] and the
  * non-fragment [CTInAppHtmlBannerOverlay].
  *
- * On a horizontal fling it slides + fades the [webView] out, then invokes [onSwipeDismiss].
+ * On a horizontal fling it slides + fades the current WebView out, then invokes [onSwipeDismiss].
  * [onSwipeStart] runs when the dismiss animation begins — the overlay uses it to coordinate its own
  * removal animation. [scaledPixels] converts dp to px in the host's context.
+ *
+ * The target is read through [webViewProvider] rather than held as state, so it always reflects the
+ * host's live field (and becomes null once the host cleans up) — no stale reference to a destroyed
+ * WebView.
  */
 internal class PartialHtmlInAppGestureListener(
+    private val webViewProvider: () -> CTInAppWebView?,
     private val scaledPixels: (Int) -> Int,
     private val onSwipeStart: () -> Unit = {},
     private val onSwipeDismiss: () -> Unit
 ) : SimpleOnGestureListener() {
-
-    var webView: CTInAppWebView? = null
 
     override fun onFling(
         e1: MotionEvent?,
@@ -44,7 +47,7 @@ internal class PartialHtmlInAppGestureListener(
     }
 
     private fun remove(ltr: Boolean): Boolean {
-        val webView = webView ?: return false
+        val webView = webViewProvider() ?: return false
         onSwipeStart()
         val animSet = AnimationSet(true)
         val anim = if (ltr) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
@@ -1,0 +1,77 @@
+package com.clevertap.android.sdk.inapp
+
+import android.view.GestureDetector.SimpleOnGestureListener
+import android.view.MotionEvent
+import android.view.animation.AlphaAnimation
+import android.view.animation.Animation
+import android.view.animation.AnimationSet
+import android.view.animation.TranslateAnimation
+import kotlin.math.abs
+
+/**
+ * Shared swipe-to-dismiss gesture for partial (header/footer) HTML in-apps, used by both the
+ * fragment-hosted [com.clevertap.android.sdk.inapp.fragment.CTInAppBasePartialHtmlFragment] and the
+ * non-fragment [CTInAppHtmlBannerOverlay].
+ *
+ * On a horizontal fling it slides + fades the [webView] out, then invokes [onSwipeDismiss].
+ * [onSwipeStart] runs when the dismiss animation begins — the overlay uses it to coordinate its own
+ * removal animation. [scaledPixels] converts dp to px in the host's context.
+ */
+internal class PartialHtmlInAppGestureListener(
+    private val scaledPixels: (Int) -> Int,
+    private val onSwipeStart: () -> Unit = {},
+    private val onSwipeDismiss: () -> Unit
+) : SimpleOnGestureListener() {
+
+    var webView: CTInAppWebView? = null
+
+    override fun onFling(
+        e1: MotionEvent?,
+        e2: MotionEvent,
+        velocityX: Float,
+        velocityY: Float
+    ): Boolean {
+        if (e1 != null) {
+            if (e1.x - e2.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
+                // Right to left
+                return remove(false)
+            } else if (e2.x - e1.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
+                // Left to right
+                return remove(true)
+            }
+        }
+        return false
+    }
+
+    private fun remove(ltr: Boolean): Boolean {
+        val webView = webView ?: return false
+        onSwipeStart()
+        val animSet = AnimationSet(true)
+        val anim = if (ltr) {
+            TranslateAnimation(0f, scaledPixels(50).toFloat(), 0f, 0f)
+        } else {
+            TranslateAnimation(0f, -scaledPixels(50).toFloat(), 0f, 0f)
+        }
+        animSet.addAnimation(anim)
+        animSet.addAnimation(AlphaAnimation(1f, 0f))
+        animSet.duration = 300
+        animSet.fillAfter = true
+        animSet.isFillEnabled = true
+        animSet.setAnimationListener(object : Animation.AnimationListener {
+            override fun onAnimationEnd(animation: Animation?) {
+                onSwipeDismiss()
+            }
+
+            override fun onAnimationRepeat(animation: Animation?) {}
+
+            override fun onAnimationStart(animation: Animation?) {}
+        })
+        webView.startAnimation(animSet)
+        return true
+    }
+
+    companion object {
+        const val SWIPE_MIN_DISTANCE = 120
+        const val SWIPE_THRESHOLD_VELOCITY = 200
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -5,75 +5,24 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.GestureDetector
-import android.view.GestureDetector.SimpleOnGestureListener
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnLongClickListener
 import android.view.View.OnTouchListener
 import android.view.ViewGroup
-import android.view.animation.AlphaAnimation
-import android.view.animation.Animation
-import android.view.animation.AnimationSet
-import android.view.animation.TranslateAnimation
 import com.clevertap.android.sdk.CTWebInterface
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.inapp.CTInAppWebView
 import com.clevertap.android.sdk.inapp.InAppWebViewClient
-import kotlin.math.abs
+import com.clevertap.android.sdk.inapp.PartialHtmlInAppGestureListener
 
 internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragment(),
     OnTouchListener,
     OnLongClickListener {
 
-    private inner class GestureListener : SimpleOnGestureListener() {
-        override fun onFling(
-            e1: MotionEvent?,
-            e2: MotionEvent,
-            velocityX: Float,
-            velocityY: Float
-        ): Boolean {
-            if (e1 != null) {
-                if (e1.x - e2.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Right to left
-                    return remove(false)
-                } else if (e2.x - e1.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Left to right
-                    return remove(true)
-                }
-            }
-            return false
-        }
-
-        fun remove(ltr: Boolean): Boolean {
-            val animSet = AnimationSet(true)
-            val anim = if (ltr) {
-                TranslateAnimation(0f, getScaledPixels(50).toFloat(), 0f, 0f)
-            } else {
-                TranslateAnimation(0f, -getScaledPixels(50).toFloat(), 0f, 0f)
-            }
-            animSet.addAnimation(anim)
-            animSet.addAnimation(AlphaAnimation(1f, 0f))
-            animSet.setDuration(300)
-            animSet.setFillAfter(true)
-            animSet.isFillEnabled = true
-            animSet.setAnimationListener(object : Animation.AnimationListener {
-                override fun onAnimationEnd(animation: Animation?) {
-                    triggerSwipeDismissAction()
-                }
-
-                override fun onAnimationRepeat(animation: Animation?) {
-                }
-
-                override fun onAnimationStart(animation: Animation?) {
-                }
-            })
-            webView?.startAnimation(animSet)
-            return true
-        }
-    }
-
     private lateinit var gd: GestureDetector
+    private lateinit var gestureListener: PartialHtmlInAppGestureListener
 
     private var webView: CTInAppWebView? = null
 
@@ -84,7 +33,11 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        gd = GestureDetector(context, GestureListener())
+        gestureListener = PartialHtmlInAppGestureListener(
+            scaledPixels = ::getScaledPixels,
+            onSwipeDismiss = ::triggerSwipeDismissAction
+        )
+        gd = GestureDetector(context, gestureListener)
     }
 
     override fun onCreateView(
@@ -141,6 +94,7 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
                 inAppNotification.aspectRatio
             )
             this.webView = webView
+            gestureListener.webView = webView
             val webViewClient = InAppWebViewClient(this)
             webView.setWebViewClient(webViewClient)
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no close
@@ -169,10 +123,5 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
         webView.updateDimension()
         val html = inAppNotification.html ?: return
         webView.loadInAppHtml(html)
-    }
-
-    companion object {
-        private const val SWIPE_MIN_DISTANCE = 120
-        private const val SWIPE_THRESHOLD_VELOCITY = 200
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -22,7 +22,6 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
     OnLongClickListener {
 
     private lateinit var gd: GestureDetector
-    private lateinit var gestureListener: PartialHtmlInAppGestureListener
 
     private var webView: CTInAppWebView? = null
 
@@ -33,7 +32,7 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        gestureListener = PartialHtmlInAppGestureListener(
+        val gestureListener = PartialHtmlInAppGestureListener(
             webViewProvider = { webView },
             scaledPixels = ::getScaledPixels,
             onSwipeDismiss = ::triggerSwipeDismissAction

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -34,6 +34,7 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
     override fun onAttach(context: Context) {
         super.onAttach(context)
         gestureListener = PartialHtmlInAppGestureListener(
+            webViewProvider = { webView },
             scaledPixels = ::getScaledPixels,
             onSwipeDismiss = ::triggerSwipeDismissAction
         )
@@ -94,7 +95,6 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
                 inAppNotification.aspectRatio
             )
             this.webView = webView
-            gestureListener.webView = webView
             val webViewClient = InAppWebViewClient(this)
             webView.setWebViewClient(webViewClient)
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no close

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridgeTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/CTHtmlBannerCallbacksBridgeTest.kt
@@ -77,6 +77,12 @@ class CTHtmlBannerCallbacksBridgeTest {
     }
 
     @Test
+    fun `hideInApp dismisses the overlay for external hide`() {
+        bridge.hideInApp()
+        verify(exactly = 1) { overlay.dismiss() }
+    }
+
+    @Test
     fun `dismiss data resolved by the action is reported only once the overlay is removed`() {
         val resolved = Bundle().apply { putString("resolved", "yes") }
         every {

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
@@ -1,8 +1,12 @@
 package com.clevertap.android.sdk.inapp
 
 import android.view.MotionEvent
+import android.view.animation.Animation
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -74,5 +78,35 @@ class PartialHtmlInAppGestureListenerTest {
 
         assertFalse(consumed)
         assertEquals(0, swipeStartCount)
+    }
+
+    @Test
+    fun `swipe dismiss fires at animation end, strictly after swipe start`() {
+        val order = mutableListOf<String>()
+        val gestureListener = PartialHtmlInAppGestureListener(
+            webViewProvider = { webView },
+            scaledPixels = { it },
+            onSwipeStart = { order += "start" },
+            onSwipeDismiss = { order += "dismiss" }
+        )
+        val animSlot = slot<Animation>()
+        every { webView.startAnimation(capture(animSlot)) } just runs
+
+        val consumed = gestureListener.onFling(event(200f), event(0f), -201f, 0f)
+
+        // onSwipeStart ran synchronously; onSwipeDismiss has NOT fired yet.
+        assertTrue(consumed)
+        assertEquals(listOf("start"), order)
+
+        // Drive the captured animation to completion -> onSwipeDismiss fires, strictly after start.
+        animationListenerOf(animSlot.captured).onAnimationEnd(animSlot.captured)
+        assertEquals(listOf("start", "dismiss"), order)
+    }
+
+    /** Reads the [Animation.AnimationListener] the gesture attached to its [AnimationSet]. */
+    private fun animationListenerOf(animation: Animation): Animation.AnimationListener {
+        val field = Animation::class.java.getDeclaredField("mListener")
+        field.isAccessible = true
+        return field.get(animation) as Animation.AnimationListener
     }
 }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
@@ -1,0 +1,78 @@
+package com.clevertap.android.sdk.inapp
+
+import android.view.MotionEvent
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PartialHtmlInAppGestureListenerTest {
+
+    private val webView = mockk<CTInAppWebView>(relaxed = true)
+    private var swipeStartCount = 0
+    private var swipeDismissCount = 0
+
+    private fun listener(
+        webViewProvider: () -> CTInAppWebView? = { webView }
+    ) = PartialHtmlInAppGestureListener(
+        webViewProvider = webViewProvider,
+        scaledPixels = { it },
+        onSwipeStart = { swipeStartCount++ },
+        onSwipeDismiss = { swipeDismissCount++ }
+    )
+
+    private fun event(x: Float) = mockk<MotionEvent>(relaxed = true).also { every { it.x } returns x }
+
+    @Test
+    fun `horizontal fling beyond both thresholds starts the swipe dismiss`() {
+        // dx = 200 (> 120), |velocity| = 201 (> 200)
+        val consumed = listener().onFling(event(200f), event(0f), -201f, 0f)
+
+        assertTrue(consumed)
+        assertEquals(1, swipeStartCount)
+        verify(exactly = 1) { webView.startAnimation(any()) }
+        // onSwipeDismiss fires only at animation end, not synchronously.
+        assertEquals(0, swipeDismissCount)
+    }
+
+    @Test
+    fun `fling below the distance threshold is ignored`() {
+        // dx = 119 (< 120), velocity well past its threshold
+        val consumed = listener().onFling(event(119f), event(0f), -400f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+        verify(exactly = 0) { webView.startAnimation(any()) }
+    }
+
+    @Test
+    fun `fling below the velocity threshold is ignored`() {
+        // dx well past its threshold, |velocity| = 199 (< 200)
+        val consumed = listener().onFling(event(200f), event(0f), -199f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+    }
+
+    @Test
+    fun `null first event is ignored`() {
+        val consumed = listener().onFling(null, event(0f), -400f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+    }
+
+    @Test
+    fun `a null webView aborts before the swipe starts`() {
+        val consumed = listener(webViewProvider = { null }).onFling(event(200f), event(0f), -400f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+    }
+}


### PR DESCRIPTION
## SDK-5977

Follow-up to **SDK-5976** (#1045). **Stacked on top of #1045** — review that first; this PR's base is `feat/html-banner-non-fragment`, so its own diff is just the hardening below.

Closes the parity gaps between the WindowManager overlay banner and the fragment-hosted banner that were called out as follow-ups:

### 1. Activity-lifecycle teardown
`CTInAppHtmlBannerOverlay` now registers `Application.ActivityLifecycleCallbacks` and, when the host Activity is destroyed, removes the overlay and reports the dismiss. Without this the overlay window would leak (`WindowLeaked`) and `currentlyDisplayingInApp` would stay set, wedging the in-app queue. A Fragment gets this for free via its `FragmentManager`.

### 2. External hide (`discardInApps`/suspend)
`CTHtmlBannerCallbacksBridge` implements `InAppDisplayListener` and `InAppController` registers it, so `discardInApps()` / suspend can hide a visible banner — parity with the fragment path's `hideInApp()`.

### 3. Re-entrancy guard
`finishDismiss()` is now one-shot, preventing a double `onBannerRemoved` → double `inAppNotificationDidDismiss` when a rapid second dismiss races the fade's `withEndAction` (or an activity-destroy teardown lands after a user dismiss).

### Tests
- **`InAppControllerTest`**: HTML header/footer dispatch — `FragmentActivity` → fragment; non-`FragmentActivity` → dropped when the flag is off, overlay when on. The default test activity is now a `FragmentActivity` (the normal host for header/footer in-apps).
- **`CTHtmlBannerCallbacksBridgeTest`**: `hideInApp` dismisses the overlay.

Full `clevertap-core` unit suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)