### PR TITLE
fix(SDK-5985): announce HTML banner overlay to TalkBack and share swipe gesture

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
@@ -7,23 +7,19 @@ import android.graphics.PixelFormat
 import android.os.Bundle
 import android.util.TypedValue
 import android.view.GestureDetector
-import android.view.GestureDetector.SimpleOnGestureListener
 import android.view.Gravity
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.WindowManager
-import android.view.animation.AlphaAnimation
-import android.view.animation.Animation
-import android.view.animation.AnimationSet
-import android.view.animation.TranslateAnimation
 import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
 import com.clevertap.android.sdk.CTWebInterface
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.CleverTapInstanceConfig
+import com.clevertap.android.sdk.R
 import com.clevertap.android.sdk.task.MainLooperHandler
 import java.lang.ref.WeakReference
-import kotlin.math.abs
 
 /**
  * Renders *custom-html* "header" and "footer" [CTInAppNotification]s in a [WindowManager] overlay,
@@ -64,9 +60,6 @@ internal class CTInAppHtmlBannerOverlay(
     }
 
     companion object {
-        private const val SWIPE_MIN_DISTANCE = 120
-        private const val SWIPE_THRESHOLD_VELOCITY = 200
-
         fun canDisplay(type: CTInAppType?): Boolean {
             return type == CTInAppType.CTInAppTypeFooterHTML || type == CTInAppType.CTInAppTypeHeaderHTML
         }
@@ -75,7 +68,14 @@ internal class CTInAppHtmlBannerOverlay(
     private val activityWeakRef = WeakReference(activity)
     private val isJsEnabled = notification.isJsEnabled
     private val mainHandler = MainLooperHandler()
-    private val gd = GestureDetector(activity, GestureListener())
+    private val gestureListener = PartialHtmlInAppGestureListener(
+        scaledPixels = ::getScaledPixels,
+        // Mark dismissing so the follow-up dismiss() from the close action removes immediately
+        // instead of re-animating.
+        onSwipeStart = { animatingDismiss = true },
+        onSwipeDismiss = { host.onBannerSwipeDismissed() }
+    )
+    private val gd = GestureDetector(activity, gestureListener)
 
     private var wm: WindowManager? = null
     private var overlayRoot: View? = null
@@ -121,6 +121,7 @@ internal class CTInAppHtmlBannerOverlay(
                 notification.aspectRatio
             )
             this.webView = webView
+            gestureListener.webView = webView
             webView.setWebViewClient(InAppWebViewClient(host))
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no
             // close button, matching CTInAppBasePartialHtmlFragment.
@@ -160,6 +161,11 @@ internal class CTInAppHtmlBannerOverlay(
             wmlp.token = activity.window.decorView.windowToken // tie to this activity
             wm = activity.windowManager
             wm?.addView(root, wmlp)
+
+            // Announce the banner to accessibility services (parity with CTInAppBaseFragment).
+            ViewCompat.setAccessibilityPaneTitle(
+                root, activity.getString(R.string.ct_inapp_message_shown)
+            )
 
             // Tear down the overlay if the host Activity is destroyed, so the window is not leaked
             // and the in-app display queue is not left wedged (a Fragment gets this for free).
@@ -278,55 +284,6 @@ internal class CTInAppHtmlBannerOverlay(
             Gravity.BOTTOM
         } else {
             Gravity.TOP
-        }
-    }
-
-    private inner class GestureListener : SimpleOnGestureListener() {
-        override fun onFling(
-            e1: MotionEvent?,
-            e2: MotionEvent,
-            velocityX: Float,
-            velocityY: Float
-        ): Boolean {
-            if (e1 != null) {
-                if (e1.x - e2.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Right to left
-                    return remove(false)
-                } else if (e2.x - e1.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Left to right
-                    return remove(true)
-                }
-            }
-            return false
-        }
-
-        private fun remove(ltr: Boolean): Boolean {
-            val webView = webView ?: return false
-            // Mark dismissing so the follow-up dismiss() from the close action removes immediately
-            // instead of re-animating.
-            animatingDismiss = true
-            val animSet = AnimationSet(true)
-            val anim = if (ltr) {
-                TranslateAnimation(0f, getScaledPixels(50).toFloat(), 0f, 0f)
-            } else {
-                TranslateAnimation(0f, -getScaledPixels(50).toFloat(), 0f, 0f)
-            }
-            animSet.addAnimation(anim)
-            animSet.addAnimation(AlphaAnimation(1f, 0f))
-            animSet.duration = 300
-            animSet.fillAfter = true
-            animSet.isFillEnabled = true
-            animSet.setAnimationListener(object : Animation.AnimationListener {
-                override fun onAnimationEnd(animation: Animation?) {
-                    host.onBannerSwipeDismissed()
-                }
-
-                override fun onAnimationRepeat(animation: Animation?) {}
-
-                override fun onAnimationStart(animation: Animation?) {}
-            })
-            webView.startAnimation(animSet)
-            return true
         }
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/CTInAppHtmlBannerOverlay.kt
@@ -69,6 +69,7 @@ internal class CTInAppHtmlBannerOverlay(
     private val isJsEnabled = notification.isJsEnabled
     private val mainHandler = MainLooperHandler()
     private val gestureListener = PartialHtmlInAppGestureListener(
+        webViewProvider = { webView },
         scaledPixels = ::getScaledPixels,
         // Mark dismissing so the follow-up dismiss() from the close action removes immediately
         // instead of re-animating.
@@ -121,7 +122,6 @@ internal class CTInAppHtmlBannerOverlay(
                 notification.aspectRatio
             )
             this.webView = webView
-            gestureListener.webView = webView
             webView.setWebViewClient(InAppWebViewClient(host))
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no
             // close button, matching CTInAppBasePartialHtmlFragment.

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
@@ -13,17 +13,20 @@ import kotlin.math.abs
  * fragment-hosted [com.clevertap.android.sdk.inapp.fragment.CTInAppBasePartialHtmlFragment] and the
  * non-fragment [CTInAppHtmlBannerOverlay].
  *
- * On a horizontal fling it slides + fades the [webView] out, then invokes [onSwipeDismiss].
+ * On a horizontal fling it slides + fades the current WebView out, then invokes [onSwipeDismiss].
  * [onSwipeStart] runs when the dismiss animation begins — the overlay uses it to coordinate its own
  * removal animation. [scaledPixels] converts dp to px in the host's context.
+ *
+ * The target is read through [webViewProvider] rather than held as state, so it always reflects the
+ * host's live field (and becomes null once the host cleans up) — no stale reference to a destroyed
+ * WebView.
  */
 internal class PartialHtmlInAppGestureListener(
+    private val webViewProvider: () -> CTInAppWebView?,
     private val scaledPixels: (Int) -> Int,
     private val onSwipeStart: () -> Unit = {},
     private val onSwipeDismiss: () -> Unit
 ) : SimpleOnGestureListener() {
-
-    var webView: CTInAppWebView? = null
 
     override fun onFling(
         e1: MotionEvent?,
@@ -44,7 +47,7 @@ internal class PartialHtmlInAppGestureListener(
     }
 
     private fun remove(ltr: Boolean): Boolean {
-        val webView = webView ?: return false
+        val webView = webViewProvider() ?: return false
         onSwipeStart()
         val animSet = AnimationSet(true)
         val anim = if (ltr) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListener.kt
@@ -1,0 +1,77 @@
+package com.clevertap.android.sdk.inapp
+
+import android.view.GestureDetector.SimpleOnGestureListener
+import android.view.MotionEvent
+import android.view.animation.AlphaAnimation
+import android.view.animation.Animation
+import android.view.animation.AnimationSet
+import android.view.animation.TranslateAnimation
+import kotlin.math.abs
+
+/**
+ * Shared swipe-to-dismiss gesture for partial (header/footer) HTML in-apps, used by both the
+ * fragment-hosted [com.clevertap.android.sdk.inapp.fragment.CTInAppBasePartialHtmlFragment] and the
+ * non-fragment [CTInAppHtmlBannerOverlay].
+ *
+ * On a horizontal fling it slides + fades the [webView] out, then invokes [onSwipeDismiss].
+ * [onSwipeStart] runs when the dismiss animation begins — the overlay uses it to coordinate its own
+ * removal animation. [scaledPixels] converts dp to px in the host's context.
+ */
+internal class PartialHtmlInAppGestureListener(
+    private val scaledPixels: (Int) -> Int,
+    private val onSwipeStart: () -> Unit = {},
+    private val onSwipeDismiss: () -> Unit
+) : SimpleOnGestureListener() {
+
+    var webView: CTInAppWebView? = null
+
+    override fun onFling(
+        e1: MotionEvent?,
+        e2: MotionEvent,
+        velocityX: Float,
+        velocityY: Float
+    ): Boolean {
+        if (e1 != null) {
+            if (e1.x - e2.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
+                // Right to left
+                return remove(false)
+            } else if (e2.x - e1.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
+                // Left to right
+                return remove(true)
+            }
+        }
+        return false
+    }
+
+    private fun remove(ltr: Boolean): Boolean {
+        val webView = webView ?: return false
+        onSwipeStart()
+        val animSet = AnimationSet(true)
+        val anim = if (ltr) {
+            TranslateAnimation(0f, scaledPixels(50).toFloat(), 0f, 0f)
+        } else {
+            TranslateAnimation(0f, -scaledPixels(50).toFloat(), 0f, 0f)
+        }
+        animSet.addAnimation(anim)
+        animSet.addAnimation(AlphaAnimation(1f, 0f))
+        animSet.duration = 300
+        animSet.fillAfter = true
+        animSet.isFillEnabled = true
+        animSet.setAnimationListener(object : Animation.AnimationListener {
+            override fun onAnimationEnd(animation: Animation?) {
+                onSwipeDismiss()
+            }
+
+            override fun onAnimationRepeat(animation: Animation?) {}
+
+            override fun onAnimationStart(animation: Animation?) {}
+        })
+        webView.startAnimation(animSet)
+        return true
+    }
+
+    companion object {
+        const val SWIPE_MIN_DISTANCE = 120
+        const val SWIPE_THRESHOLD_VELOCITY = 200
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -5,75 +5,24 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.GestureDetector
-import android.view.GestureDetector.SimpleOnGestureListener
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.View.OnLongClickListener
 import android.view.View.OnTouchListener
 import android.view.ViewGroup
-import android.view.animation.AlphaAnimation
-import android.view.animation.Animation
-import android.view.animation.AnimationSet
-import android.view.animation.TranslateAnimation
 import com.clevertap.android.sdk.CTWebInterface
 import com.clevertap.android.sdk.CleverTapAPI
 import com.clevertap.android.sdk.inapp.CTInAppWebView
 import com.clevertap.android.sdk.inapp.InAppWebViewClient
-import kotlin.math.abs
+import com.clevertap.android.sdk.inapp.PartialHtmlInAppGestureListener
 
 internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragment(),
     OnTouchListener,
     OnLongClickListener {
 
-    private inner class GestureListener : SimpleOnGestureListener() {
-        override fun onFling(
-            e1: MotionEvent?,
-            e2: MotionEvent,
-            velocityX: Float,
-            velocityY: Float
-        ): Boolean {
-            if (e1 != null) {
-                if (e1.x - e2.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Right to left
-                    return remove(false)
-                } else if (e2.x - e1.x > SWIPE_MIN_DISTANCE && abs(velocityX.toDouble()) > SWIPE_THRESHOLD_VELOCITY) {
-                    // Left to right
-                    return remove(true)
-                }
-            }
-            return false
-        }
-
-        fun remove(ltr: Boolean): Boolean {
-            val animSet = AnimationSet(true)
-            val anim = if (ltr) {
-                TranslateAnimation(0f, getScaledPixels(50).toFloat(), 0f, 0f)
-            } else {
-                TranslateAnimation(0f, -getScaledPixels(50).toFloat(), 0f, 0f)
-            }
-            animSet.addAnimation(anim)
-            animSet.addAnimation(AlphaAnimation(1f, 0f))
-            animSet.setDuration(300)
-            animSet.setFillAfter(true)
-            animSet.isFillEnabled = true
-            animSet.setAnimationListener(object : Animation.AnimationListener {
-                override fun onAnimationEnd(animation: Animation?) {
-                    triggerSwipeDismissAction()
-                }
-
-                override fun onAnimationRepeat(animation: Animation?) {
-                }
-
-                override fun onAnimationStart(animation: Animation?) {
-                }
-            })
-            webView?.startAnimation(animSet)
-            return true
-        }
-    }
-
     private lateinit var gd: GestureDetector
+    private lateinit var gestureListener: PartialHtmlInAppGestureListener
 
     private var webView: CTInAppWebView? = null
 
@@ -84,7 +33,11 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        gd = GestureDetector(context, GestureListener())
+        gestureListener = PartialHtmlInAppGestureListener(
+            scaledPixels = ::getScaledPixels,
+            onSwipeDismiss = ::triggerSwipeDismissAction
+        )
+        gd = GestureDetector(context, gestureListener)
     }
 
     override fun onCreateView(
@@ -141,6 +94,7 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
                 inAppNotification.aspectRatio
             )
             this.webView = webView
+            gestureListener.webView = webView
             val webViewClient = InAppWebViewClient(this)
             webView.setWebViewClient(webViewClient)
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no close
@@ -169,10 +123,5 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
         webView.updateDimension()
         val html = inAppNotification.html ?: return
         webView.loadInAppHtml(html)
-    }
-
-    companion object {
-        private const val SWIPE_MIN_DISTANCE = 120
-        private const val SWIPE_THRESHOLD_VELOCITY = 200
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -22,7 +22,6 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
     OnLongClickListener {
 
     private lateinit var gd: GestureDetector
-    private lateinit var gestureListener: PartialHtmlInAppGestureListener
 
     private var webView: CTInAppWebView? = null
 
@@ -33,7 +32,7 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        gestureListener = PartialHtmlInAppGestureListener(
+        val gestureListener = PartialHtmlInAppGestureListener(
             webViewProvider = { webView },
             scaledPixels = ::getScaledPixels,
             onSwipeDismiss = ::triggerSwipeDismissAction

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/fragment/CTInAppBasePartialHtmlFragment.kt
@@ -34,6 +34,7 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
     override fun onAttach(context: Context) {
         super.onAttach(context)
         gestureListener = PartialHtmlInAppGestureListener(
+            webViewProvider = { webView },
             scaledPixels = ::getScaledPixels,
             onSwipeDismiss = ::triggerSwipeDismissAction
         )
@@ -94,7 +95,6 @@ internal abstract class CTInAppBasePartialHtmlFragment : CTInAppBasePartialFragm
                 inAppNotification.aspectRatio
             )
             this.webView = webView
-            gestureListener.webView = webView
             val webViewClient = InAppWebViewClient(this)
             webView.setWebViewClient(webViewClient)
             // Attach the swipe/pan gesture only when swipe-to-dismiss is enabled and there is no close

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
@@ -1,8 +1,12 @@
 package com.clevertap.android.sdk.inapp
 
 import android.view.MotionEvent
+import android.view.animation.Animation
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -74,5 +78,35 @@ class PartialHtmlInAppGestureListenerTest {
 
         assertFalse(consumed)
         assertEquals(0, swipeStartCount)
+    }
+
+    @Test
+    fun `swipe dismiss fires at animation end, strictly after swipe start`() {
+        val order = mutableListOf<String>()
+        val gestureListener = PartialHtmlInAppGestureListener(
+            webViewProvider = { webView },
+            scaledPixels = { it },
+            onSwipeStart = { order += "start" },
+            onSwipeDismiss = { order += "dismiss" }
+        )
+        val animSlot = slot<Animation>()
+        every { webView.startAnimation(capture(animSlot)) } just runs
+
+        val consumed = gestureListener.onFling(event(200f), event(0f), -201f, 0f)
+
+        // onSwipeStart ran synchronously; onSwipeDismiss has NOT fired yet.
+        assertTrue(consumed)
+        assertEquals(listOf("start"), order)
+
+        // Drive the captured animation to completion -> onSwipeDismiss fires, strictly after start.
+        animationListenerOf(animSlot.captured).onAnimationEnd(animSlot.captured)
+        assertEquals(listOf("start", "dismiss"), order)
+    }
+
+    /** Reads the [Animation.AnimationListener] the gesture attached to its [AnimationSet]. */
+    private fun animationListenerOf(animation: Animation): Animation.AnimationListener {
+        val field = Animation::class.java.getDeclaredField("mListener")
+        field.isAccessible = true
+        return field.get(animation) as Animation.AnimationListener
     }
 }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PartialHtmlInAppGestureListenerTest.kt
@@ -1,0 +1,78 @@
+package com.clevertap.android.sdk.inapp
+
+import android.view.MotionEvent
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PartialHtmlInAppGestureListenerTest {
+
+    private val webView = mockk<CTInAppWebView>(relaxed = true)
+    private var swipeStartCount = 0
+    private var swipeDismissCount = 0
+
+    private fun listener(
+        webViewProvider: () -> CTInAppWebView? = { webView }
+    ) = PartialHtmlInAppGestureListener(
+        webViewProvider = webViewProvider,
+        scaledPixels = { it },
+        onSwipeStart = { swipeStartCount++ },
+        onSwipeDismiss = { swipeDismissCount++ }
+    )
+
+    private fun event(x: Float) = mockk<MotionEvent>(relaxed = true).also { every { it.x } returns x }
+
+    @Test
+    fun `horizontal fling beyond both thresholds starts the swipe dismiss`() {
+        // dx = 200 (> 120), |velocity| = 201 (> 200)
+        val consumed = listener().onFling(event(200f), event(0f), -201f, 0f)
+
+        assertTrue(consumed)
+        assertEquals(1, swipeStartCount)
+        verify(exactly = 1) { webView.startAnimation(any()) }
+        // onSwipeDismiss fires only at animation end, not synchronously.
+        assertEquals(0, swipeDismissCount)
+    }
+
+    @Test
+    fun `fling below the distance threshold is ignored`() {
+        // dx = 119 (< 120), velocity well past its threshold
+        val consumed = listener().onFling(event(119f), event(0f), -400f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+        verify(exactly = 0) { webView.startAnimation(any()) }
+    }
+
+    @Test
+    fun `fling below the velocity threshold is ignored`() {
+        // dx well past its threshold, |velocity| = 199 (< 200)
+        val consumed = listener().onFling(event(200f), event(0f), -199f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+    }
+
+    @Test
+    fun `null first event is ignored`() {
+        val consumed = listener().onFling(null, event(0f), -400f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+    }
+
+    @Test
+    fun `a null webView aborts before the swipe starts`() {
+        val consumed = listener(webViewProvider = { null }).onFling(event(200f), event(0f), -400f, 0f)
+
+        assertFalse(consumed)
+        assertEquals(0, swipeStartCount)
+    }
+}


### PR DESCRIPTION
## SDK-5985

Quick-win follow-ups to **SDK-5976** (#1045) and **SDK-5977** (#1046). **Stacked on #1046** — its base is `feat/html-banner-hardening`, so this PR's own diff is just the two changes below.

### 1. Accessibility (TalkBack parity)
The fragment path announces every in-app via `ViewCompat.setAccessibilityPaneTitle(...)`; the overlay didn't. `CTInAppHtmlBannerOverlay` now sets the pane title (`R.string.ct_inapp_message_shown`) on the overlay root after it's attached, so screen readers announce the banner when it appears.

### 2. De-duplicate the swipe gesture
Extracts the swipe-to-dismiss gesture — fling detection, the slide+fade `AnimationSet`, and the `SWIPE_MIN_DISTANCE`/`SWIPE_THRESHOLD_VELOCITY` constants — into a shared **`PartialHtmlInAppGestureListener`**, now used by **both** `CTInAppHtmlBannerOverlay` and `CTInAppBasePartialHtmlFragment` (mirrors the extraction in the original PR #841). It's parameterized so each host keeps its own behavior: the overlay passes `onSwipeStart` to set its `animatingDismiss` flag and `onSwipeDismiss = host.onBannerSwipeDismissed()`; the fragment passes `onSwipeDismiss = ::triggerSwipeDismissAction`. Net **−94 lines** of duplicated animation code.

### Validation
Compiles; `inapp.fragment.*`, `InAppControllerTest`, bridge/parser/web-interface suites pass; detekt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)