### PR TITLE
[SDK-5983] InApp: add dismissPipInApp() public API to dismiss the visible PIP in-app

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -3148,6 +3148,29 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
         }
     }
 
+    /**
+     * Dismisses the currently visible Picture-in-Picture (PIP) InApp Notification, if any.
+     * <p>
+     * This is a no-op when no PIP is visible. Other InApp Notification types are never
+     * affected. Safe to call from any thread.
+     * <p>
+     * Note: dismissing releases the in-app display slot, so the next queued InApp (if any)
+     * may show immediately. To keep the screen free of all in-apps, pair this with
+     * {@link #suspendInAppNotifications()} on screen entry and
+     * {@link #resumeInAppNotifications()} on exit.
+     *
+     * @noinspection unused
+     */
+    public void dismissPipInApp() {
+        if (!coreState.getConfig().isAnalyticsOnly()) {
+            getConfigLogger().debug(getAccountId(), "Dismissing PIP InApp Notification if visible...");
+            coreState.getInAppController().dismissPipInApp();
+        } else {
+            getConfigLogger().debug(getAccountId(),
+                    "CleverTap instance is set for Analytics only! Cannot dismiss PIP InApp Notification.");
+        }
+    }
+
     /** @noinspection unused*/
     @RestrictTo(Scope.LIBRARY_GROUP)
     public int getCustomSdkVersion(String customSdkName) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -206,6 +206,15 @@ public interface Constants {
     String INAPP_IMAGE_LOAD_FAILED_ERROR_MSG = "InApp image failed to load";
     String INAPP_VIDEO_LOAD_FAILED_ERROR_MSG = "InApp video failed to load";
 
+    // wzrk_error codes/messages for PIP media failures (all URLs failed, PIP never showed).
+    // One code per PIP media type, keyed by the campaign's primary media type.
+    int INAPP_PIP_IMAGE_LOAD_FAILED_ERROR_CODE = 593;
+    int INAPP_PIP_VIDEO_LOAD_FAILED_ERROR_CODE = 594;
+    int INAPP_PIP_GIF_LOAD_FAILED_ERROR_CODE = 595;
+    String INAPP_PIP_IMAGE_LOAD_FAILED_ERROR_MSG = "InApp PIP image failed to load";
+    String INAPP_PIP_VIDEO_LOAD_FAILED_ERROR_MSG = "InApp PIP video failed to load";
+    String INAPP_PIP_GIF_LOAD_FAILED_ERROR_MSG = "InApp PIP GIF failed to load";
+
     String KEY_EFC = "efc";
     String KEY_EXCLUDE_GLOBAL_CAPS = "excludeGlobalFCaps";
     String KEY_TLC = "tlc";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -538,6 +538,15 @@ internal class InAppController(
         logger.verbose(defaultLogTag, "InAppState is SUSPENDED")
     }
 
+    /**
+     * Dismisses the currently visible PIP in-app, if any. Safe to call from any thread.
+     * No-op when no PIP is showing — other in-app types are never affected.
+     */
+    fun dismissPipInApp() {
+        logger.verbose(defaultLogTag, "dismissPipInApp() called by app")
+        pipManager.dismiss()
+    }
+
     @WorkerThread
     fun addInAppNotificationsToQueue(inappNotifs: List<JSONObject>) {
         try {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -54,6 +54,7 @@ import com.clevertap.android.sdk.inapp.fragment.CTInAppNativeFooterFragment
 import com.clevertap.android.sdk.inapp.fragment.CTInAppNativeHeaderFragment
 import com.clevertap.android.sdk.inapp.images.FileResourceProvider
 import com.clevertap.android.sdk.inapp.pipsdk.PIPManager
+import com.clevertap.android.sdk.inapp.pipsdk.PIPMediaType
 import com.clevertap.android.sdk.network.NetworkMonitor
 import com.clevertap.android.sdk.task.CTExecutors
 import com.clevertap.android.sdk.utils.Clock
@@ -869,8 +870,9 @@ internal class InAppController(
         }
     }
 
-    override fun onPIPShowFailed(inAppNotification: CTInAppNotification) {
+    override fun onPIPShowFailed(inAppNotification: CTInAppNotification, mediaType: PIPMediaType) {
         logger.verbose(defaultLogTag, "PIP failed to show: ${inAppNotification.campaignId}")
+        reportPipMediaError(mediaType)
         // Same threading pattern as inAppNotificationDidDismiss: clear the lock and advance
         // the queue atomically on the async in-app thread. This avoids a race where
         // currentlyDisplayingInApp is cleared on main but _showNotificationIfAvailable
@@ -880,6 +882,33 @@ internal class InAppController(
             inAppDidDismiss(inAppNotification)
             _showNotificationIfAvailable()
         }
+    }
+
+    /**
+     * Reports a PIP all-media-failed as a structured [ValidationResult] on the validation stack,
+     * riding out as top-level `wzrk_error` on the next queued event — mirroring how the bundled
+     * advanced-builder HTML template reports its media failures. No click or viewed event is
+     * raised: the PIP never showed. One distinct code per PIP media type.
+     */
+    private fun reportPipMediaError(mediaType: PIPMediaType) {
+        val validationResult = when (mediaType) {
+            PIPMediaType.IMAGE -> ValidationResult(
+                Constants.INAPP_PIP_IMAGE_LOAD_FAILED_ERROR_CODE,
+                Constants.INAPP_PIP_IMAGE_LOAD_FAILED_ERROR_MSG
+            )
+
+            PIPMediaType.VIDEO -> ValidationResult(
+                Constants.INAPP_PIP_VIDEO_LOAD_FAILED_ERROR_CODE,
+                Constants.INAPP_PIP_VIDEO_LOAD_FAILED_ERROR_MSG
+            )
+
+            PIPMediaType.GIF -> ValidationResult(
+                Constants.INAPP_PIP_GIF_LOAD_FAILED_ERROR_CODE,
+                Constants.INAPP_PIP_GIF_LOAD_FAILED_ERROR_MSG
+            )
+        }
+        logger.debug("PIP media failed to load, reporting wzrk_error ${validationResult.errorCode}")
+        validationResultStack.pushValidationResult(validationResult)
     }
 
     private fun incrementLocalInAppCountInPersistentStore(

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PIPInAppCallbacksBridge.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PIPInAppCallbacksBridge.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.ILogger
 import com.clevertap.android.sdk.inapp.pipsdk.PIPCallbacks
+import com.clevertap.android.sdk.inapp.pipsdk.PIPMediaType
 
 internal class PIPInAppCallbacksBridge(
     private val inAppNotification: CTInAppNotification,
@@ -106,8 +107,8 @@ internal class PIPInAppCallbacksBridge(
         logger.debug(LOG_TAG, "PIP onMediaError for campaign: ${inAppNotification.campaignId}, url: $url, error: $error")
     }
 
-    override fun onShowFailed() {
-        logger.debug(LOG_TAG, "PIP onShowFailed for campaign: ${inAppNotification.campaignId}")
-        showFailureHandler.onPIPShowFailed(inAppNotification)
+    override fun onShowFailed(mediaType: PIPMediaType) {
+        logger.debug(LOG_TAG, "PIP onShowFailed for campaign: ${inAppNotification.campaignId}, mediaType: $mediaType")
+        showFailureHandler.onPIPShowFailed(inAppNotification, mediaType)
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PIPShowFailureHandler.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/PIPShowFailureHandler.kt
@@ -1,12 +1,15 @@
 package com.clevertap.android.sdk.inapp
 
+import com.clevertap.android.sdk.inapp.pipsdk.PIPMediaType
+
 /**
- * Handles PIP show failure — clears the in-app display lock and advances the queue.
+ * Handles PIP show failure — reports the media failure as a `wzrk_error`, clears the
+ * in-app display lock, and advances the queue.
  *
  * Separated from [InAppListener] so that
  * [com.clevertap.android.sdk.InAppNotificationActivity] (which only hosts standard
  * in-app fragments) is not forced to implement PIP-specific callbacks.
  */
 internal fun interface PIPShowFailureHandler {
-    fun onPIPShowFailed(inAppNotification: CTInAppNotification)
+    fun onPIPShowFailed(inAppNotification: CTInAppNotification, mediaType: PIPMediaType)
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/PIPCallbacks.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/PIPCallbacks.kt
@@ -21,6 +21,8 @@ interface PIPCallbacks {
     fun onMediaError(url: String, error: String) {}
 
     /** Called when PIP failed to show because all media URLs failed to load.
-     *  PIP was never visible — no [onShow] or [onClose] will fire for this session. */
-    fun onShowFailed() {}
+     *  PIP was never visible — no [onShow] or [onClose] will fire for this session.
+     *  @param mediaType the session's primary media type — the campaign's intent, even when
+     *  a fallback of a different kind also failed. */
+    fun onShowFailed(mediaType: PIPMediaType) {}
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/PIPManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/pipsdk/PIPManager.kt
@@ -165,7 +165,7 @@ internal class PIPManager(
                 }
                 DismissReason.Dismiss,
                 DismissReason.SessionCleanup -> s.config.callbacks?.onClose()
-                DismissReason.ShowFailed -> s.config.callbacks?.onShowFailed()
+                DismissReason.ShowFailed -> s.config.callbacks?.onShowFailed(s.config.mediaType)
                 DismissReason.Replaced -> {}
             }
         }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
@@ -25,6 +25,7 @@ import com.clevertap.android.sdk.inapp.delay.InActionResult
 import com.clevertap.android.sdk.inapp.delay.InAppScheduler
 import com.clevertap.android.sdk.inapp.evaluation.EvaluationManager
 import com.clevertap.android.sdk.inapp.fragment.CTInAppBaseFragment
+import com.clevertap.android.sdk.inapp.pipsdk.PIPManager
 import com.clevertap.android.sdk.network.NetworkMonitor
 import com.clevertap.android.sdk.validation.ValidationResult
 import com.clevertap.android.sdk.validation.ValidationResultStack
@@ -1002,7 +1003,9 @@ class InAppControllerTest {
     }
 
 
-    private fun createInAppController(): InAppController {
+    private fun createInAppController(
+        pipManager: PIPManager = mockk(relaxed = true)
+    ): InAppController {
         return InAppController(
             context = mockk(relaxed = true),
             config = mockConfig,
@@ -1022,9 +1025,19 @@ class InAppControllerTest {
             inAppInActionManager = mockInAppInActionManager,
             networkMonitor = mockNetworkMonitor,
             clock = fakeClock,
-            pipManager = mockk(relaxed = true),
+            pipManager = pipManager,
             validationResultStack = mockValidationResultStack,
         )
+    }
+
+    @Test
+    fun `dismissPipInApp delegates to pipManager dismiss`() {
+        val mockPipManager = mockk<PIPManager>(relaxed = true)
+        val inAppController = createInAppController(pipManager = mockPipManager)
+
+        inAppController.dismissPipInApp()
+
+        verify(exactly = 1) { mockPipManager.dismiss() }
     }
 
     // Deep Link Attribution Tests

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
@@ -26,6 +26,7 @@ import com.clevertap.android.sdk.inapp.delay.InAppScheduler
 import com.clevertap.android.sdk.inapp.evaluation.EvaluationManager
 import com.clevertap.android.sdk.inapp.fragment.CTInAppBaseFragment
 import com.clevertap.android.sdk.inapp.pipsdk.PIPManager
+import com.clevertap.android.sdk.inapp.pipsdk.PIPMediaType
 import com.clevertap.android.sdk.network.NetworkMonitor
 import com.clevertap.android.sdk.validation.ValidationResult
 import com.clevertap.android.sdk.validation.ValidationResultStack
@@ -1038,6 +1039,57 @@ class InAppControllerTest {
         inAppController.dismissPipInApp()
 
         verify(exactly = 1) { mockPipManager.dismiss() }
+    }
+
+    @Test
+    fun `onPIPShowFailed with VIDEO pushes the PIP video error onto the validation stack`() {
+        val inAppController = createInAppController()
+        val notification = mockk<CTInAppNotification>(relaxed = true) {
+            every { campaignId } returns "pip_campaign"
+        }
+
+        inAppController.onPIPShowFailed(notification, PIPMediaType.VIDEO)
+
+        verify(exactly = 1) {
+            mockValidationResultStack.pushValidationResult(match<ValidationResult> {
+                it.errorCode == Constants.INAPP_PIP_VIDEO_LOAD_FAILED_ERROR_CODE &&
+                        it.errorDesc == Constants.INAPP_PIP_VIDEO_LOAD_FAILED_ERROR_MSG
+            })
+        }
+    }
+
+    @Test
+    fun `onPIPShowFailed with IMAGE pushes the PIP image error onto the validation stack`() {
+        val inAppController = createInAppController()
+        val notification = mockk<CTInAppNotification>(relaxed = true) {
+            every { campaignId } returns "pip_campaign"
+        }
+
+        inAppController.onPIPShowFailed(notification, PIPMediaType.IMAGE)
+
+        verify(exactly = 1) {
+            mockValidationResultStack.pushValidationResult(match<ValidationResult> {
+                it.errorCode == Constants.INAPP_PIP_IMAGE_LOAD_FAILED_ERROR_CODE &&
+                        it.errorDesc == Constants.INAPP_PIP_IMAGE_LOAD_FAILED_ERROR_MSG
+            })
+        }
+    }
+
+    @Test
+    fun `onPIPShowFailed with GIF pushes the PIP GIF error onto the validation stack`() {
+        val inAppController = createInAppController()
+        val notification = mockk<CTInAppNotification>(relaxed = true) {
+            every { campaignId } returns "pip_campaign"
+        }
+
+        inAppController.onPIPShowFailed(notification, PIPMediaType.GIF)
+
+        verify(exactly = 1) {
+            mockValidationResultStack.pushValidationResult(match<ValidationResult> {
+                it.errorCode == Constants.INAPP_PIP_GIF_LOAD_FAILED_ERROR_CODE &&
+                        it.errorDesc == Constants.INAPP_PIP_GIF_LOAD_FAILED_ERROR_MSG
+            })
+        }
     }
 
     // Deep Link Attribution Tests

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PIPInAppCallbacksBridgeTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/PIPInAppCallbacksBridgeTest.kt
@@ -2,6 +2,7 @@ package com.clevertap.android.sdk.inapp
 
 import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.TestLogger
+import com.clevertap.android.sdk.inapp.pipsdk.PIPMediaType
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -116,6 +117,28 @@ class PIPInAppCallbacksBridgeTest {
         val bridge = PIPInAppCallbacksBridge(notification, mockListener, mockShowFailureHandler, logger)
         bridge.onCloseButtonClick()
         verify(exactly = 0) { mockListener.inAppNotificationDidDismiss(any(), any()) }
+    }
+
+    @Test
+    fun `onShowFailed forwards the notification and media type to the failure handler`() {
+        val notification = mockk<CTInAppNotification> {
+            every { campaignId } returns "test_campaign_123"
+        }
+        val bridge = PIPInAppCallbacksBridge(notification, mockListener, mockShowFailureHandler, logger)
+        bridge.onShowFailed(PIPMediaType.VIDEO)
+        verify(exactly = 1) { mockShowFailureHandler.onPIPShowFailed(notification, PIPMediaType.VIDEO) }
+    }
+
+    @Test
+    fun `onShowFailed does not report a show or a dismiss (PIP was never visible)`() {
+        val notification = mockk<CTInAppNotification> {
+            every { campaignId } returns "test_campaign_123"
+        }
+        val bridge = PIPInAppCallbacksBridge(notification, mockListener, mockShowFailureHandler, logger)
+        bridge.onShowFailed(PIPMediaType.IMAGE)
+        verify(exactly = 0) { mockListener.inAppNotificationDidShow(any(), any()) }
+        verify(exactly = 0) { mockListener.inAppNotificationDidDismiss(any(), any()) }
+        verify(exactly = 0) { mockListener.inAppNotificationActionTriggered(any(), any(), any(), any(), any()) }
     }
 
     // ─── Callbacks that only log (do not forward to InAppListener) ────────────────


### PR DESCRIPTION
Adds a public `CleverTapAPI.dismissPipInApp()` API that dismisses the currently visible Picture-in-Picture (PIP) in-app notification.

- No-op when no PIP is visible; other in-app types are never affected. Safe to call from any thread.
- Guarded for analytics-only instances.
- Delegates through `InAppController.dismissPipInApp()` to the PIP manager; unit tests included.

Jira: [SDK-5983](https://wizrocket.atlassian.net/browse/SDK-5983)


[SDK-5983]: https://wizrocket.atlassian.net/browse/SDK-5983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ