### PR TITLE
docs changes and version bump SDK-5981

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## CHANGE LOG.
+### August 7, 2026
+* [CleverTap Android SDK v8.4.1](docs/CTCORECHANGELOG.md).
+
 ### July 28, 2026
 * [CleverTap Android SDK v8.4.0](docs/CTCORECHANGELOG.md).
 * [CleverTap Push Templates SDK v2.5.0](docs/CTPUSHTEMPLATESCHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We publish the SDK to `mavenCentral` as an `AAR` file. Just declare it as depend
 
 ```groovy
     dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:8.4.0"
+         implementation "com.clevertap.android:clevertap-android-sdk:8.4.1"
     }
 ```
 
@@ -34,7 +34,7 @@ Alternatively, you can download and add the AAR file included in this repo in yo
     
  ```groovy
     dependencies {      
-        implementation (name: "clevertap-android-sdk-8.4.0", ext: 'aar')
+        implementation (name: "clevertap-android-sdk-8.4.1", ext: 'aar')
     }
 ```
 
@@ -46,7 +46,7 @@ Add the Firebase Messaging library and Android Support Library v4 as dependencie
 
 ```groovy
      dependencies {      
-         implementation "com.clevertap.android:clevertap-android-sdk:8.4.0"
+         implementation "com.clevertap.android:clevertap-android-sdk:8.4.1"
          implementation "androidx.core:core:1.13.0"
          implementation "com.google.firebase:firebase-messaging:24.0.0"
          implementation "com.google.android.gms:play-services-ads:23.6.0" // Required only if you enable Google ADID collection in the SDK (turned off by default).

--- a/docs/CTCORECHANGELOG.md
+++ b/docs/CTCORECHANGELOG.md
@@ -1,4 +1,25 @@
 ## CleverTap Android SDK CHANGE LOG
+### Version 8.4.1 (August 7, 2026)
+
+#### New Features
+* **Spin-the-Wheel and Scratch Card Templates:** Adds Spin-the-Wheel and Scratch Card gamified
+  template support to Advanced InApp Builder in-app notifications.
+* **Dismiss PIP In-App API:** New `dismissPipInApp()` method on `CleverTapAPI` dismisses the
+  currently visible Picture-in-Picture (PIP) In-App notification. Safe to call from any thread;
+  a no-op when no PIP is visible, and other in-app types are never affected.
+    * **Note:** Dismissing frees the in-app display slot, so the next queued in-app (if any) may
+      show immediately. To keep a screen free of all in-apps, pair this with
+      `suspendInAppNotifications()` on screen entry and `resumeInAppNotifications()` on exit.
+* **HTML Header/Footer In-Apps Without FragmentActivity:** Custom-HTML header and footer in-app
+  notifications can now render when the host Activity is not a `FragmentActivity` — for example
+  Unity or Unreal game engines. Opt-in via the `CLEVERTAP_INAPP_FRAGMENTLESS_BANNERS` manifest
+  flag; default off, so existing integrations are unaffected.
+
+#### Bug Fixes
+* **App Inbox Pull-to-Refresh:** Fixes an issue where the built-in App Inbox did not repaint the
+  message list after a pull-to-refresh — newly fetched messages only appeared after closing and
+  reopening the inbox.
+
 ### Version 8.4.0 (July 28, 2026)
 
 #### New Features

--- a/docs/CTGEOFENCE.md
+++ b/docs/CTGEOFENCE.md
@@ -17,7 +17,7 @@ Add the following dependencies to the `build.gradle`
 
 ```Groovy
 implementation "com.clevertap.android:clevertap-geofence-sdk:1.4.0"
-implementation "com.clevertap.android:clevertap-android-sdk:8.4.0" // 3.9.0 and above
+implementation "com.clevertap.android:clevertap-android-sdk:8.4.1" // 3.9.0 and above
 implementation "com.google.android.gms:play-services-location:21.3.0"
 implementation "androidx.work:work-runtime:2.10.2" // required for FETCH_LAST_LOCATION_PERIODIC
 implementation "androidx.concurrent:concurrent-futures:1.2.0" // required for FETCH_LAST_LOCATION_PERIODIC

--- a/docs/CTPUSHTEMPLATES.md
+++ b/docs/CTPUSHTEMPLATES.md
@@ -21,7 +21,7 @@ CleverTap Push Templates SDK helps you engage with your users using fancy push n
 
 ```groovy
 implementation "com.clevertap.android:push-templates:2.5.0"
-implementation "com.clevertap.android:clevertap-android-sdk:8.4.0" // 4.4.0 and above
+implementation "com.clevertap.android:clevertap-android-sdk:8.4.1" // 4.4.0 and above
 ```
 
 2. Add the following line to your Application class before the `onCreate()`

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -514,6 +514,33 @@ To support in-app notifications, register the following activity in your Android
         android:value="YourSplashActivity1, YourSplashActivity2" />
    ```
 
+#### Dismissing a Picture-in-Picture (PIP) In-App Notification
+
+Use `dismissPipInApp()` to programmatically dismiss the currently visible PIP in-app notification —
+for example when the user navigates to a screen where the floating window would cover important
+content, such as a checkout or video-call screen.
+
+Java
+
+```java
+CleverTapAPI clevertap = CleverTapAPI.getDefaultInstance(getApplicationContext());
+clevertap.dismissPipInApp();
+```
+
+Kotlin
+
+```kotlin
+val clevertap = CleverTapAPI.getDefaultInstance(applicationContext)
+clevertap?.dismissPipInApp()
+```
+
+The call is safe from any thread, is a no-op when no PIP is visible, and never affects other
+in-app notification types.
+
+**Note:** Dismissing frees the in-app display slot, so the next queued in-app (if any) may show
+immediately. To keep a screen free of all in-apps, pair this with `suspendInAppNotifications()`
+on screen entry and `resumeInAppNotifications()` on exit.
+
 #### Push primer Android 13 notification runtime permission.
 
 Using Half-Interstitial in-app

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ lifecycleRuntimeTesting = "2.9.4"
 installreferrer = "2.2"
 
 #SDK Versions
-clevertap_android_sdk = "8.4.0"
+clevertap_android_sdk = "8.4.1"
 clevertap_rendermax_sdk = "1.0.3"
 clevertap_geofence_sdk = "1.4.0"
 clevertap_hms_sdk = "1.5.1"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,8 +22,8 @@ android {
         applicationId "com.clevertap.demo"
         minSdkVersion 23
         targetSdkVersion 36
-        versionCode 8020000
-        versionName "8.2.0"
+        versionCode 8040100
+        versionName "8.4.1"
         multiDexEnabled true
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -179,12 +179,12 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
     implementation "org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.1.1"*/
 
-    remoteImplementation("com.clevertap.android:clevertap-android-sdk:8.4.0")
+    remoteImplementation("com.clevertap.android:clevertap-android-sdk:8.4.1")
     remoteImplementation("com.clevertap.android:clevertap-geofence-sdk:1.4.0")
     remoteImplementation("com.clevertap.android:push-templates:2.5.0")
     remoteImplementation("com.clevertap.android:clevertap-hms-sdk:1.5.1")
 
-    stagingImplementation("com.clevertap.android:clevertap-android-sdk:8.4.0")
+    stagingImplementation("com.clevertap.android:clevertap-android-sdk:8.4.1")
     stagingImplementation("com.clevertap.android:clevertap-geofence-sdk:1.4.0")
     stagingImplementation("com.clevertap.android:push-templates:2.5.0")
     stagingImplementation("com.clevertap.android:clevertap-hms-sdk:1.5.1")

--- a/templates/CTCORECHANGELOG.md
+++ b/templates/CTCORECHANGELOG.md
@@ -1,4 +1,25 @@
 ## CleverTap Android SDK CHANGE LOG
+### Version 8.4.1 (August 7, 2026)
+
+#### New Features
+* **Spin-the-Wheel and Scratch Card Templates:** Adds Spin-the-Wheel and Scratch Card gamified
+  template support to Advanced InApp Builder in-app notifications.
+* **Dismiss PIP In-App API:** New `dismissPipInApp()` method on `CleverTapAPI` dismisses the
+  currently visible Picture-in-Picture (PIP) In-App notification. Safe to call from any thread;
+  a no-op when no PIP is visible, and other in-app types are never affected.
+    * **Note:** Dismissing frees the in-app display slot, so the next queued in-app (if any) may
+      show immediately. To keep a screen free of all in-apps, pair this with
+      `suspendInAppNotifications()` on screen entry and `resumeInAppNotifications()` on exit.
+* **HTML Header/Footer In-Apps Without FragmentActivity:** Custom-HTML header and footer in-app
+  notifications can now render when the host Activity is not a `FragmentActivity` — for example
+  Unity or Unreal game engines. Opt-in via the `CLEVERTAP_INAPP_FRAGMENTLESS_BANNERS` manifest
+  flag; default off, so existing integrations are unaffected.
+
+#### Bug Fixes
+* **App Inbox Pull-to-Refresh:** Fixes an issue where the built-in App Inbox did not repaint the
+  message list after a pull-to-refresh — newly fetched messages only appeared after closing and
+  reopening the inbox.
+
 ### Version 8.4.0 (July 28, 2026)
 
 #### New Features

--- a/templates/EXAMPLES.md
+++ b/templates/EXAMPLES.md
@@ -514,6 +514,33 @@ To support in-app notifications, register the following activity in your Android
         android:value="YourSplashActivity1, YourSplashActivity2" />
    ```
 
+#### Dismissing a Picture-in-Picture (PIP) In-App Notification
+
+Use `dismissPipInApp()` to programmatically dismiss the currently visible PIP in-app notification —
+for example when the user navigates to a screen where the floating window would cover important
+content, such as a checkout or video-call screen.
+
+Java
+
+```java
+CleverTapAPI clevertap = CleverTapAPI.getDefaultInstance(getApplicationContext());
+clevertap.dismissPipInApp();
+```
+
+Kotlin
+
+```kotlin
+val clevertap = CleverTapAPI.getDefaultInstance(applicationContext)
+clevertap?.dismissPipInApp()
+```
+
+The call is safe from any thread, is a no-op when no PIP is visible, and never affects other
+in-app notification types.
+
+**Note:** Dismissing frees the in-app display slot, so the next queued in-app (if any) may show
+immediately. To keep a screen free of all in-apps, pair this with `suspendInAppNotifications()`
+on screen entry and `resumeInAppNotifications()` on exit.
+
 #### Push primer Android 13 notification runtime permission.
 
 Using Half-Interstitial in-app


### PR DESCRIPTION
Release chores for core **8.4.1** ([SDK-5981](https://wizrocket.atlassian.net/browse/SDK-5981)):

- Bumps `clevertap_android_sdk` to `8.4.1` in `gradle/libs.versions.toml`
- Bumps `sample/build.gradle` in all four places: `versionCode 8040100`, `versionName "8.4.1"`, `remoteImplementation`, `stagingImplementation` (versionCode/versionName were stale at 8.2.0)
- Prepends the 8.4.1 entry to `templates/CTCORECHANGELOG.md` and the dated entry to root `CHANGELOG.md`
- Adds a "Dismissing a Picture-in-Picture (PIP) In-App Notification" usage section to `templates/EXAMPLES.md` for the new `dismissPipInApp()` API
- `./gradlew copyTemplates` regenerated `README.md` and `docs/*` (pure version-string substitutions)

Changelog covers: SDK-5982 Spin-the-Wheel & Scratch Card templates, SDK-5983 `dismissPipInApp()`, SDK-5976 HTML header/footer in-apps without FragmentActivity, SDK-5955 App Inbox pull-to-refresh fix.

[SDK-5981]: https://wizrocket.atlassian.net/browse/SDK-5981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ