### PR TITLE
SDK-6057 [Android][ND] Phase 1 — Fcap foundations (stores, constants, NdFCManager)

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -3237,6 +3237,19 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
                             coreState.getExecutors(), clevertapClock));
         }
 
+        /*
+          Reinitialising NdFCManager (Native Display frequency caps) with device id, if it's null
+          during first initialisation from CleverTapFactory.getCoreState()
+         */
+        if (coreState.getControllerManager().getNdFCManager() == null) {
+            getConfigLogger().verbose(accountId + ":async_deviceID",
+                    "Initializing NdFC after Device ID Created = " + deviceId);
+            coreState.getControllerManager()
+                    .setNdFCManager(new NdFCManager(context, coreState.getConfig(), deviceId,
+                            coreState.getNdImpressionManager(),
+                            coreState.getExecutors(), clevertapClock));
+        }
+
         //todo : replace with variables
         /*
           Reinitialising product config & Feature Flag controllers with device id, if it's null

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
@@ -229,8 +229,13 @@ internal object CleverTapFactory {
 
         val triggersMatcher = TriggersMatcher(localDataStore)
         val triggersManager = TriggerManager(context, config.accountId, deviceInfo)
-        val impressionManager = ImpressionManager(storeRegistry)
+        val impressionManager = ImpressionManager({ storeRegistry.impressionStore })
         val limitsMatcher = LimitsMatcher(impressionManager, triggersManager)
+
+        // Native Display (ND) frequency caps (SDK-6055) — separate per-channel instances.
+        val ndTriggersManager =
+            TriggerManager(context, config.accountId, deviceInfo, Constants.KEY_ND_TRIGGERS_PER_TARGET)
+        val ndImpressionManager = ImpressionManager({ storeRegistry.ndImpressionStore })
 
         val inAppActionHandler = InAppActionHandler(
             context,
@@ -271,6 +276,25 @@ internal object CleverTapFactory {
                     storeRegistry.impressionStore = impStore
                     callbackManager.addChangeUserCallback(impStore)
                 }
+                // Native Display (ND) frequency caps (SDK-6055) — separate per-channel stores.
+                if (storeRegistry.ndStore == null) {
+                    val ndStore = storeProvider.provideNdStore(
+                        context = context,
+                        deviceId = deviceInfo.getDeviceID(),
+                        accountId = config.accountId
+                    )
+                    storeRegistry.ndStore = ndStore
+                    callbackManager.addChangeUserCallback(ndStore)
+                }
+                if (storeRegistry.ndImpressionStore == null) {
+                    val ndImpStore = storeProvider.provideNdImpressionStore(
+                        context = context,
+                        deviceId = deviceInfo.getDeviceID(),
+                        accountId = config.accountId
+                    )
+                    storeRegistry.ndImpressionStore = ndImpStore
+                    callbackManager.addChangeUserCallback(ndImpStore)
+                }
             }
         }
 
@@ -290,6 +314,17 @@ internal object CleverTapFactory {
                     deviceId,
                     storeRegistry,
                     impressionManager,
+                    executors,
+                    SYSTEM
+                )
+            }
+            // Native Display (ND) frequency caps (SDK-6055)
+            if (deviceId != null && controllerManager.ndFCManager == null) {
+                controllerManager.ndFCManager = NdFCManager(
+                    context,
+                    config,
+                    deviceId,
+                    ndImpressionManager,
                     executors,
                     SYSTEM
                 )
@@ -614,6 +649,8 @@ internal object CleverTapFactory {
             controllerManager = controllerManager,
             inAppController = inAppController,
             evaluationManager = evaluationManager,
+            ndImpressionManager = ndImpressionManager,
+            ndTriggerManager = ndTriggersManager,
             impressionManager = impressionManager,
             loginController = loginController,
             sessionManager = sessionManager,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -99,6 +99,25 @@ public interface Constants {
     String PREFS_EVALUATED_INAPP_KEY_SS = "evaluated_ss";
     String PREFS_SUPPRESSED_INAPP_KEY_CS = "suppressed_ss";
 
+    // ---- Native Display (ND) frequency caps (SDK-6055) ----
+    // ND == Display Units channel. SS + legacy only (no CS mode). Mirrors the in-app keys above.
+    // Response keys (LC -> SDK). Campaign content still arrives under DISPLAY_UNIT_JSON_RESPONSE_KEY ("adUnit_notifs").
+    String DISPLAY_UNIT_NOTIFS_SS_KEY = "adUnit_notifs_ss";                 // advanced-rule metadata bundle (rules only)
+    String DISPLAY_UNIT_NOTIFS_APP_LAUNCHED_KEY = "adUnit_notifs_applaunched"; // app-launch content + CG-suppressed stubs
+    String DISPLAY_UNIT_NOTIFS_STALE_KEY = "adUnit_stale";                  // dead-target GC ids
+    // Request meta keys (SDK -> LC)
+    String ND_SS_EVAL_META = "adUnit_eval";                                 // eligible advanced ND campaign votes
+    String ND_SUPPRESSED_META = "adUnit_suppressed";                        // CG-suppression acks (app-launch path only)
+    String ND_TARGET_SHOWN_LIST = "ndtlc";                                  // [[ti, todayCount, lifetimeCount], ...]
+    // Wire keys with directional overload (mirror in-app imc/imp)
+    String ND_MAX_PER_SESSION_KEY = "ndmc";                                 // resp: session ceiling; also storage key
+    String ND_MAX_PER_DAY_KEY = "ndmp";                                     // req: SDK daily count; resp: daily ceiling
+    // ND store prefs namespace + keys
+    String ND_KEY = "adUnit";                                               // ND metadata store prefs namespace
+    String PREFS_ND_KEY_SS = DISPLAY_UNIT_NOTIFS_SS_KEY;                    // metadata bundle pref key
+    String PREFS_EVALUATED_ND_KEY_SS = "evaluated_nd_ss";                   // pending adUnit_eval report
+    String PREFS_SUPPRESSED_ND_KEY = "suppressed_nd";                       // pending adUnit_suppressed report
+
     String INBOX_JSON_RESPONSE_KEY = "inbox_notifs";
     String INBOX_V2_JSON_RESPONSE_KEY = "inbox_notifs_v2";
     String INBOX_V2_ISREAD_KEY = "isRead";
@@ -157,6 +176,12 @@ public interface Constants {
     String KEY_COUNTS_PER_INAPP = "counts_per_inapp";
 
     String KEY_TRIGGERS_PER_INAPP = "triggers_per_inapp";
+
+    // ---- Native Display (ND) frequency-cap storage keys (SDK-6055), mirror the in-app keys above ----
+    String KEY_ND_MAX_PER_DAY = "ndstmcd";                 // stored ND daily ceiling (mirror of istmcd_inapp)
+    String KEY_ND_COUNTS_SHOWN_TODAY = "ndstc";            // stored ND global shown-today (mirror of istc_inapp)
+    String KEY_ND_COUNTS_PER_TARGET = "nd_counts_per_target";   // per-target today/lifetime + impressions file
+    String KEY_ND_TRIGGERS_PER_TARGET = "nd_triggers_per_target"; // onEvery/onExactly trigger counts
     String INAPP_ID_IN_PAYLOAD = "ti";
     int LOCATION_PING_INTERVAL_IN_SECONDS = 10;
     String[] SYSTEM_EVENTS = {NOTIFICATION_CLICKED_EVENT_NAME,
@@ -371,6 +396,8 @@ public interface Constants {
     int FETCH_TYPE_IN_APPS = 5;
     int FETCH_TYPE_IN_ACTION_IN_APPS = 6;
     int FETCH_TYPE_INBOX_V2 = 7;
+    // Native Display SS metadata refresh (SDK-6055). Placeholder value 100 — LOCK with BE before release.
+    int FETCH_TYPE_ND_META = 100;
     String LOG_TAG_SIGNED_CALL = "SignedCall : ";
     String LOG_TAG_GEOFENCES = "Geofences : ";
     String LOG_TAG_INAPP = "InApp : ";

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/ControllerManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/ControllerManager.java
@@ -27,6 +27,8 @@ public class ControllerManager {
 
     private InAppFCManager inAppFCManager;
 
+    private NdFCManager ndFCManager;
+
     private final BaseDatabaseManager baseDatabaseManager;
 
     private volatile DisplayUnitCache displayUnitCache;
@@ -213,6 +215,14 @@ public class ControllerManager {
 
     public void setInAppFCManager(final InAppFCManager inAppFCManager) {
         this.inAppFCManager = inAppFCManager;
+    }
+
+    public NdFCManager getNdFCManager() {
+        return ndFCManager;
+    }
+
+    public void setNdFCManager(final NdFCManager ndFCManager) {
+        this.ndFCManager = ndFCManager;
     }
 
     public PushProviders getPushProviders() {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CoreState.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CoreState.kt
@@ -7,6 +7,7 @@ import com.clevertap.android.sdk.events.BaseEventQueueManager
 import com.clevertap.android.sdk.events.EventMediator
 import com.clevertap.android.sdk.inapp.ImpressionManager
 import com.clevertap.android.sdk.inapp.InAppController
+import com.clevertap.android.sdk.inapp.TriggerManager
 import com.clevertap.android.sdk.inapp.customtemplates.TemplatesManager
 import com.clevertap.android.sdk.inapp.evaluation.EvaluationManager
 import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry
@@ -42,6 +43,9 @@ internal open class CoreState(
     val inAppController: InAppController,
     val evaluationManager: EvaluationManager,
     val impressionManager: ImpressionManager,
+    // Native Display (ND) frequency caps (SDK-6055) — separate per-channel instances.
+    val ndImpressionManager: ImpressionManager,
+    val ndTriggerManager: TriggerManager,
     val loginController: LoginController,
     val sessionManager: SessionManager,
     val validationResultStack: ValidationResultStack,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/NdFCManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/NdFCManager.java
@@ -1,0 +1,403 @@
+package com.clevertap.android.sdk;
+
+import static com.clevertap.android.sdk.StorageHelper.getPreferences;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.RestrictTo;
+import androidx.annotation.RestrictTo.Scope;
+
+import com.clevertap.android.sdk.inapp.ImpressionManager;
+import com.clevertap.android.sdk.task.CTExecutors;
+import com.clevertap.android.sdk.task.Task;
+import com.clevertap.android.sdk.utils.Clock;
+
+import org.json.JSONArray;
+
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Frequency-cap counter gate for the Native Display (ND / Display Units) channel.
+ *
+ * <p>This is the ND sibling of {@link InAppFCManager} and enforces the counter-based caps at the
+ * point a unit would be surfaced to the host app:
+ * <ul>
+ *   <li>per-target lifetime ({@code tlc}) and daily ({@code tdc}) counts,</li>
+ *   <li>per-target and global session caps ({@code mdc} / {@code ndmc}),</li>
+ *   <li>global daily cap ({@code ndstc} shown-today vs {@code ndstmcd} ceiling).</li>
+ * </ul>
+ *
+ * <p>ND is SS + legacy only, so unlike {@link InAppFCManager} there is no legacy pref-key migration
+ * here. Counter state lives in its own namespaces (see {@link Constants#KEY_ND_COUNTS_PER_TARGET})
+ * and never collides with in-app. The advanced {@code frequencyLimits}/{@code occurrenceLimits}
+ * (whenLimits) are evaluated separately by the ND {@code LimitsMatcher}; their result is passed in as
+ * {@code frequencyLimitsMaxedOut}.
+ *
+ * <p>The API is model-light (primitives) so it stays decoupled from the ND content/target model,
+ * which is parsed elsewhere.
+ */
+@RestrictTo(Scope.LIBRARY)
+public class NdFCManager {
+
+    static final int UNCAPPED = -1;
+
+    private static final String ND_DATE_KEY = "nd_ict_date";
+
+    private final SimpleDateFormat ddMMyyyy = new SimpleDateFormat("ddMMyyyy", Locale.US);
+
+    private final CleverTapInstanceConfig config;
+
+    private final Context context;
+
+    private String deviceId;
+
+    private final ImpressionManager impressionManager;
+
+    private final CTExecutors executors;
+
+    private final Clock clock;
+
+    NdFCManager(Context context,
+                CleverTapInstanceConfig config,
+                String deviceId,
+                ImpressionManager impressionManager,
+                CTExecutors executors,
+                Clock clock) {
+        this.config = config;
+        this.context = context;
+        this.deviceId = deviceId;
+        this.impressionManager = impressionManager;
+        this.executors = executors;
+        this.clock = clock;
+
+        Task<Void> task = executors.postAsyncSafelyTask();
+        task.execute("initNdFCManager", () -> {
+            init(deviceId);
+            return null;
+        });
+    }
+
+    /**
+     * Whether the given ND target can currently be surfaced under all counter caps.
+     *
+     * @param id                       ND target id ({@code ti}).
+     * @param excludeFromCaps          {@code efc == 1} — exempt from all caps.
+     * @param totalLifetimeCount       {@code tlc}; {@link #UNCAPPED} means uncapped.
+     * @param totalDailyCount          {@code tdc}; {@link #UNCAPPED} means uncapped.
+     * @param maxPerSession            {@code mdc}; negative means the per-target session default.
+     * @param frequencyLimitsMaxedOut  Result of the ND whenLimits (advanced) re-check by LimitsMatcher.
+     */
+    public boolean canShow(String id,
+                           boolean excludeFromCaps,
+                           int totalLifetimeCount,
+                           int totalDailyCount,
+                           int maxPerSession,
+                           boolean frequencyLimitsMaxedOut) {
+        try {
+            if (id == null || id.isEmpty()) {
+                return true;
+            }
+
+            // Re-check advanced whenLimits (without Nth triggers), mirrors in-app canShow.
+            if (frequencyLimitsMaxedOut) {
+                return false;
+            }
+
+            // Exclude from all counter caps?
+            if (excludeFromCaps) {
+                return true;
+            }
+
+            if (!hasSessionCapacityMaxedOut(id, maxPerSession)
+                    && !hasLifetimeCapacityMaxedOut(id, totalLifetimeCount)
+                    && !hasDailyCapacityMaxedOut(id, totalDailyCount)) {
+                return true;
+            }
+        } catch (Throwable t) {
+            return false;
+        }
+        return false;
+    }
+
+    public void changeUser(String deviceId) {
+        impressionManager.clearSessionData();
+        this.deviceId = deviceId;
+        init(deviceId);
+    }
+
+    /**
+     * Records a surfaced ND impression: bumps the per-target today/lifetime counts, the global
+     * shown-today counter, and the in-memory session impression state.
+     */
+    public void didShow(final Context context, final String id) {
+        if (id == null || id.isEmpty()) {
+            return;
+        }
+
+        Task<Void> task = executors.ioTask();
+        task.execute("recordNdImpressionsAndCounts", () -> {
+            impressionManager.recordImpression(id);
+
+            incrementNdCountsInPersistentStore(id);
+
+            int shownToday = getIntFromPrefs(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_SHOWN_TODAY, deviceId), 0);
+            StorageHelper.putInt(context,
+                    storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_SHOWN_TODAY, deviceId)),
+                    ++shownToday);
+            return null;
+        });
+    }
+
+    /**
+     * @return the SDK's total ND render count today ({@code ndmp} request value).
+     */
+    public int getShownTodayCount() {
+        return getIntFromPrefs(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_SHOWN_TODAY, deviceId), 0);
+    }
+
+    /**
+     * @return the {@code ndtlc} array: {@code [[targetId, todayCount, lifetimeCount], ...]}.
+     */
+    public JSONArray getNdCounts(final Context context) {
+        try {
+            JSONArray arr = new JSONArray();
+            final SharedPreferences prefs = getPreferences(context,
+                    storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_PER_TARGET, deviceId)));
+            final Map<String, ?> all = prefs.getAll();
+            for (Map.Entry<String, ?> target : all.entrySet()) {
+                // impressions share this file under the "__impressions_" prefix — skip them.
+                if (target.getKey().startsWith(com.clevertap.android.sdk.inapp.store.preference.ImpressionStore.PREF_PREFIX)) {
+                    continue;
+                }
+                if (target.getValue() instanceof String) {
+                    final String[] parts = ((String) target.getValue()).split(",");
+                    if (parts.length == 2) {
+                        JSONArray a = new JSONArray();
+                        a.put(0, target.getKey());
+                        a.put(1, Integer.parseInt(parts[0]));
+                        a.put(2, Integer.parseInt(parts[1]));
+                        arr.put(a);
+                    }
+                }
+            }
+            return arr;
+        } catch (Throwable t) {
+            Logger.v("Failed to get ND counts", t);
+            return null;
+        }
+    }
+
+    /**
+     * Purges dead-target ({@code adUnit_stale}) counter state from the ND counts store.
+     */
+    public void processResponse(final Context context, final JSONArray staleIds) {
+        try {
+            if (staleIds == null) {
+                return;
+            }
+
+            final SharedPreferences prefs = getPreferences(context,
+                    storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_PER_TARGET, deviceId)));
+            final SharedPreferences.Editor editor = prefs.edit();
+
+            for (int i = 0; i < staleIds.length(); i++) {
+                final Object o = staleIds.get(i);
+                if (o instanceof Integer) {
+                    editor.remove("" + o);
+                    Logger.d("Purged stale ND target - " + o);
+                } else if (o instanceof String) {
+                    editor.remove((String) o);
+                    Logger.d("Purged stale ND target - " + o);
+                }
+            }
+
+            StorageHelper.persist(editor);
+        } catch (Throwable t) {
+            Logger.v("Failed to purge stale ND targets", t);
+        }
+    }
+
+    /**
+     * Stores the account-level ND ceilings pushed on every response ({@code ndmp}/{@code ndmc}).
+     */
+    public synchronized void updateLimits(final Context context, int perDay, int perSession) {
+        StorageHelper.putInt(context, storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_MAX_PER_DAY, deviceId)),
+                perDay);
+        StorageHelper.putInt(context,
+                storageKeyWithSuffix(getKeyWithDeviceId(Constants.ND_MAX_PER_SESSION_KEY, deviceId)),
+                perSession);
+    }
+
+    private boolean hasDailyCapacityMaxedOut(String id, int totalDailyCount) {
+        // 1. Global daily cap.
+        int shownTodayCount = getIntFromPrefs(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_SHOWN_TODAY, deviceId), 0);
+        int maxPerDayCount = getIntFromPrefs(getKeyWithDeviceId(Constants.KEY_ND_MAX_PER_DAY, deviceId), 1);
+        if (shownTodayCount >= maxPerDayCount) {
+            return true;
+        }
+
+        // 2. Per-target daily cap.
+        try {
+            if (totalDailyCount == UNCAPPED) {
+                return false;
+            }
+            final int[] counts = getNdCountsFromPersistentStore(id);
+            if (counts[0] >= totalDailyCount) {
+                return true;
+            }
+        } catch (Throwable t) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean hasLifetimeCapacityMaxedOut(String id, int totalLifetimeCount) {
+        if (totalLifetimeCount == UNCAPPED) {
+            return false;
+        }
+        try {
+            final int[] counts = getNdCountsFromPersistentStore(id);
+            if (counts[1] >= totalLifetimeCount) {
+                return true;
+            }
+        } catch (Exception e) {
+            return true;
+        }
+        return false;
+    }
+
+    private boolean hasSessionCapacityMaxedOut(String id, int maxPerSession) {
+        // 1. Per-target session cap.
+        try {
+            final int perSession = maxPerSession >= 0 ? maxPerSession : 1000;
+            if (impressionManager.perSession(id) >= perSession) {
+                return true;
+            }
+        } catch (Throwable t) {
+            return true;
+        }
+
+        // 2. Global per-session cap (ndmc, default 1).
+        final int c = getIntFromPrefs(getKeyWithDeviceId(Constants.ND_MAX_PER_SESSION_KEY, deviceId), 1);
+        int sessionTotal = impressionManager.perSessionTotal();
+        return (sessionTotal >= c);
+    }
+
+    private int[] getNdCountsFromPersistentStore(String id) {
+        final SharedPreferences prefs = getPreferences(context,
+                storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_PER_TARGET, deviceId)));
+        final String str = prefs.getString(id, null);
+        if (str == null) {
+            return new int[]{0, 0};
+        }
+        try {
+            final String[] parts = str.split(",");
+            if (parts.length != 2) {
+                return new int[]{0, 0};
+            }
+            // protocol: todayCount,lifeTimeCount
+            return new int[]{Integer.parseInt(parts[0]), Integer.parseInt(parts[1])};
+        } catch (Throwable t) {
+            return new int[]{0, 0};
+        }
+    }
+
+    private void incrementNdCountsInPersistentStore(String id) {
+        int[] current = getNdCountsFromPersistentStore(id);
+        current[0] = current[0] + 1;
+        current[1] = current[1] + 1;
+
+        final SharedPreferences prefs = getPreferences(context,
+                storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_PER_TARGET, deviceId)));
+        final SharedPreferences.Editor editor = prefs.edit();
+
+        // protocol: todayCount,lifeTimeCount
+        editor.putString(id, current[0] + "," + current[1]);
+        StorageHelper.persist(editor);
+    }
+
+    private void init(String deviceId) {
+        getConfigLogger().verbose(config.getAccountId() + ":async_deviceID", "NdFCManager init() called");
+        try {
+            final String today = ddMMyyyy.format(clock.newDate());
+            final String lastUpdated = getStringFromPrefs(getKeyWithDeviceId(ND_DATE_KEY, deviceId), "20140428");
+            if (!today.equals(lastUpdated)) {
+                StorageHelper.putString(context, storageKeyWithSuffix(getKeyWithDeviceId(ND_DATE_KEY, deviceId)), today);
+
+                // Reset global shown-today count.
+                StorageHelper.putInt(context,
+                        storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_SHOWN_TODAY, deviceId)), 0);
+
+                // Reset per-target today counts (keep lifetime). Impression keys share this file under
+                // the "__impressions_" prefix — leave them untouched.
+                final SharedPreferences prefs = getPreferences(context,
+                        storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_PER_TARGET, deviceId)));
+                final SharedPreferences.Editor editor = prefs.edit();
+                final Map<String, ?> all = prefs.getAll();
+                for (String target : all.keySet()) {
+                    if (target.startsWith(com.clevertap.android.sdk.inapp.store.preference.ImpressionStore.PREF_PREFIX)) {
+                        continue;
+                    }
+                    Object ov = all.get(target);
+                    if (!(ov instanceof String)) {
+                        continue;
+                    }
+                    String[] oldValues = ((String) ov).split(",");
+                    if (oldValues.length != 2) {
+                        continue;
+                    }
+                    // protocol: todayCount,lifeTimeCount
+                    try {
+                        editor.putString(target, "0," + oldValues[1]);
+                    } catch (Throwable t) {
+                        getConfigLogger().verbose(getConfigAccountId(),
+                                "Failed to reset todayCount for ND target " + target, t);
+                    }
+                }
+                StorageHelper.persist(editor);
+            }
+        } catch (Exception e) {
+            getConfigLogger().verbose(getConfigAccountId(),
+                    "Failed to init ND FC manager " + e.getLocalizedMessage());
+        }
+    }
+
+    private String getConfigAccountId() {
+        return this.config.getAccountId();
+    }
+
+    private Logger getConfigLogger() {
+        return this.config.getLogger();
+    }
+
+    private int getIntFromPrefs(String rawKey, int defaultValue) {
+        if (this.config.isDefaultInstance()) {
+            int dummy = -1000;
+            int _new = StorageHelper.getInt(this.context, storageKeyWithSuffix(rawKey), dummy);
+            return _new != dummy ? _new : StorageHelper.getInt(this.context, rawKey, defaultValue);
+        } else {
+            return StorageHelper.getInt(this.context, storageKeyWithSuffix(rawKey), defaultValue);
+        }
+    }
+
+    private String getStringFromPrefs(String rawKey, String defaultValue) {
+        if (this.config.isDefaultInstance()) {
+            String _new = StorageHelper.getString(this.context, storageKeyWithSuffix(rawKey), defaultValue);
+            return _new != null ? _new : StorageHelper.getString(this.context, rawKey, defaultValue);
+        } else {
+            return StorageHelper.getString(this.context, storageKeyWithSuffix(rawKey), defaultValue);
+        }
+    }
+
+    private String getKeyWithDeviceId(String key, String deviceId) {
+        return key + ":" + deviceId;
+    }
+
+    private String storageKeyWithSuffix(String key) {
+        return key + ":" + getConfigAccountId();
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/StoreProvider.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/StoreProvider.kt
@@ -9,6 +9,7 @@ import com.clevertap.android.sdk.inapp.store.preference.ImpressionStore
 import com.clevertap.android.sdk.inapp.store.preference.InAppAssetsStore
 import com.clevertap.android.sdk.inapp.store.preference.InAppStore
 import com.clevertap.android.sdk.inapp.store.preference.LegacyInAppStore
+import com.clevertap.android.sdk.inapp.store.preference.NdStore
 import com.clevertap.android.sdk.store.preference.CTPreference
 
 const val STORE_TYPE_INAPP = 1
@@ -16,6 +17,10 @@ const val STORE_TYPE_IMPRESSION = 2
 const val STORE_TYPE_LEGACY_INAPP = 3
 const val STORE_TYPE_INAPP_ASSETS = 4
 const val STORE_TYPE_FILES = 5
+
+// Native Display (ND) frequency caps (SDK-6055)
+const val STORE_TYPE_ND = 6
+const val STORE_TYPE_ND_IMPRESSION = 7
 
 /**
  * The `StoreProvider` class is responsible for providing different types of stores
@@ -112,6 +117,32 @@ internal class StoreProvider {
     }
 
     /**
+     * Provides an instance of [NdStore] (Native Display SS metadata + eval/suppressed lists).
+     * Plaintext — ND is SS-only, there is no CS-style encrypted content on device.
+     */
+    fun provideNdStore(
+        context: Context,
+        deviceId: String,
+        accountId: String
+    ): NdStore {
+        val prefName = constructStorePreferenceName(STORE_TYPE_ND, deviceId, accountId)
+        return NdStore(getCTPreference(context, prefName))
+    }
+
+    /**
+     * Provides an [ImpressionStore] pointed at the Native Display namespace, so ND impression
+     * timestamps never collide with in-app's. Reuses the in-app [ImpressionStore] implementation.
+     */
+    fun provideNdImpressionStore(
+        context: Context,
+        deviceId: String,
+        accountId: String
+    ): ImpressionStore {
+        val prefName = constructStorePreferenceName(STORE_TYPE_ND_IMPRESSION, deviceId, accountId)
+        return ImpressionStore(getCTPreference(context, prefName), STORE_TYPE_ND_IMPRESSION)
+    }
+
+    /**
      * Provides an instance of [LegacyInAppStore] using the given parameters.
      *
      * @param context The Android application context.
@@ -147,6 +178,8 @@ internal class StoreProvider {
             STORE_TYPE_FILES -> "$FILE_STORE_PREFIX:$accountId"
             STORE_TYPE_INAPP -> "${Constants.INAPP_KEY}:$deviceId:$accountId"
             STORE_TYPE_IMPRESSION -> "${Constants.KEY_COUNTS_PER_INAPP}:$deviceId:$accountId"
+            STORE_TYPE_ND -> "${Constants.ND_KEY}:$deviceId:$accountId"
+            STORE_TYPE_ND_IMPRESSION -> "${Constants.KEY_ND_COUNTS_PER_TARGET}:$deviceId:$accountId"
             STORE_TYPE_LEGACY_INAPP -> Constants.CLEVERTAP_STORAGE_TAG
             else -> Constants.CLEVERTAP_STORAGE_TAG
         }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/ImpressionManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/ImpressionManager.kt
@@ -1,6 +1,6 @@
 package com.clevertap.android.sdk.inapp
 
-import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry
+import com.clevertap.android.sdk.inapp.store.preference.ImpressionStore
 import com.clevertap.android.sdk.utils.Clock
 import java.util.Calendar
 import java.util.Date
@@ -10,12 +10,16 @@ import java.util.concurrent.TimeUnit
 /**
  * Provides functionality for tracking and managing impressions for various campaigns.
  *
- * @property storeRegistry A storage manager responsible for storing and retrieving impression data.
+ * The same implementation backs both in-app and Native Display; [impressionStoreProvider] resolves
+ * which persistent [ImpressionStore] to use (in-app vs ND). It is a provider (not a direct instance)
+ * because the underlying store is created lazily once the device id is available.
+ *
+ * @property impressionStoreProvider Resolves the [ImpressionStore] to persist/read timestamps.
  * @property clock           An optional Clock implementation for handling time-related operations.
  * @property locale          An optional Locale specifying the locale to use for date and time calculations.
  */
 internal class ImpressionManager @JvmOverloads constructor(
-    private val storeRegistry: StoreRegistry,
+    private val impressionStoreProvider: () -> ImpressionStore?,
     private val clock: Clock = Clock.SYSTEM,
     private val locale: Locale = Locale.getDefault(),
 ) {
@@ -39,7 +43,7 @@ internal class ImpressionManager @JvmOverloads constructor(
         val records = sessionImpressions.getOrPut(campaignId) { mutableListOf() }
         records.add(now)
 
-        storeRegistry.impressionStore?.write(campaignId, now)
+        impressionStoreProvider()?.write(campaignId, now)
     }
 
     /**
@@ -176,7 +180,7 @@ internal class ImpressionManager @JvmOverloads constructor(
      * @return The total number of impressions recorded for the campaign.
      */
     private fun getImpressionCount(campaignId: String): Int {
-        return storeRegistry.impressionStore?.read(campaignId)?.size ?: 0
+        return impressionStoreProvider()?.read(campaignId)?.size ?: 0
     }
 
     /**
@@ -207,7 +211,7 @@ internal class ImpressionManager @JvmOverloads constructor(
     }
 
     fun getImpressions(campaignId: String): List<Long> {
-        return storeRegistry.impressionStore?.read(campaignId) ?: emptyList()
+        return impressionStoreProvider()?.read(campaignId) ?: emptyList()
     }
 
     /**

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/TriggerManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/TriggerManager.kt
@@ -15,7 +15,8 @@ import java.lang.ref.WeakReference
 class TriggerManager(
     context: Context,
     private val accountId: String,
-    private val deviceInfo: DeviceInfo
+    private val deviceInfo: DeviceInfo,
+    private val namespace: String = Constants.KEY_TRIGGERS_PER_INAPP
 ) {
     companion object {
         const val PREF_PREFIX = "__triggers"
@@ -84,7 +85,7 @@ class TriggerManager(
      * @return The SharedPreferences instance, or null if the context reference is null.
      */
     fun sharedPrefs(): SharedPreferences? {
-        val prefName = "${Constants.KEY_TRIGGERS_PER_INAPP}:${deviceInfo.deviceID}:$accountId"
+        val prefName = "$namespace:${deviceInfo.deviceID}:$accountId"
         val context = contextRef.get() ?: return null
         return StorageHelper.getPreferences(context, prefName)
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/ImpressionStore.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/ImpressionStore.kt
@@ -9,9 +9,13 @@ import com.clevertap.android.sdk.store.preference.ICTPreference
  * Responsible for storing impressions count for a given campaign ID.
  * It stores impressions in the shared preferences named "WizRocket_counts_per_inapp:<<account_id>>:<<device_id>>"
  * with keys in the format "__impression_<<campaign_id>>".
+ *
+ * The same implementation backs both in-app and Native Display; [storeType] selects which namespace
+ * to reconstruct on user change (in-app counts_per_inapp vs ND nd_counts_per_target).
  */
 class ImpressionStore(
     private val ctPreference: ICTPreference,
+    private val storeType: Int = STORE_TYPE_IMPRESSION,
 ) : ChangeUserCallback {
 
     companion object {
@@ -78,7 +82,7 @@ class ImpressionStore(
 
     override fun onChangeUser(deviceId: String, accountId: String) {
         val newPrefName =
-            StoreProvider.getInstance().constructStorePreferenceName(STORE_TYPE_IMPRESSION, deviceId, accountId)
+            StoreProvider.getInstance().constructStorePreferenceName(storeType, deviceId, accountId)
         ctPreference.changePreferenceName(newPrefName)
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/NdStore.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/NdStore.kt
@@ -1,0 +1,113 @@
+package com.clevertap.android.sdk.inapp.store.preference
+
+import com.clevertap.android.sdk.Constants.PREFS_EVALUATED_ND_KEY_SS
+import com.clevertap.android.sdk.Constants.PREFS_ND_KEY_SS
+import com.clevertap.android.sdk.Constants.PREFS_SUPPRESSED_ND_KEY
+import com.clevertap.android.sdk.STORE_TYPE_ND
+import com.clevertap.android.sdk.StoreProvider
+import com.clevertap.android.sdk.login.ChangeUserCallback
+import com.clevertap.android.sdk.store.preference.ICTPreference
+import com.clevertap.android.sdk.toList
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Stores Native Display (ND) Server-Side state, mirroring the SS half of [InAppStore].
+ *
+ * ND is **SS + legacy only** — there is no client-side (CS) mode, so unlike [InAppStore] there is no
+ * encrypted content cache and no delivery-mode switching. This store holds:
+ *  - the advanced-rule metadata bundle (`adUnit_notifs_ss`, rules only — used for local eval),
+ *  - the pending `adUnit_eval` vote list, and
+ *  - the pending `adUnit_suppressed` CG-ack list.
+ *
+ * Prefs file: `WizRocket_adUnit:<deviceId>:<accountId>`.
+ */
+internal class NdStore(
+    private val ctPreference: ICTPreference,
+) : ChangeUserCallback {
+
+    private var metaCache: List<JSONObject>? = null
+
+    /**
+     * Stores the ND advanced-rule metadata bundle (`adUnit_notifs_ss`). Plaintext — rules only, no content.
+     */
+    fun storeServerSideNdMetaData(metaData: List<JSONObject>) {
+        metaCache = metaData
+        ctPreference.writeString(PREFS_ND_KEY_SS, JSONArray(metaData).toString())
+    }
+
+    /**
+     * Reads the ND advanced-rule metadata bundle.
+     */
+    fun readServerSideNdMetaData(): List<JSONObject> {
+        metaCache?.let { return it }
+
+        val stored = ctPreference.readString(PREFS_ND_KEY_SS, "")
+        val result = if (stored.isNullOrBlank()) {
+            emptyList()
+        } else {
+            try {
+                JSONArray(stored).toList<JSONObject>()
+            } catch (e: JSONException) {
+                emptyList()
+            }
+        }
+        metaCache = result
+        return result
+    }
+
+    /**
+     * Removes the ND metadata bundle (used by dead-target GC / clear paths).
+     */
+    fun removeServerSideNdMetaData() {
+        ctPreference.remove(PREFS_ND_KEY_SS)
+        metaCache = null
+    }
+
+    /**
+     * Stores the pending `adUnit_eval` ids (eligible advanced ND campaigns not yet reported).
+     */
+    fun storeEvaluatedServerSideNdIds(evaluatedIds: JSONArray) {
+        ctPreference.writeString(PREFS_EVALUATED_ND_KEY_SS, evaluatedIds.toString())
+    }
+
+    /**
+     * Reads the pending `adUnit_eval` ids.
+     */
+    fun readEvaluatedServerSideNdIds(): JSONArray {
+        val stored = ctPreference.readString(PREFS_EVALUATED_ND_KEY_SS, "")
+        if (stored.isNullOrBlank()) return JSONArray()
+        return try {
+            JSONArray(stored)
+        } catch (e: JSONException) {
+            JSONArray()
+        }
+    }
+
+    /**
+     * Stores the pending `adUnit_suppressed` CG acks (App-Launched path only).
+     */
+    fun storeSuppressedNdIds(suppressedIds: JSONArray) {
+        ctPreference.writeString(PREFS_SUPPRESSED_ND_KEY, suppressedIds.toString())
+    }
+
+    /**
+     * Reads the pending `adUnit_suppressed` CG acks.
+     */
+    fun readSuppressedNdIds(): JSONArray {
+        val stored = ctPreference.readString(PREFS_SUPPRESSED_ND_KEY, "")
+        if (stored.isNullOrBlank()) return JSONArray()
+        return try {
+            JSONArray(stored)
+        } catch (e: JSONException) {
+            JSONArray()
+        }
+    }
+
+    override fun onChangeUser(deviceId: String, accountId: String) {
+        val newPrefName =
+            StoreProvider.getInstance().constructStorePreferenceName(STORE_TYPE_ND, deviceId, accountId)
+        ctPreference.changePreferenceName(newPrefName)
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/StoreRegistry.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/StoreRegistry.kt
@@ -8,6 +8,8 @@ package com.clevertap.android.sdk.inapp.store.preference
  * @property impressionStore An instance of [ImpressionStore] for tracking impressions of In-App messages.
  * @property legacyInAppStore An instance of [LegacyInAppStore] for storing legacy In-App messages.
  * @property inAppAssetsStore An instance of [InAppAssetsStore] for handling In-App assets storage.
+ * @property ndStore An instance of [NdStore] for Native Display SS metadata + eval/suppressed lists.
+ * @property ndImpressionStore An instance of [ImpressionStore] pointed at the Native Display namespace.
  *
  * @constructor Creates a StoreRegistry with optional instances of different stores.
  */
@@ -16,5 +18,7 @@ internal data class StoreRegistry(
     var impressionStore: ImpressionStore? = null,
     val legacyInAppStore: LegacyInAppStore,
     val inAppAssetsStore: InAppAssetsStore,
-    val filesStore: FileStore
+    val filesStore: FileStore,
+    var ndStore: NdStore? = null,
+    var ndImpressionStore: ImpressionStore? = null
 )

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/MockCoreState.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/MockCoreState.kt
@@ -18,12 +18,14 @@ internal class MockCoreStateKotlin(cleverTapInstanceConfig: CleverTapInstanceCon
     mockk(relaxed = true),
     CTLockManager(),
     CallbackManager(cleverTapInstanceConfig, mockk(relaxed = true)),
-    mockk(relaxed = true),
-    mockk(relaxed = true),
-    mockk(relaxed = true),
-    mockk(relaxed = true),
-    mockk(relaxed = true),
-    mockk(relaxed = true),
+    mockk(relaxed = true), // controllerManager
+    mockk(relaxed = true), // inAppController
+    mockk(relaxed = true), // evaluationManager
+    mockk(relaxed = true), // impressionManager
+    mockk(relaxed = true), // ndImpressionManager
+    mockk(relaxed = true), // ndTriggerManager
+    mockk(relaxed = true), // loginController
+    mockk(relaxed = true), // sessionManager
     ValidationResultStack(),
     mockk(relaxed = true),
     mockk(relaxed = true),

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/ImpressionManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/ImpressionManagerTest.kt
@@ -43,7 +43,7 @@ class ImpressionManagerTest : BaseTestCase() {
         )
 
         impressionManager = ImpressionManager(
-            storeRegistry = storeRegistry, clock = clock, locale = Locale.getDefault()
+            impressionStoreProvider = { storeRegistry.impressionStore }, clock = clock, locale = Locale.getDefault()
         )
 
         every { deviceInfo.deviceID } returns "device_id"

--- a/docs/InAppFrequencyCapsAndServing.md
+++ b/docs/InAppFrequencyCapsAndServing.md
@@ -1,0 +1,750 @@
+# In-App Notifications: Frequency Caps, Staleness/Meta, and Serving/Rendering
+
+This document explains how the CleverTap Android SDK (`clevertap-core`) handles in-app
+notifications end-to-end: the three in-app "families" (client-side, server-side, legacy),
+how frequency caps are evaluated, how staleness and request/response meta-headers work,
+and how in-apps are served to the SDK and rendered.
+
+All paths are relative to
+`clevertap-core/src/main/java/com/clevertap/android/sdk/`.
+Line numbers are accurate as of this writing (branch `develop`) and may drift; treat them
+as anchors, not guarantees.
+
+---
+
+## 0. Architecture at a glance: event stream ⇄ network ⇄ in-apps
+
+Before the in-app specifics, here's how the whole thing fits together. In-apps are not a
+standalone subsystem — they are **driven by the SDK's event pipeline**. Every event the app raises
+does two things on the *same* background thread: it gets persisted to the outbound queue **and** it
+is run through local in-app evaluation. The server's reply (carrying new in-apps, limits, stale ids)
+comes back on that same flush and updates the stores the next evaluation reads.
+
+### 0.1 The block diagram
+
+```mermaid
+flowchart TD
+    APP[App: pushEvent / pushProfile / pushChargedEvent] --> AM[AnalyticsManager]
+    AM --> EM[EventMediator<br/>shouldDrop / shouldDefer / getEventName]
+    EM --> EQM
+
+    subgraph SERIAL[SINGLE serial executor per account -- PostAsyncSafelyExecutor + ctLockManager.eventLock]
+      direction TB
+      EQM[EventQueueManager.processEvent] --> DB[(SQLite queue<br/>DBAdapter: EVENTS / PROFILE_EVENTS)]
+      EQM --> IAE[initInAppEvaluation<br/>same lock, right after DB write]
+    end
+
+    IAE --> IC[InAppController.onQueueEvent /<br/>onQueueChargedEvent / onQueueProfileEvent]
+    IC --> EVAL[EvaluationManager.evaluate]
+    EVAL --> CS1[CS immediate -> display queue]
+    EVAL --> CS2[CS delayed -> scheduled]
+    EVAL --> SSE[SS eligible -> evaluated_ss]
+    EVAL --> SUP[CS suppressed -> suppressed_ss]
+
+    EQM --> SF[scheduleQueueFlush<br/>MainLooperHandler.postDelayed]
+    SF --> FLUSH
+
+    subgraph NET[Network flush -- NetworkManager]
+      direction TB
+      FLUSH[flushDBQueue loop] --> BATCH[getQueuedEvents batch=50]
+      BATCH --> HDR[build queue header<br/>imp/tlc + inapps_eval / inapps_suppressed + arp]
+      HDR --> POST[POST /a1]
+      POST --> CLEAN[cleanupSentEvents + onSentHeaders<br/>removes reported ids]
+      CLEAN -->|hasMore| BATCH
+    end
+
+    POST --> RESP[response body]
+    RESP --> CRH[ClevertapResponseHandler chain<br/>InAppResponse first]
+    CRH --> IR[InAppResponse.processResponse]
+    IR --> STORE[(InAppStore cs/ss/meta<br/>InAppFCManager limits<br/>stale purge)]
+    STORE -.feeds next eval.-> EVAL
+    IR --> DQ[InApp display queue]
+    CS1 --> DQ
+    DQ -.one at a time.-> DISPLAY[render + didShow -> counters++]
+```
+
+### 0.2 The request/response round-trip
+
+```mermaid
+sequenceDiagram
+    participant APP as App
+    participant EQM as EventQueueManager (serial + eventLock)
+    participant DB as SQLite queue
+    participant EVAL as EvaluationManager (local CS/SS)
+    participant NM as NetworkManager
+    participant SRV as Server /a1
+
+    APP->>EQM: pushEvent(e)
+    Note over EQM,EVAL: same lock, same thread
+    EQM->>DB: queueEventToDB(e)
+    EQM->>EVAL: initInAppEvaluation(e)
+    EVAL-->>EVAL: CS display / mark evaluated_ss / suppressed_ss
+    EQM->>NM: scheduleQueueFlush (delayed)
+
+    NM->>DB: getQueuedEvents(batch=50)
+    NM->>NM: build header (imp/tlc + inapps_eval/suppressed + arp)
+    NM->>SRV: POST /a1 (header + events)
+    SRV-->>NM: response (inapp_notifs_cs/ss/..., limits, stale, arp)
+    NM->>EVAL: onSentHeaders -> drop reported ids
+    NM->>DB: cleanupSentEvents
+    NM->>NM: ClevertapResponseHandler -> InAppResponse.processResponse
+    Note over NM: store CS/SS, updateLimits, purge stale
+    NM-->>EVAL: next event evals see fresh in-app store
+    loop while hasMore
+        NM->>DB: next batch of 50
+    end
+```
+
+### 0.3 The "single queue" — what is actually serialized
+
+There are **two distinct one-at-a-time chokepoints**; both are deliberate.
+
+1. **The per-account serial executor (the event pipeline queue).** All event work runs on one
+   background thread per account: `CTExecutorFactory.executors(config)` is keyed by `accountId`, and
+   `PostAsyncSafelyExecutor` wraps a `newSingleThreadExecutor()`. On top of that, the hot path
+   `EventQueueManager.processEvent` runs inside `synchronized(ctLockManager.eventLock)` and, in that
+   one critical section, first `queueEventToDB(...)` (272) **then** `initInAppEvaluation(...)` (274).
+   Consequence: **DB persistence and in-app evaluation for a given event are atomic and ordered** —
+   evaluation always sees the event already committed, and no two events interleave. The network
+   flush (`flushDBQueue`) runs on this same executor, so queueing, evaluation, and flushing never race.
+
+2. **The in-app display queue (one in-app on screen at a time).** Selected in-apps go through a
+   single FIFO (`StoreRegistryInAppQueue`, persisted), and `currentlyDisplayingInApp` +
+   `pendingNotifications` guarantee exactly one is rendered at a time; the next is pulled only after
+   `inAppNotificationDidDismiss` (see §4.3).
+
+### 0.4 Updates and checks along the path
+
+| Stage | Update / check | Where |
+|---|---|---|
+| Ingest | drop opted-out/muted, defer pre-launch events | `EventMediator.shouldDropEvent` / `shouldDeferProcessingEvent` |
+| Persist | write event to `EVENTS`/`PROFILE_EVENTS` (encrypted `DATA`) | `EventQueueManager.processEvent` → `DBAdapter` |
+| Evaluate | trigger match → limit check → priority sort → select/suppress | `EvaluationManager.evaluate` (§4.1, §4.2, §2.2) |
+| Header out | attach `imp`/`tlc` counts + `inapps_eval`/`inapps_suppressed` (only `/a1`) | `QueueHeaderBuilder`, `EvaluationManager.onAttachHeaders` (§3.2) |
+| Send | batch of 50, loop `while hasMore`; handshake forced after `responseFailureCount > 5`; cadence from `getDelayFrequency()` | `NetworkManager.flushDBQueue` / `sendQueue` |
+| After send | remove **exactly** the reported ids; delete sent rows from DB | `onSentHeaders`, `cleanupSentEvents` |
+| Response | decorator chain, InApp first: `updateLimits`, stale purge, store CS/SS, route families | `ClevertapResponseHandler` → `InAppResponse.processResponse` (§3.3) |
+| Display | TTL + activity/foreground/suspend checks, then the two cap engines | `InAppController` (§4.3), `InAppFCManager.canShow` (§2) |
+
+Key files for this section: `AnalyticsManager.java`, `events/EventMediator.java`,
+`events/EventQueueManager.kt`, `task/CTExecutorFactory.kt` / `CTExecutors.java` /
+`PostAsyncSafelyExecutor.java`, `db/DBAdapter.kt`, `network/NetworkManager.kt`,
+`response/ClevertapResponseHandler.kt`, `CleverTapFactory.kt` (response-chain wiring).
+
+---
+
+## 1. The three in-app families
+
+CleverTap has evolved through three delivery models. All three can arrive in the same
+network response and coexist.
+
+| Family | Response key | Where decided | Content in response? | Cap engine |
+|---|---|---|---|---|
+| **Legacy** | `inapp_notifs` (+ `inapp_notifs_meta` for in-action) | Server picks, SDK just displays | Yes (full content) | `InAppFCManager` global + per-in-app counts only |
+| **Server-Side (SS)** | `inapp_notifs_ss` (metadata) / `inapp_notifs_applaunched` | Server sends *candidates*; SDK evaluates triggers + limits locally | Metadata only for `_ss`; full content for app-launched | `EvaluationManager` + `LimitsMatcher` (triggers/whenLimits) **and** `InAppFCManager` at display time |
+| **Client-Side (CS)** | `inapp_notifs_cs` | Fully evaluated on device against local events | Yes (full content, stored encrypted) | Same as SS: `EvaluationManager` + `LimitsMatcher` **and** `InAppFCManager` |
+
+Constant definitions (`Constants.java`):
+```
+INAPP_JSON_RESPONSE_KEY           = "inapp_notifs"                 // 85  legacy content
+INAPP_NOTIFS_META_KEY             = "inapp_notifs_meta"            // 86  legacy in-action meta
+INAPP_NOTIFS_STALE_KEY            = "inapp_stale"                  // 88  stale IDs
+INAPP_NOTIFS_APP_LAUNCHED_KEY     = "inapp_notifs_applaunched"     // 89  SS app-launch content
+INAPP_NOTIFS_APP_LAUNCHED_META_KEY= "inapp_notifs_applaunched_meta"// 90  SS app-launch in-action meta
+INAPP_NOTIFS_KEY_CS               = "inapp_notifs_cs"             // 92  client-side
+INAPP_NOTIFS_KEY_SS               = "inapp_notifs_ss"             // 93  server-side metadata
+```
+
+The delivery mode (CS vs SS) is switched by the server and persisted; when the mode flips,
+`InAppStore` purges the opposite family's cache (see §4).
+
+---
+
+## 1.5 Flow diagrams (at a glance)
+
+> These Mermaid diagrams render on GitHub. They are the "map"; the sections below are the "terrain".
+
+**End-to-end lifecycle** — response in, events drive evaluation, display gate, results reported back:
+
+```mermaid
+flowchart TD
+    NR[Network response /a1] --> IR[InAppResponse.processResponse]
+    IR --> UL[updateLimits imc/imp] & ST[clear stale: impressions+triggers+counters]
+    IR --> LEG[legacy inapp_notifs] --> Q
+    IR --> CS[inapp_notifs_cs<br/>store ENCRYPTED] --> EV
+    IR --> SS[inapp_notifs_ss<br/>store metadata] --> EV
+    IR --> AL[inapp_notifs_applaunched] --> EV
+
+    EVT([App event / charged / profile / app-launch]) --> EV[EvaluationManager.evaluate]
+    EV --> TM{TriggersMatcher<br/>matchEvent}
+    TM -- no --> DROP1[skip]
+    TM -- yes --> INC[TriggerManager.increment] --> LM{LimitsMatcher<br/>matchWhenLimits}
+    LM -- fail --> DROP2[not eligible]
+    LM -- pass --> SORT[sortByPriority<br/>priority desc, ti asc]
+    SORT --> SEL{selected vs suppressed}
+    SEL -- suppressed --> SUP[suppressed_ss store] --> HDR
+    SEL -- selected/SS eligible --> EVAL[evaluated_ss store] --> HDR
+    SEL -- CS selected --> Q[InAppController inAppQueue FIFO]
+
+    Q --> SHOW[showNotificationIfAvailable -> dequeue -> inflate media]
+    SHOW --> GATE{{checkLimitsBeforeShowing}}
+    GATE -- rejected --> NEXT[try next] --> Q
+    GATE -- ok --> RENDER[render: Activity / Fragment / PIP / template]
+    RENDER --> DIDSHOW[didShow: recordImpression + counters++]
+    DIDSHOW --> HDR[next request header:<br/>imp/tlc + inapps_eval/inapps_suppressed]
+    HDR --> NR
+```
+
+**The two cap engines** (both must pass at display time — `InAppFCManager.canShow`):
+
+```mermaid
+flowchart TD
+    A[canShow inapp] --> B{whenLimits maxed?<br/>matchWhenLimitsBeforeDisplay}
+    B -- yes --> DENY[deny]
+    B -- no --> C{isExcludeFromCaps?<br/>efc / excludeGlobalFCaps}
+    C -- yes --> ALLOW[allow]
+    C -- no --> D{session cap<br/>per-inapp mdc + global imc}
+    D -- maxed --> DENY
+    D -- ok --> E{lifetime cap<br/>tlc}
+    E -- maxed --> DENY
+    E -- ok --> F{daily cap<br/>per-inapp tdc + global istmcd/istc}
+    F -- maxed --> DENY
+    F -- ok --> ALLOW
+```
+
+---
+
+## 2. Frequency capping
+
+There are two cap engines that both must pass before an in-app is shown:
+
+1. **Global + per-in-app counters** — `InAppFCManager` (applies to *all* families).
+2. **whenLimits / occurrence limits** — `LimitsMatcher` (only CS/SS carry these).
+
+### 2.1 `InAppFCManager` — the counter-based gate
+
+File: `InAppFCManager.java`. The single entry point is `canShow(...)` (lines 72-107),
+called from `InAppController.checkLimitsBeforeShowing()` right before display.
+
+```java
+public boolean canShow(CTInAppNotification inapp,
+        Function2<JSONObject, String, Boolean> hasInAppFrequencyLimitsMaxedOut) {
+    final String id = getInAppID(inapp);
+    if (id == null) return true;
+
+    // (a) Re-check whenLimits (LimitsMatcher) in case the msg was queued multiple times
+    if (hasInAppFrequencyLimitsMaxedOut.invoke(inapp.getJsonDescription(), id)) return false;
+
+    // (b) Campaign explicitly exempt from all caps?
+    if (inapp.isExcludeFromCaps()) return true;
+
+    // (c) Three counter checks — all must be under cap
+    if (!hasSessionCapacityMaxedOut(inapp)
+            && !hasLifetimeCapacityMaxedOut(inapp)
+            && !hasDailyCapacityMaxedOut(inapp)) return true;
+
+    return false;
+}
+```
+
+**Session cap** (`hasSessionCapacityMaxedOut`, lines 325-349):
+- Per-in-app: `impressionManager.perSession(id) >= maxPerSession` (in-memory session count).
+  `maxPerSession` = campaign's `mdc` (`INAPP_MAX_DISPLAY_COUNT`) if `>= 0`, else `1000`.
+- Global: `impressionManager.perSessionTotal() >= imc` (global per-session limit, **read-default 1**
+  if never pushed by the server).
+
+**Lifetime cap** (`hasLifetimeCapacityMaxedOut`, lines 303-323):
+- `totalLifetimeCount` (`tlc` on the campaign) `== -1` means uncapped.
+- Otherwise `counts[1] >= totalLifetimeCount` where `counts[1]` is the persisted lifetime count.
+
+**Daily cap** (`hasDailyCapacityMaxedOut`, lines 271-300):
+- Global first: `shownTodayCount (istc_inapp) >= maxPerDayCount (istmcd_inapp)` (**read-default 1**).
+- Then per-in-app: `totalDailyCount` (`tdc`) `== -1` = uncapped; else `counts[0] >= totalDailyCount`.
+
+Note the two different "defaults": when the server pushes global limits they arrive as `imc`/`imp`
+in the response and default to **10** (`InAppResponseAdapter`, §2.5); the **1** above is the fallback
+`getIntFromPrefs` uses only if `updateLimits` has never run for this account/device.
+
+**Exclude-from-caps**: `CTInAppNotification.isExcludeFromCaps` is set from either
+`efc == 1` (`KEY_EFC`) or `excludeGlobalFCaps == 1` (`KEY_EXCLUDE_GLOBAL_CAPS`)
+(`CTInAppNotification.kt` ~387-388). When true, `canShow` returns `true` after the
+whenLimits check — i.e. it bypasses the session/lifetime/daily *counter* caps but **not**
+the `LimitsMatcher` whenLimits.
+
+**Recording an impression** (`didShow`, lines 116-134): on an IO task it calls
+`impressionManager.recordImpression(id)`, `incrementInAppCountsInPersistentStore(id)`
+(bumps both today and lifetime), and increments the global `istc_inapp` shown-today counter.
+
+**Global limits** are pushed by the server and stored via `updateLimits(context, perDay,
+perSession)` (lines 196-202) → writes `istmcd_inapp` (per-day) and `imc` (per-session), both
+namespaced `:deviceId:accountId`. `InAppResponse.processResponse` reads them from the response
+via `InAppResponseAdapter`: per-session key **`imc`** (`INAPP_MAX_PER_SESSION_KEY`), per-day key
+**`imp`** (`INAPP_MAX_PER_DAY_KEY`), each defaulting to **10** if absent.
+(The old doc claim of `inApp_notifs_per_day`/`inApp_notifs_per_session` was wrong.)
+
+**Daily reset**: `init()` compares today's date against the stored `ict_date`; on a new day
+it resets each in-app's today-count to `0` (keeping the lifetime part) and clears the global
+shown-today counter (`istc_inapp`).
+
+### 2.2 `LimitsMatcher` — whenLimits / occurrence limits (CS + SS only)
+
+Files: `inapp/evaluation/LimitsMatcher.kt`, `LimitAdapter.kt`, `ImpressionManager.kt`,
+`TriggerManager.kt`.
+
+`matchWhenLimits(whenLimits, campaignId)` returns true only if **every** limit passes.
+`whenLimits` is the union of the campaign's frequency limits and occurrence limits.
+Per-limit logic (`matchLimit`, lines 40-69):
+
+```
+Session   -> impressionManager.perSession(id)        < limit
+Seconds   -> impressionManager.perSecond(id, freq)   < limit
+Minutes   -> impressionManager.perMinute(id, freq)   < limit
+Hours     -> impressionManager.perHour(id, freq)     < limit
+Days      -> impressionManager.perDay(id, freq)      < limit
+Weeks     -> impressionManager.perWeek(id, freq)     < limit
+Ever      -> impressionManager.getImpressions(id).size < limit
+OnEvery   -> triggerCount % limit == 0      // show every Nth trigger
+OnExactly -> triggerCount == limit          // show only on the Nth trigger
+```
+
+`LimitType` values (`LimitAdapter.kt`): `ever, session, seconds, minutes, hours, days,
+weeks, onEvery, onExactly`.
+
+- **Impressions** (time-windowed counts) are backed by `ImpressionManager`, which holds
+  an in-memory per-session map plus persistent timestamps in `ImpressionStore`
+  (`__impressions_<campaignId>` → comma-separated unix seconds). Time-window queries use
+  binary search over the timestamp list.
+- **Trigger counts** for `onEvery`/`onExactly` are backed by `TriggerManager`
+  (`__triggers_<campaignId>` → int). `EvaluationManager.evaluate()` increments the trigger
+  count *when the trigger matches*, before checking limits.
+
+### 2.3 Where each family's caps get evaluated — summary
+
+- **Legacy**: only `InAppFCManager.canShow` (no whenLimits). The `hasInAppFrequencyLimitsMaxedOut`
+  lambda evaluates to "not maxed" because there are no whenLimits.
+- **SS / CS**: evaluated **twice** — once in `EvaluationManager.evaluate()` (trigger match →
+  increment trigger count → `matchWhenLimits`) to build the eligible set, and again at display
+  time inside `canShow` via `matchWhenLimitsBeforeDisplay` (the "without Nth triggers" re-check,
+  guarding against a campaign being queued multiple times before it actually renders).
+
+### 2.4 Where cap state is persisted — the SharedPreferences files
+
+All persistence goes through `StorageHelper.getPreferences(context, namespace)`, which opens a
+SharedPreferences file named `WizRocket` (base) or `WizRocket_<namespace>`
+(`StorageHelper.kt` 10-17). "Modern" stores build the namespace via
+`StoreProvider.constructStorePreferenceName(type, deviceId, accountId)`
+(`StoreProvider.kt` ~144). So each concrete file is tied to a **device + account** (multi-user /
+multi-account isolation), and the file is chosen by the *store type*.
+
+| What | Prefs file (Android `xml` name) | Keys | Value format | Written by |
+|---|---|---|---|---|
+| **Per-in-app counters** (today + lifetime) | `WizRocket_counts_per_inapp:<deviceId>:<accountId>` | `<inAppId>` | `"<today>,<lifetime>"` (CSV of two ints) | `InAppFCManager.incrementInAppCountsInPersistentStore` (350-362) |
+| **Impression timestamps** (whenLimits time windows) | **same file** `WizRocket_counts_per_inapp:<deviceId>:<accountId>` | `__impressions_<campaignId>` | comma-joined unix-**seconds** | `ImpressionStore.write` (`ImpressionStore.kt` 38-63) |
+| **Trigger counts** (onEvery / onExactly) | `WizRocket_triggers_per_inapp:<deviceId>:<accountId>` | `__triggers_<campaignId>` | single int | `TriggerManager.increment` (`TriggerManager.kt` 42-46) |
+| **Global FC counters + limits** | base `WizRocket` | `istc_inapp:<deviceId>:<accountId>` (shown-today), `istmcd_inapp:<…>` (max/day), `imc:<…>` (max/session), `ict_date:<…>` (reset date, `ddMMyyyy`) | ints / date string | `InAppFCManager.updateLimits` / `didShow` / `init` |
+| **CS/SS in-app payloads & meta** | `WizRocket_inApp:<deviceId>:<accountId>` | `inapp_notifs_cs`, `inapp_notifs_ss`, `inaction_inapp_notifs_ss`, `delayed_inapp_notifs_cs`, `inApp` (SS display queue), `evaluated_ss`, `suppressed_ss` | JSON arrays (CS keys **encrypted**) | `InAppStore.kt` |
+| **Legacy SS in-apps** | base `WizRocket` | `inApp:<accountId>` | encrypted JSON array | `LegacyInAppStore.kt` |
+
+Key points and gotchas:
+
+- **Impressions live in the *same* `counts_per_inapp` file as the today/lifetime counters** — they
+  are just distinguished by the `__impressions_` key prefix. `STORE_TYPE_IMPRESSION` maps to the
+  `KEY_COUNTS_PER_INAPP` namespace (`StoreProvider.kt`), so the two share one xml file.
+- **Two different "impression" notions**: `ImpressionManager` keeps an *in-memory* per-session map
+  (`perSession`, `perSessionTotal`, cleared on session end) **and** delegates durable timestamps to
+  `ImpressionStore`. `recordImpression(id)` writes both. Session counts never hit disk; time-window
+  limits (`perSecond/Minute/Hour/Day/Week`, `ever`) read the persisted timestamp list and binary-search
+  the window.
+- **Which store each cap engine reads**: `InAppFCManager` (session/daily/lifetime counter caps) reads
+  the CSV counters + global counters; `LimitsMatcher` (whenLimits) reads `ImpressionStore` timestamps +
+  `TriggerManager` counts. The two engines do **not** share counters — a campaign can pass one and fail
+  the other.
+- **Stale purge touches all three cap stores** (§3.1): `ImpressionStore.clear(id)` +
+  `TriggerManager.removeTriggers(id)` (CS/SS state) and `InAppFCManager.processResponse` removes the
+  `<inAppId>` key from `counts_per_inapp` (legacy counters).
+- **Key migration**: `InAppFCManager` has migrated the counts key across three shapes —
+  `counts_per_inapp` (v1) → `…:<deviceId>` (v2) → `…:<deviceId>:<accountId>` (v3, current); old files
+  are read once and purged.
+
+### 2.5 Global limits and delivery duration on the wire
+
+`InAppResponseAdapter.kt` (~184-190) reads the response-level knobs that feed the caps and routing:
+
+```
+imc  (INAPP_MAX_PER_SESSION_KEY)  -> inAppsPerSession   default 10  -> InAppFCManager.updateLimits
+imp  (INAPP_MAX_PER_DAY_KEY)      -> inAppsPerDay        default 10  -> InAppFCManager.updateLimits
+inapp_delivery_mode              -> inAppMode           ""/CS/SS/NO_MODE (InAppStore.setMode)
+inapp_stale                      -> staleInApps         JSON array of ids (§3.1)
+```
+
+Every family is also **partitioned by duration** before routing, via `InAppDurationPartitioner`:
+
+- `delayAfterTrigger` (`InAppDelayConstants`, 1–1200 s, default 0) splits a family into **immediate**
+  vs **delayed** in-apps.
+- `inactionDuration` (`InAppInActionConstants`, 1–1200 s, default 0) marks **in-action** in-apps
+  (fetched/shown only if the user takes no action within the window).
+
+That is why each response key produces a `DurationPartitionedInApps.*` object (immediate / delayed /
+inAction / unknown) rather than a flat list — see the routing table in §3.3.
+
+---
+
+## 3. Staleness, meta, and request/response headers
+
+### 3.1 Stale in-apps
+
+The server tells the SDK which campaigns are dead via `inapp_stale` (a JSON array of IDs).
+Two independent cleanups run:
+
+- `InAppResponse.clearStaleInAppCache(...)` (~220-228): for each stale ID,
+  `impressionStore.clear(id)` and `triggerManager.removeTriggers(id)` — wipes impression
+  timestamps and trigger counters (the CS/SS cap state).
+- `InAppFCManager.processResponse(...)` (167-194): removes the stale ID's entry from the
+  `counts_per_inapp` store — wipes the legacy today/lifetime counters.
+
+The campaign identity used throughout is `ti` (`INAPP_ID_IN_PAYLOAD`), read into
+`CTInAppNotification.id`.
+
+### 3.2 Request headers — what the SDK tells the server
+
+The queue/event request header is assembled in `network/QueueHeaderBuilder.kt`
+(`buildHeader`, 29-61). Two header pieces matter for in-apps:
+
+**In-app frequency counts** (`addInAppFC`, 188-194):
+```kotlin
+header.put("imp", it.shownTodayCount)         // global count shown today
+header.put("tlc", it.getInAppsCount(context)) // [[targetId, todayCount, lifetimeCount], ...]
+```
+`getInAppsCount` (140-165) serializes the entire `counts_per_inapp` store as the `tlc`
+array so the server knows per-campaign today/lifetime counts. (Note: the literal header
+keys are `"imp"` and `"tlc"`; the similarly named `Constants` `imc`/`imp` are the *local*
+storage keys for global session/day limits.)
+
+**Evaluated / suppressed meta — the "evals" the SDK reports back.**
+`EvaluationManager` implements `NetworkHeadersListener` and contributes two arrays to the queue
+header. This is how local evaluation results get back to the server without a separate call.
+
+*What the two arrays are*
+- `inapps_eval` (`INAPP_SS_EVAL_META`) — **server-side** campaign `ti`s that the SDK locally
+  evaluated as eligible. The server uses this to attribute the impression (it "renders" nothing on
+  device for pure SS, so the eval is the signal that the campaign fired). A flat JSON array of longs.
+- `inapps_suppressed` (`INAPP_SUPPRESSED_META`) — **client-side** campaigns that qualified but were
+  suppressed by a rule (the `isSuppressed` flag). Each entry is an object so the server can still
+  count/attribute the suppressed occurrence:
+  ```
+  { "wzrk_id": "<ti>_<yyyyMMdd>", "wzrk_pivot": "<pivot|wzrk_default>", "wzrk_cgId": <int> }
+  ```
+  (`suppress()`, EvaluationManager.kt ~540-552; `generateWzrkId` = `ti + "_" + yyyyMMdd`.)
+
+*How each array is populated*
+- `inapps_eval`: `evaluateServerSide()` (256) reads SS metadata, runs `evaluate()` per event, and
+  `trackAndSaveEvaluatedCampaignIds()` appends each eligible `ti` to the in-memory
+  `evaluatedServerSideCampaignIds` **and persists it** to `InAppStore` (`evaluated_ss`).
+- `inapps_suppressed`: during `selectAndProcessEligibleInApps()` (396), any eligible in-app whose
+  `shouldSuppress()` is true is added via `suppress()` to `suppressedClientSideInApps` and persisted
+  (`suppressed_ss`). Both lists are reloaded on init via `loadSuppressedCSAndEvaluatedSSInAppsIds()`,
+  so pending reports survive process death.
+
+*Attach → send → remove lifecycle* (the important part for correctness)
+```
+NetworkManager.applyQueueHeaderListeners(header, endpointId)
+   └─ onAttachHeaders(endpointId)                 // EvaluationManager, 632-654
+        if endpointId == ENDPOINT_A1 (the "/a1" REGULAR event queue) AND list non-empty:
+            header["inapps_eval"]       = evaluatedServerSideCampaignIds
+            header["inapps_suppressed"] = suppressedClientSideInApps
+   ... request is sent ...
+NetworkManager.notifyHeaderListeners(sentBody, endpointId)   // only after send
+   └─ onSentHeaders(allHeaders, endpointId)       // 664-672
+        removeSentEvaluatedServerSideCampaignIds(allHeaders)  // removes EXACTLY the ti's in the sent header
+        removeSentSuppressedClientSideInApps(allHeaders)      // removes entries whose id appears in the sent header
+        → re-persists the trimmed lists
+```
+Why remove-exactly-what-was-sent instead of clearing the whole list: an evaluation can happen on
+another thread **between** attach and the actual send. Clearing blindly would drop that new eval; so
+`onSentHeaders` only removes the ids that were actually serialized into the sent header
+(`removeSent…` iterates the *sent* header's array, not the current in-memory list).
+
+*Endpoint gating*: both arrays are attached **only** for `ENDPOINT_A1` — the regular `/a1` event
+queue (`EndpointId.fromEventGroup(REGULAR)`). Push-impression (`-spiky`), `/hello`, and
+`/defineVars` requests never carry them.
+
+**ARP** (`arp`) is also attached to the header and updated from the `arp` response key
+(`ARPResponse` → `arpRepo.handleARPUpdate`).
+
+*Eval-header lifecycle diagram:*
+
+```mermaid
+sequenceDiagram
+    participant EV as EvaluationManager
+    participant ST as InAppStore (evaluated_ss / suppressed_ss)
+    participant NM as NetworkManager
+    participant SRV as Server (/a1)
+
+    Note over EV: event evaluated
+    EV->>EV: SS eligible -> evaluatedServerSideCampaignIds.add(ti)
+    EV->>EV: CS suppressed -> suppressedClientSideInApps.add({wzrk_id,pivot,cgId})
+    EV->>ST: persist both lists
+
+    NM->>EV: onAttachHeaders(ENDPOINT_A1)
+    EV-->>NM: {inapps_eval:[...], inapps_suppressed:[...]}
+    NM->>SRV: send queue header (imp/tlc + eval/suppressed)
+    Note right of EV: a new eval may arrive here (other thread)
+    NM->>EV: onSentHeaders(sentHeader)
+    EV->>EV: remove ONLY ids present in sentHeader
+    EV->>ST: re-persist trimmed lists
+```
+
+### 3.3 Response processing entry point and family routing
+
+`response/InAppResponse.java` `processResponse()` (68-218) drives everything. Order of operations:
+
+1. Early-out if analytics-only / empty response / uninitialized stores.
+2. `updateLimits(perDay, perSession)` + `InAppFCManager.processResponse` (legacy stale purge).
+3. If `inapp_stale` present → `clearStaleInAppCache` (impression + trigger purge).
+4. If `inapp_delivery_mode` present → `inAppStore.setMode(mode)` (may drop the opposite cache, §3.4).
+5. Route **six** families, each already split by duration (§2.5):
+
+| Response key | Content? | Immediate | Delayed | In-action | Terminal handler |
+|---|---|---|---|---|---|
+| `inapp_notifs` (legacy) | full | `displayInApp` → `InAppController.addInAppNotificationsToQueue` | `scheduleDelayedLegacyInApps` | — | queue / delay timer |
+| `inapp_notifs_meta` (legacy in-action) | meta | — | — | `scheduleInActionInApps` | in-action timer → fetch |
+| `inapp_notifs_applaunched` (SS app-launch) | full | `onAppLaunchServerSideInAppsResponse` | delayed app-launch variant | — | `EvaluationManager.evaluateOnAppLaunchedServerSide` |
+| `inapp_notifs_applaunched_meta` (SS app-launch in-action) | meta | — | — | `onAppLaunchServerSideInactionInAppsResponse` | evaluate → in-action timer |
+| `inapp_notifs_cs` (client-side) | full (**encrypted**) | `InAppStore.storeClientSideInApps` | `storeClientSideDelayedInApps` | — | stored; evaluated on client events |
+| `inapp_notifs_ss` (server-side meta) | meta | `storeServerSideInAppsMetaData` (unknown-duration) | — | `storeServerSideInActionMetaData` | stored; evaluated + reported via header |
+
+6. Asset preloading: `res.getPreloadAssetsMeta()` → `FileResourcesRepo.preloadFilesAndCache`; on a
+   full response, `cleanupStaleFiles` prunes assets no longer referenced.
+
+**Legacy vs CS/SS** is decided purely by *which key* carries the in-app: legacy keys are shown/queued
+directly with content; CS is stored-with-content and evaluated locally on events; SS is stored as
+metadata and only materializes content after local evaluation reports eligibility to the server (or,
+for app-launch SS, is evaluated immediately on the app-launch event).
+
+`clearStaleInAppCache` (220-227): for each id in `inapp_stale`, `impressionStore.clear(id)` and
+`triggerManager.removeTriggers(id)`.
+
+### 3.4 Storage and TTL
+
+`inapp/store/preference/InAppStore.kt` keys:
+```
+inapp_notifs_cs              CS in-apps (ENCRYPTED via CryptHandler)
+inapp_notifs_ss              SS metadata (plaintext)
+inaction_inapp_notifs_ss     SS in-action metadata
+delayed_inapp_notifs_cs      delayed CS in-apps
+PREFS_EVALUATED_INAPP_KEY_SS evaluated SS IDs pending report
+PREFS_SUPPRESSED_INAPP_KEY_CS suppressed CS meta pending report
+```
+Mode change semantics: SS→CS drops all SS caches, CS→SS drops all CS caches, `NO_MODE` drops
+everything.
+
+**TTL/expiry**: `CTInAppNotification.timeToLive` comes from `wzrk_ttl` (`WZRK_TIME_TO_LIVE`),
+defaulting to `now + 2 days`. At display time `InAppController` drops the in-app if
+`now/1000 > timeToLive` ("InApp has elapsed its time to live"). For SS/CS, `EvaluationManager.
+updateTTL` can (re)compute `wzrk_ttl = now + wzrk_ttl_offset` when a campaign becomes eligible.
+
+---
+
+## 4. Serving and rendering — how an in-app reaches the screen
+
+### 4.1 Evaluation (CS/SS) on events
+
+`inapp/evaluation/EvaluationManager.kt` hooks (called from `InAppController.onQueue*`):
+- `evaluateOnEvent` (raised events), `evaluateOnChargedEvent`, `evaluateOnUserAttributeChange`
+- `evaluateOnAppLaunchedClientSide` / `evaluateOnAppLaunchedServerSide`
+
+Core loop `evaluate(event, inappNotifs)` (355-393):
+1. `triggersMatcher.matchEvent(getWhenTriggers(inApp), event)` — see §4.2.
+2. On match: `triggersManager.increment(campaignId)`.
+3. `limitsMatcher.matchWhenLimits(getWhenLimits(inApp), campaignId)` — §2.2.
+4. If both pass, add to `eligibleInApps`.
+
+Then `sortByPriority(eligibleInApps)` (522-532): sort by `priority` **descending**
+(`INAPP_PRIORITY`, default 1, range 1–100), tie-broken by `ti` **ascending** (earliest wins).
+A strategy (immediate vs delayed) selects the winner(s); suppressed ones are recorded to the
+CS-suppressed store; TTL may be updated; selected in-apps are handed to the controller queue.
+
+### 4.2 Trigger matching — how in-apps are filtered by events
+
+This is the heart of "which in-apps qualify". Files:
+`inapp/evaluation/TriggersMatcher.kt`, `TriggerAdapter.kt`, `TriggerValue.kt`, `EventAdapter.kt`.
+
+**Structure of a trigger** (`TriggerAdapter`): a campaign's `whenTriggers` is a JSON array of
+triggers. Each trigger has:
+- `eventName` (or `profileAttrName` for user-attribute-change triggers),
+- `eventProperties` — a list of `TriggerCondition{propertyName, op, value}` (event property filters),
+- `itemProperties` — same shape, applied to line-items of a **Charged** event,
+- `geoRadius` — a list of `{lat, lng, radius}`,
+- `firstTimeOnly` — boolean.
+
+**Combining logic** (`matchEvent` → `match`, TriggersMatcher.kt 33-76):
+
+```
+whenTriggers      : trigger1 OR trigger2 OR …           (any() — TriggersMatcher 41)
+within a trigger  : eventName match
+                    AND all eventProperties            (matchPropertyConditions, AND — 87-101)
+                    AND firstTimeOnly (if set)         (matchFirstTimeOnly, 78-85)
+                    AND all itemProperties (if Charged)(matchChargedItemConditions, 103-120)
+                    AND any geoRadius (if geoRadiusCount>0)  (matchGeoRadius, OR — 131-151)
+charged items     : all conditions AND-ed, but each condition matches if ANY item satisfies it
+                    (outer all{}, inner any{})
+```
+
+```mermaid
+flowchart TD
+    S([event]) --> T{any trigger matches?<br/>whenTriggers OR-ed}
+    T -- none --> NO[not eligible]
+    T -- check each trigger --> N{event name /<br/>profileAttr match?}
+    N -- no --> T
+    N -- yes --> P{all eventProperties pass?<br/>AND-ed}
+    P -- no --> T
+    P -- yes --> F{firstTimeOnly ok?}
+    F -- no --> T
+    F -- yes --> C{charged? all itemProperties<br/>pass on some item?}
+    C -- no --> T
+    C -- yes --> G{geoRadius set?<br/>any within radius? OR-ed}
+    G -- no match --> T
+    G -- ok / not set --> YES[trigger matched -> eligible]
+```
+
+- **Event-name match** (54-57): case/whitespace-insensitive (`Utils.areNamesNormalizedEqual`).
+  Matches if the event name matches **or** both sides' `profileAttrName` match (attribute-change path).
+- **first-time-only** (78-85): passes only if `localDataStore.isUserEventLogFirstTime(key)` — i.e. the
+  event/attribute has been seen exactly once. Key is `profileAttrName ?: eventName`.
+- **geo-radius** (`evaluateDistance`, 198-202): Haversine distance ≤ radius; needs a valid
+  `event.userLocation`.
+- **System / mapped properties** (`EventAdapter` 37-59, `getActualPropertyValue` 121-136): lookups fall
+  back from the literal name → normalized name → a mapping table for CT system props
+  (`CT App Version`/`ct_app_version` → `CLTAP_APP_VERSION`, latitude/longitude, OS/SDK version, carrier,
+  network type, wifi, bluetooth) and for `wzrk_id`/variant/pivot.
+
+**Operators** (`TriggerOperator`, TriggerAdapter.kt 33-56; evaluated in `TriggersMatcher.evaluate`
+164-185). If the actual value is **null**, only `NotSet` matches; everything else is false.
+
+| Operator | int | Semantics | Coercion / notes |
+|---|---|---|---|
+| `Set` | 26 | property exists (non-null) | — |
+| `NotSet` | 27 | property absent (null) | the only op that is true on null |
+| `Equals` | 1 | actual == expected | list↔list (set equality), scalar-in-list either direction, else numeric-then-string; strings compared trimmed+lowercased |
+| `NotEquals` | 15 | `!Equals` | same as Equals |
+| `LessThan` | 2 | actual < expected | both coerced to `Double` (numbers or numeric strings); list-expected uses first element |
+| `GreaterThan` | 0 | actual > expected | same coercion as LessThan |
+| `Between` | 4 | expected[0] ≤ actual ≤ expected[1] | expected must be a ≥2-element list; all coerced to `Double`; inclusive |
+| `Contains` | 3 | actual contains expected | string-substring (case-insens.), list-contains-element, list-contains-any-of-list |
+| `NotContains` | 28 | `!Contains` | same as Contains |
+
+`TriggerValue` normalizes each value on construction: strings/booleans are stored raw **and** cleaned
+(trimmed + lowercased); numbers stay `Number`; lists/`JSONArray` clean their string elements. Numeric
+comparisons accept numeric **strings** ("42" behaves like 42).
+
+### 4.3 The display pipeline
+
+`inapp/InAppController.kt`:
+- `showNotificationIfAvailable()` → `_showNotificationIfAvailable()` (717-762): checks the
+  current activity isn't blacklisted, not `SUSPENDED`, drains `pendingNotifications`, then
+  `inAppQueue.dequeue()` (SS queue is FIFO, persisted via `StoreRegistryInAppQueue`).
+- `prepareNotificationForDisplay()` → `InAppNotificationInflater.inflate()`: builds the
+  `CTInAppNotification` and downloads media / custom-template files off the main thread, then
+  fires `notificationReady()`.
+- `displayNotification()` → `checkLimitsBeforeShowing()` (932-970): the final cap gate —
+  builds the `hasInAppFrequencyLimitsMaxedOut` lambda (`matchWhenLimitsBeforeDisplay`) and
+  calls `inAppFCManager.canShow(...)`. Also an optional host-app `beforeShow(kvs)` veto.
+- State/robustness checks: discarded → drop; app backgrounded, another in-app showing,
+  blacklisted activity, or suspended → park in `pendingNotifications`; TTL expired → drop;
+  HTML in-app with no network → skip and try next.
+- Dispatch by type: full-screen (Cover/Interstitial/Alert/Half-Interstitial) →
+  `InAppNotificationActivity`; Header/Footer banners → `CTInAppBaseFragment`; PIP → `PIPManager`;
+  custom-code template → `TemplatesManager.presentTemplate`.
+
+`currentlyDisplayingInApp` + `pendingNotifications` (a synchronized static list) enforce
+**one in-app at a time**.
+
+### 4.4 Post-display accounting
+
+- `inAppNotificationDidShow` (493-506): `inAppFCManager.didShow` (records impression + bumps
+  counts, §2.1), pushes the "viewed" analytics event, host `onShow` callback.
+- `inAppNotificationActionTriggered` (271-353): sets `wzrk_id`/`c2a`, pushes the clicked event
+  (unless local in-app), then executes the action (open URL, key-values, etc.).
+- `inAppNotificationDidDismiss` (447-491): records dismissal, clears
+  `currentlyDisplayingInApp`, and calls `_showNotificationIfAvailable()` to advance the queue.
+
+### 4.5 In-app types and their renderers
+
+`CTInAppType` (`inapp/CTInAppType.kt`) enumerates every layout; `CTInAppNotification.configureWithJson`
+picks it from the `type` field (a null `type` or `"html"` takes the legacy path). Dispatch happens in
+`InAppController.showInApp` (~1059-1174):
+
+| `CTInAppType` (wire value) | Renderer |
+|---|---|
+| `CTInAppTypeCover`/`Interstitial`/`HalfInterstitial` (+ their `…HTML` and `…ImageOnly` variants), `CTInAppTypeAlert` | `InAppNotificationActivity` (full-screen) |
+| `CTInAppTypeHeaderHTML` / `CTInAppTypeFooterHTML` | `CTInAppHtmlHeader/FooterFragment` if `FragmentActivity`; else, if `fragmentlessInAppBannersEnabled`, a WindowManager overlay (`showHtmlBannerOverlay`) |
+| `CTInAppTypeHeader` / `CTInAppTypeFooter` | `CTInAppNativeHeader/FooterFragment` |
+| `CTInAppTypePIP` | `PIPManager.show` (floating window) |
+| `CTInAppTypeCustomCodeTemplate` (`custom-code`) | `TemplatesManager.presentTemplate` (visual or non-visual) |
+| `UNKNOWN` | dropped with an error log |
+
+Type-specific validation in `configureWithJson` (446-476): image-only and PIP types require a media
+entry (else `error`), and Cover/HalfInterstitial/Header/Footer strip any video/audio media they can't
+render.
+
+---
+
+## 5. End-to-end flow (condensed)
+
+```
+Network response
+  └─ InAppResponse.processResponse
+       ├─ updateLimits (global istmcd_inapp / imc)
+       ├─ clearStaleInAppCache + InAppFCManager.processResponse   (inapp_stale)
+       ├─ legacy inapp_notifs        → queue / delayed / in-action
+       ├─ inapp_notifs_applaunched   → evaluateOnAppLaunchedServerSide
+       ├─ inapp_notifs_cs            → InAppStore.storeClientSideInApps (encrypted)
+       └─ inapp_notifs_ss            → InAppStore.storeServerSideInAppsMetaData
+
+Event (raised / charged / profile / app-launch)
+  └─ EvaluationManager.evaluate
+       ├─ TriggersMatcher.matchEvent          (whenTriggers, OR of AND-groups)
+       ├─ TriggerManager.increment            (for onEvery/onExactly)
+       ├─ LimitsMatcher.matchWhenLimits       (session/time/ever/onEvery/onExactly)
+       ├─ sortByPriority  (priority desc, ti asc)
+       └─ selected → InAppController queue  (suppressed → suppressed store → header report)
+
+Display
+  └─ showNotificationIfAvailable → dequeue → inflate(media) → displayNotification
+       └─ checkLimitsBeforeShowing
+            ├─ matchWhenLimitsBeforeDisplay      (LimitsMatcher re-check, no Nth trigger)
+            └─ InAppFCManager.canShow
+                 ├─ excludeFromCaps? → allow
+                 ├─ session cap (per-inapp mdc + global imc)
+                 ├─ lifetime cap (tlc)
+                 └─ daily cap (per-inapp tdc + global istmcd_inapp/istc_inapp)
+       └─ render (Activity / Fragment / PIP / custom template)
+            └─ didShow → recordImpression + increment counts + istc_inapp++
+
+Next request header
+  ├─ imp = shownTodayCount, tlc = [[ti, today, lifetime], ...]   (QueueHeaderBuilder.addInAppFC)
+  └─ inapps_eval / inapps_suppressed                              (EvaluationManager.onAttachHeaders)
+```
+
+---
+
+## 6. Key file index
+
+| Concern | File |
+|---|---|
+| Counter caps (global + per-inapp), stale purge, header counts | `InAppFCManager.java` |
+| whenLimits / occurrence limits | `inapp/evaluation/LimitsMatcher.kt`, `LimitAdapter.kt` |
+| Impression storage (timestamps, time windows) | `inapp/ImpressionManager.kt`, `inapp/store/preference/ImpressionStore.kt` |
+| Trigger counts (onEvery/onExactly) | `inapp/TriggerManager.kt` |
+| Trigger matching + operators + value coercion | `inapp/evaluation/TriggersMatcher.kt`, `TriggerAdapter.kt`, `TriggerValue.kt`, `EventAdapter.kt` |
+| Eligibility, priority sort, suppression, TTL, header meta | `inapp/evaluation/EvaluationManager.kt` |
+| Response parsing / routing + duration partition | `response/InAppResponse.java`, `inapp/data/InAppResponseAdapter.kt`, `inapp/data/InAppDurationPartitioner*` |
+| CS/SS storage, mode switching, TTL | `inapp/store/preference/InAppStore.kt`, `LegacyInAppStore.kt` |
+| Prefs file-name construction (namespaces) | `StorageHelper.kt`, `StoreProvider.kt` |
+| Request header assembly (imp/tlc, arp) | `network/QueueHeaderBuilder.kt` |
+| Serving queue + render pipeline | `inapp/InAppController.kt`, `inapp/StoreRegistryInAppQueue.kt`, `inapp/InAppNotificationInflater.kt` |
+| In-app model / JSON parsing | `inapp/CTInAppNotification.kt` |
+| In-app types → renderers | `inapp/CTInAppType.kt` |
+| Event pipeline (ingest → serial executor → DB → flush) | `AnalyticsManager.java`, `events/EventMediator.java`, `events/EventQueueManager.kt`, `task/CTExecutorFactory.kt`, `task/PostAsyncSafelyExecutor.java`, `db/DBAdapter.kt` |
+| Network flush + response-chain wiring | `network/NetworkManager.kt`, `response/ClevertapResponseHandler.kt`, `CleverTapFactory.kt` |
+| Constants (all keys above) | `Constants.java` |

--- a/docs/NativeDisplayFrequencyCaps.md
+++ b/docs/NativeDisplayFrequencyCaps.md
@@ -1,0 +1,372 @@
+# Native Display Frequency Caps — Android SDK TAN
+
+Android SDK Technical Approach Note for **Native Display (ND) Frequency Caps**
+(epic [SDK-6055](https://wizrocket.atlassian.net/browse/SDK-6055), TAN task
+[SDK-6056](https://wizrocket.atlassian.net/browse/SDK-6056)).
+
+This document is the SDK-side companion to the cross-team design, written to mirror the structure
+of [`InAppFrequencyCapsAndServing.md`](./InAppFrequencyCapsAndServing.md). It will be published to
+Confluence (child of the *Native Display Fcaps* landing page) once reviewed.
+
+**Source of truth for the contract/design (read these first):**
+- BE + SDK design TAN — *Fcaps in ND campaigns*: https://wizrocket.atlassian.net/wiki/spaces/EN/pages/6985482280
+- Wire contract — *FE ↔ BE ↔ SDK Contract*: https://wizrocket.atlassian.net/wiki/spaces/EN/pages/6986170380
+- Landing — *Native Display Fcaps*: https://wizrocket.atlassian.net/wiki/spaces/EN/pages/6972964894
+
+Paths are relative to `clevertap-core/src/main/java/com/clevertap/android/sdk/`.
+
+---
+
+## 0. TL;DR (the decisions that shape the SDK work)
+
+- **ND on Android = the Display Units subsystem** (`displayunits/`, response key `adUnit_notifs`).
+  Today it is a thin parse-and-cache-and-callback path; **the host app renders the unit**, the SDK
+  does not. This is the single biggest structural difference from in-app.
+- **ND is SS + Legacy only — there is NO Client-Side (CS) mode, no in-action, no delivery-mode
+  switching.** We port the *server-side eval* and *legacy counter* halves of the in-app fcap system,
+  not the CS half.
+- **Fully separate per-channel state.** ND gets its own counters/impressions/triggers/metadata
+  stores. It never shares files or in-memory state with in-app. Wire: `ndtlc` (per-target counts),
+  `ndmp` (global daily count/ceiling), `ndmc` (session ceiling) — all separate from `tlc`/`imp`/`imc`.
+- **Two fcap models:** *advanced* (frequencyLimits + occurrenceLimits + excludeGlobalFCaps) for
+  standalone ND **campaigns**; *legacy* (`efc`/`tlc`/`tdc`/`mdc`) for ND **journey nodes**.
+- **The fcap/limit/trigger schema is identical to in-app.** `frequencyLimits`↔`AdvancedLimits.fCaps`,
+  `occurrenceLimits`↔`AdvancedLimits.triggers`. This is what makes engine reuse viable.
+- **Impression accounting is app-driven for ND** (`pushDisplayUnitViewedEventForID`), whereas in-app
+  is SDK-driven (`didShow`). The natural hook for ND `recordImpression` is the viewed-event path.
+- **The delivery mechanism (the `DisplayUnitListener` callback) is unchanged** — we keep giving units
+  to the client via the callback, but now the SDK **gates which units it hands over based on the
+  fcaps**, exactly as in-app gates display. Only *whether/when* the callback fires becomes cap-aware.
+- Gated behind LaunchDarkly `rollout-native-display-fcaps` + an SDK-version gate (LC returns V2 vs
+  V1). Old SDK ⇒ V1 ⇒ delivery unchanged.
+
+---
+
+## 1. What exists today on Android (baseline)
+
+ND is delivered through **Display Units**, entirely separate from in-app:
+
+| Concern | Where | Notes |
+|---|---|---|
+| Response key | `Constants.DISPLAY_UNIT_JSON_RESPONSE_KEY = "adUnit_notifs"` | already parsed today |
+| Response processor | `response/DisplayUnitResponse.java` → `parseDisplayUnits()` | in the `ClevertapResponseHandler` chain |
+| Model | `displayunits/model/CleverTapDisplayUnit.java` (`unitID`, `type` `CTDisplayUnitType`, `bgColor`, content array, custom KV) | not `CTInAppNotification` |
+| Cache | `displayunits/CTDisplayUnitController.java` (implements `DisplayUnitCache`) | `updateDisplayUnits` / `getAllDisplayUnits` / `getDisplayUnitForID` / `reset` |
+| Delivery to app | `DisplayUnitListener` callback | **host app renders** |
+| Viewed event | `AnalyticsManager.pushDisplayUnitViewedEventForID(unitID)` → `NOTIFICATION_VIEWED_EVENT_NAME` | app-driven |
+| Clicked event | `pushDisplayUnitClickedEventForID` / `pushDisplayUnitElementClickedEventForID` | app-driven |
+
+**Consequences for fcaps:**
+- There is **no SDK render pipeline / display queue** to gate at (contrast in-app §4.3). Enforcement
+  and impression recording must attach to *delivery* and to the *viewed event*, not to a render step.
+- Today ND fires with only server-side priority-lock + CG suppression; **no per-campaign, per-user, or
+  global caps run**. This project introduces them.
+
+---
+
+## 2. What's changing (the layer we add)
+
+We add an ND fcap + SS-eval layer alongside the existing Display Units path:
+
+1. **ND evaluation** on the event stream (mirrors in-app SS): match triggers → count → check limits →
+   vote eligible advanced campaigns into `adUnit_eval` (reported in the request meta header).
+2. **ND metadata store** for the `adUnit_notifs_ss` bundle (advanced-rule campaigns, rules only).
+3. **ND counter/impression/trigger stores** — separate from in-app — powering both the SDK-side caps
+   and the request-meta counters (`ndtlc`, `ndmp`).
+4. **ND FC gate** (`canShow`-equivalent) applied when a unit would be surfaced, plus a global-daily
+   re-check; session cap against `ndmc`.
+5. **CG-suppression ack** (`adUnit_suppressed`) for the App-Launched content-in-advance path only.
+6. **Dead-target GC** honoring `adUnit_stale`.
+7. **Mid-session refresh** trigger `wzrk_fetch t=WZRK_FETCH_ND_META`.
+
+The existing render/callback path (host renders the unit) is **unchanged**; content still arrives in
+`adUnit_notifs` (regular / journey winner) and now also `adUnit_notifs_applaunched` (App-Launched).
+
+---
+
+## 3. Wire mapping (in-app → ND)
+
+| Concern | In-app (existing) | ND (new) | Direction |
+|---|---|---|---|
+| Campaign content | `inapp_notifs` | `adUnit_notifs` | resp |
+| App-launch content (+ CG stubs) | `inapp_notifs_applaunched` | `adUnit_notifs_applaunched` | resp |
+| SS metadata bundle (rules only) | `inapp_notifs_ss` | `adUnit_notifs_ss` | resp |
+| Stale ids (GC) | `inapp_stale` | `adUnit_stale` | resp |
+| Session ceiling | `imc` | `ndmc` | resp |
+| Daily ceiling | `imp` | `ndmp` | resp (overload) |
+| Per-target counts | `tlc` = `[[ti,today,life],…]` | `ndtlc` = `[[ti,today,life],…]` | req |
+| Global daily count | `imp` (pre-summed int) | `ndmp` (pre-summed int) | req (overload) |
+| Eval vote list | `inapps_eval` | `adUnit_eval` | req |
+| CG-suppressed acks | `inapps_suppressed` | `adUnit_suppressed` | req |
+| SS meta-fetch trigger | `FETCH_TYPE_IN_APPS = 5` | `WZRK_FETCH_ND_META` (**placeholder 100 — lock with BE**) | req |
+| Account defaults (session/day) | `ism`/`imp` = 1/10 | `ndsm`/`ndmp` = **1/10** | account |
+| Legacy campaign caps | `efc`/`tlc`/`tdc`/`mdc` | same keys | resp/config |
+
+`ndmp` **directional overload** (identical to in-app `imp`): request-side = the SDK's own daily ND
+render count; response-side = the account daily ceiling. Keep the two roles straight in the code.
+
+All ND request-meta fields ride inside the same `type:"meta"` header entry as the in-app fields
+(`QueueHeaderBuilder`), e.g.:
+
+```json
+{ "type":"meta",
+  "tlc":[["55001",3,12]], "imp":5, "inapps_eval":[55001], "inapps_suppressed":[],
+  "ndtlc":[["70001",1,4]], "ndmp":2, "adUnit_eval":[70001], "adUnit_suppressed":[] }
+```
+
+---
+
+## 4. Storage layout (new ND stores)
+
+Follow the exact in-app pattern (`StoreProvider.constructStorePreferenceName(type, deviceId,
+accountId)` → `StorageHelper` file `WizRocket_<namespace>`), with **new namespaces** so ND never
+collides with in-app:
+
+| State | Proposed prefs file | Key | Value | Mirror of |
+|---|---|---|---|---|
+| Per-target counters (today+lifetime) | `WizRocket_nd_counts_per_target:<deviceId>:<accountId>` | `<ti>` | `"today,lifetime"` | `counts_per_inapp` (`InAppFCManager`) |
+| Impression timestamps (whenLimits windows) | **same** `nd_counts_per_target:…` file | `__impressions_<ti>` | unix-seconds CSV | `ImpressionStore` |
+| Trigger counts (onEvery/onExactly) | `WizRocket_nd_triggers_per_target:<deviceId>:<accountId>` | `__triggers_<ti>` | int | `TriggerManager` |
+| Global ND counters + ceilings | base `WizRocket` | `ndstc:<…>` (shown-today), `ndmp:<…>` (day ceiling), `ndmc:<…>` (session ceiling), `nd_ict_date:<…>` | ints / date | `istc_inapp`/`istmcd_inapp`/`imc`/`ict_date` |
+| Advanced metadata bundle | `WizRocket_adUnit:<deviceId>:<accountId>` | `adUnit_notifs_ss` | JSON array (plaintext — SS only, no CS encryption) | `inapp_notifs_ss` in `InAppStore` |
+| Eval / suppressed pending report | `WizRocket_adUnit:…` | `adUnit_eval`, `adUnit_suppressed` | JSON arrays | `evaluated_ss` / `suppressed_ss` |
+
+Notes:
+- **No encrypted CS store** and **no delivery-mode/purge machinery** — ND has no CS mode.
+- Impressions share the counters file (via the `__impressions_` prefix) exactly like in-app.
+- New `STORE_TYPE_ND_*` constants in `StoreProvider` (mirrors `STORE_TYPE_IMPRESSION`, etc.).
+- New constants: `KEY_ND_COUNTS_PER_TARGET`, `KEY_ND_TRIGGERS_PER_TARGET`, `ND_MAX_PER_SESSION`
+  (`ndsm`/`ndmc`), `ND_MAX_PER_DAY` (`ndmp`), `ND_COUNTS_SHOWN_TODAY` (`ndstc`), plus the wire keys.
+
+---
+
+## 5. Cap model & SDK enforcement matrix
+
+From the design TAN §7, the SDK's responsibilities (what the SDK must enforce locally):
+
+| Cap | Applies to | SDK enforces? | How on SDK |
+|---|---|---|---|
+| `isNdFcapEnabled == false` short-circuit | all | yes | skip ND eval entirely → deliver as today |
+| `efc == 1` (exclude from caps) | basic campaigns + journeys | yes | short-circuit allow |
+| `tlc` once-per-user-for-campaign | basic campaigns + journeys | yes | lifetime counter (`ndtlc[…][2]`) |
+| `tdc` once-per-day | basic campaigns + journeys | yes | today counter (`ndtlc[…][1]`) + daily reset |
+| `mdc` once-per-session | basic campaigns + journeys | **yes (SDK-only)** | in-memory session count |
+| `frequencyLimits` (AND) | advanced campaigns | yes | `LimitsMatcher` over ND ImpressionStore |
+| `occurrenceLimits` (onEvery/onExactly) | advanced campaigns | yes | `LimitsMatcher` over ND TriggerManager |
+| ND global daily (`ndmp`, def 10) | all ND unless `excludeGlobalFCaps` | yes (canShow re-check) | global `ndstc` vs `ndmp` ceiling |
+| ND global session (`ndsm`/`ndmc`, def 1) | all ND | **yes (SDK-only)** | session render count vs `ndmc` |
+
+Precedence (same as in-app): `isNdFcapEnabled==false` overrides all; then `efc==1` short-circuits;
+`excludeGlobalFCaps==true` bypasses only the ND global-daily cap.
+
+The elegant simplification: **the SDK does not need to classify campaigns.** Only advanced-rule,
+non-journey campaigns ever appear in `adUnit_notifs_ss` (the server's eligibility filter, design §6.7).
+So "evaluate everything in the metadata bundle and vote the eligible ones into `adUnit_eval`" is
+correct by construction — journeys and simple campaigns never reach the SDK evaluator.
+
+---
+
+## 6. Evaluation & the eval-header flow
+
+### 6.1 Where ND evaluation hooks in
+Same event stream as in-app (§0 of the in-app doc): on the per-account serial executor, right after
+the event is queued to DB, `initInAppEvaluation` runs. We add an **ND evaluation sibling** invoked in
+the same place so ND sees the committed event. It reads the `adUnit_notifs_ss` bundle and, per event:
+1. `TriggersMatcher.matchEvent(whenTriggers, event)`  *(see open question Q1)*
+2. on match → ND `TriggerManager.increment(ti)`
+3. `LimitsMatcher.matchWhenLimits(whenLimits, ti)` over the **ND** impression/trigger stores
+4. eligible → add `ti` to `adUnit_eval`
+
+### 6.2 `adUnit_eval` — the vote list
+Advanced-rule campaigns the SDK deemed eligible on this event. The server delivers content
+(`adUnit_notifs`) only for campaigns present in `adUnit_eval` (design §6.4/§6.9). Simple campaigns and
+journey nodes are **not** voted (server evaluates them fully). May contain duplicates → server dedups.
+
+### 6.3 `adUnit_suppressed` — CG acks (App-Launched only)
+Server ships CG-suppressed campaigns as **stubs** (`suppressed:true` + `wzrk_cgId`) inline in
+`adUnit_notifs_applaunched`. The SDK acks each at its would-have-been-surfaced moment with the bare
+shape `{wzrk_id, wzrk_pivot, wzrk_cgId}` (identical to `inapps_suppressed`; reuse
+`SuppressionMetaConverter`).
+- **Only for the App-Launched content-in-advance path.** On regular events the server decides CG
+  itself and needs **no** SDK ack.
+
+### 6.4 Attach → send → remove lifecycle
+Reuse the in-app `NetworkHeadersListener` mechanism (attach only for `ENDPOINT_A1` `/a1`):
+`onAttachHeaders` adds `adUnit_eval`/`adUnit_suppressed` (+ `ndtlc`/`ndmp` counters via the header
+builder); `onSentHeaders` removes **exactly** the ids present in the sent header (so a concurrent ND
+eval isn't lost). Persist both lists (`adUnit_eval`/`adUnit_suppressed`) so pending reports survive
+process death.
+
+```mermaid
+sequenceDiagram
+    participant EV as ND Evaluator
+    participant ST as ND stores (adUnit_eval / adUnit_suppressed)
+    participant NM as NetworkManager
+    participant SRV as Server /a1
+
+    EV->>EV: event -> match triggers -> check ND limits
+    EV->>EV: eligible advanced campaign -> adUnit_eval.add(ti)
+    EV->>EV: App-Launched CG stub -> adUnit_suppressed.add({wzrk_id,pivot,cgId})
+    EV->>ST: persist
+    NM->>EV: onAttachHeaders(ENDPOINT_A1)
+    EV-->>NM: {adUnit_eval, adUnit_suppressed, ndtlc, ndmp}
+    NM->>SRV: POST /a1 (meta header + events)
+    SRV-->>NM: adUnit_notifs_ss / adUnit_notifs / adUnit_notifs_applaunched / adUnit_stale / ndmc / ndmp
+    NM->>EV: onSentHeaders -> remove exactly reported ids
+    EV->>ST: re-persist trimmed lists
+```
+
+---
+
+## 7. Flows & diagrams
+
+### 7.1 Response routing (new ND keys)
+
+```mermaid
+flowchart TD
+    RESP[/a1 response/] --> CRH[ClevertapResponseHandler chain]
+    CRH --> NDR[AdUnitResponse - NEW]
+    NDR --> SS[adUnit_notifs_ss<br/>store metadata bundle]
+    NDR --> AL[adUnit_notifs_applaunched<br/>content + CG stubs]
+    NDR --> NF[adUnit_notifs<br/>winner content]
+    NDR --> STALE[adUnit_stale<br/>purge ND counters/impressions/triggers]
+    NDR --> CEIL[ndmc / ndmp<br/>update ND ceilings]
+    SS -.feeds next eval.-> EVAL[ND Evaluator]
+    AL --> CACHE[CTDisplayUnitController cache]
+    NF --> CACHE
+    AL --> ACK[CG stub -> adUnit_suppressed ack]
+    CACHE --> APP[[DisplayUnitListener -> host app renders]]
+    APP --> VIEW[pushDisplayUnitViewedEventForID]
+    VIEW --> REC[ND recordImpression:<br/>ndtlc++ , ndstc++ , session++]
+```
+
+### 7.2 The ND cap gate (mirrors in-app canShow, minus CS)
+
+```mermaid
+flowchart TD
+    A[unit about to be surfaced / viewed] --> M{isNdFcapEnabled?}
+    M -- no --> ALLOW[allow - deliver as today]
+    M -- yes --> B{advanced whenLimits maxed?}
+    B -- yes --> DENY[suppress]
+    B -- no --> C{efc == 1?}
+    C -- yes --> ALLOW
+    C -- no --> D{session cap<br/>mdc + global ndmc}
+    D -- maxed --> DENY
+    D -- ok --> E{lifetime cap tlc}
+    E -- maxed --> DENY
+    E -- ok --> F{daily cap<br/>tdc + global ndmp/ndstc}
+    F -- maxed --> DENY
+    F -- ok --> ALLOW
+```
+
+### 7.3 App-Launched vs regular-event dispatch (server-side, for SDK context)
+- **App-Launched:** union of app-launched + no-trigger ND targets, sorted priority DESC then ti ASC.
+  Journey wins alone (→ `adUnit_notifs`); otherwise campaign lock-in delivers one-or-more campaigns
+  (real + CG stubs) under `adUnit_notifs_applaunched`. **SDK must ack CG stubs** via `adUnit_suppressed`.
+- **Regular event:** one target per event (server hard-stops after first delivery). Advanced-rule
+  campaigns gated on `adUnit_eval`; journeys + simple bypass. **No SDK CG ack** on this path.
+
+---
+
+## 8. Reuse vs new — component plan
+
+**Reuse / generalize into a channel-agnostic core** (pure logic; parameterize the store + wire keys):
+- `inapp/evaluation/TriggersMatcher.kt`, `TriggerAdapter.kt`, `TriggerValue.kt`, `EventAdapter.kt`
+- `inapp/evaluation/LimitsMatcher.kt`, `LimitAdapter.kt`, `LimitType`
+- The `evaluate()` loop + `sortByPriority` from `EvaluationManager.kt` (extract the channel-specific
+  store reads/writes and header lists behind an interface)
+- `SuppressionMetaConverter` + the `{wzrk_id,wzrk_pivot,wzrk_cgId}` shape
+- The `NetworkHeadersListener` attach/remove mechanism
+- `ImpressionManager` / `ImpressionStore` / `TriggerManager` — reuse the classes, instantiate a
+  **second set** pointed at the ND namespaces
+
+**New, ND-specific (must not share state with in-app):**
+- `NdFCManager` (sibling of `InAppFCManager`): ND counters, global `ndstc`/`ndmp`/`ndmc`, daily reset,
+  `canShow`-equivalent, `didShow`-equivalent (driven by the viewed event), `ndtlc`/`ndmp` serializers.
+- `NdStore` (sibling of the SS half of `InAppStore`): metadata bundle + eval/suppressed lists.
+- `NdEvaluationManager` (or a generalized `EvaluationManager<Channel>`).
+- `AdUnitResponse` `CleverTapResponse` processor, wired into `CleverTapFactory` chain.
+- ND `NetworkHeadersListener` contributions (`adUnit_eval`/`adUnit_suppressed`/`ndtlc`/`ndmp`).
+- New constants incl. `FETCH_TYPE_ND_META` and the trigger for mid-session refresh.
+- **No new renderer** — reuse the existing Display Units delivery/callback path; hook impression
+  recording on `pushDisplayUnitViewedEventForID` and gating on delivery.
+
+**Recommendation:** invest in extracting a small channel-agnostic evaluation core now (the server side
+already mirrors in-app class-for-class). A thin `Channel` abstraction (store namespaces + wire-key set
++ impression hook) lets in-app and ND — and later Web Inbox etc. — share one engine.
+
+---
+
+## 9. Backward compatibility, flags, version gate
+
+- Per-campaign master switch `isNdFcapEnabled` (absent ⇒ uncapped).
+- LD flag `rollout-native-display-fcaps` (FE + LC). SDK-version gate: old SDK ⇒ LC returns **V1** ⇒
+  no metadata, no gate, delivery unchanged.
+- Response ceilings `ndmc`/`ndmp` are emitted regardless of V1/V2 ⇒ **SDK must ignore unknown response
+  keys** (already standard).
+- **Additive limit `type` values** — ND `LimitType`/operator parsing must skip unknown values
+  gracefully (verify the ported enums do).
+- Account defaults `ndsm=1`, `ndmp=10` when unset. No Mongo migration.
+- Old SDK never sends `ndtlc`/`ndmp`/`adUnit_eval`/`wzrk_fetch t=ND_META` — natural forward-compat.
+
+---
+
+## 10. Open questions
+
+Resolved by the design TAN:
+- **Advanced vs simple vs journey classification (was Q4)** — RESOLVED. The SDK doesn't classify; it
+  only ever evaluates campaigns present in `adUnit_notifs_ss`, which by the server filter are
+  advanced-rule non-journey. Vote those into `adUnit_eval`.
+- **`adUnit_stale` scope (was Q5)** — RESOLVED. Dead-target GC purges ND counter/impression/trigger
+  state (mirrors `inapp_stale`); emitted whenever the SDK sent `ndtlc`.
+- **Content model (was Q3)** — largely RESOLVED. Content is the existing ND (Display Units) payload;
+  no new renderer. Confirm the `type` taxonomy if new ND types ship with this feature.
+- **Global daily/session ceilings, dead-target GC, mid-session refresh, dispatch rules** — RESOLVED in
+  design TAN §12.
+
+Also resolved:
+- **`whenTriggers` in `adUnit_notifs_ss` (was Q1)** — RESOLVED. `whenTriggers` **is** present, exactly
+  like in-app SS; it is simply not shown in the contract's §5.2 example. The evaluator matches events
+  against `whenTriggers` and evaluates `frequencyLimits`/`occurrenceLimits` the same way in-app does.
+
+Still to lock:
+1. **Lock `WZRK_FETCH_ND_META`** (placeholder `100`; distinct from `FETCH_TYPE_IN_APPS = 5`).
+2. **SDK impression-map size for ND** (design TAN open Q7) — mirror in-app's cap or ND-specific?
+3. **Mid-session refresh cadence** — when exactly does the SDK fire `wzrk_fetch t=ND_META`?
+   (e.g., bundle empty + advanced campaign delivered, or on a timer.)
+4. **Re-view / dedupe semantics** — the ND impression hook is the viewed event
+   (`pushDisplayUnitViewedEventForID`); confirm whether repeated views of the same unit should each
+   count, and how multiple units on one screen are handled.
+
+---
+
+## 11. Phased implementation plan (SDK)
+
+1. **Foundations**: constants + `StoreProvider` ND types + `NdStore`, `NdFCManager`, and a second
+   `ImpressionManager`/`TriggerManager` instance on ND namespaces. Daily-reset + serializers.
+2. **Response ingest**: `AdUnitResponse` for `adUnit_notifs_ss` (cache), `adUnit_notifs_applaunched`,
+   `adUnit_notifs`, `adUnit_stale`, `ndmc`/`ndmp`. Wire into `CleverTapFactory` chain.
+3. **Header out**: `ndtlc`/`ndmp` in `QueueHeaderBuilder`; `adUnit_eval`/`adUnit_suppressed` via an ND
+   `NetworkHeadersListener` (attach/remove exactly-sent).
+4. **Evaluator**: extract channel-agnostic eval core; add `NdEvaluationManager`; hook into the event
+   stream next to `initInAppEvaluation`. (Blocked on Q1.)
+5. **Cap gate + impressions**: `canShow`-equivalent at delivery; `recordImpression` on the viewed
+   event; global daily/session enforcement.
+6. **CG acks**: consume App-Launched stubs → `adUnit_suppressed`.
+7. **Refresh + flags**: `wzrk_fetch t=ND_META` trigger; version/flag gating; ignore-unknown-keys checks.
+8. **Tests + docs**: unit tests mirroring the in-app fcap tests; finalize this doc → Confluence.
+
+---
+
+## 12. File index
+
+Existing (baseline / to touch):
+- `response/DisplayUnitResponse.java`, `displayunits/CTDisplayUnitController.java`,
+  `displayunits/model/CleverTapDisplayUnit.java`, `AnalyticsManager` (viewed/clicked),
+  `Constants.java` (`DISPLAY_UNIT_JSON_RESPONSE_KEY`), `CleverTapFactory.kt` (response chain).
+
+Reference implementation to mirror (in-app):
+- `InAppFCManager.java`, `inapp/store/preference/{InAppStore,ImpressionStore}.kt`,
+  `inapp/{ImpressionManager,TriggerManager}.kt`, `inapp/evaluation/*` (matchers, `EvaluationManager`),
+  `network/QueueHeaderBuilder.kt`, `StoreProvider.kt`, and this doc's companion
+  [`InAppFrequencyCapsAndServing.md`](./InAppFrequencyCapsAndServing.md).


### PR DESCRIPTION
Part of epic **SDK-6055** (Native Display Frequency Caps) · ticket **SDK-6057** · design **SDK-6056** (`docs/NativeDisplayFrequencyCaps.md`).

Bottom of the ND fcaps stacked-PR series. Adds the Native Display (Display Units) frequency-cap **storage + counter foundation**, mirroring the in-app fcap system but **SS + legacy only** with **fully separate per-channel state**.

## What's in this PR
- **Constants**: ND wire keys (`adUnit_notifs_ss` / `_applaunched` / `_stale`, `adUnit_eval`, `adUnit_suppressed`, `ndtlc`, `ndmc`, `ndmp`) + storage keys (`nd_counts_per_target`, `nd_triggers_per_target`, `ndstmcd`, `ndstc`) + `FETCH_TYPE_ND_META` (placeholder 100, to lock with BE).
- **StoreProvider**: `STORE_TYPE_ND` / `STORE_TYPE_ND_IMPRESSION` + `provideNdStore` / `provideNdImpressionStore`.
- **NdStore** (new): SS metadata bundle + eval/suppressed lists (plaintext — no CS/crypt, no delivery-mode).
- **ImpressionStore**: `storeType` param so ND reconstructs its own namespace on user change.
- **ImpressionManager**: now takes an `ImpressionStore` provider (enables a second ND instance) instead of the whole `StoreRegistry`.
- **TriggerManager**: `namespace` param (ND uses `nd_triggers_per_target`).
- **NdFCManager** (new): per-target today/lifetime counts, global daily (`ndstc`/`ndstmcd`) + session (`ndmc`) caps, daily reset, `canShow`/`didShow`, `ndtlc`/`ndmp` serializers, `updateLimits`. Model-light API (primitives), no legacy migration.
- Wiring via `CleverTapFactory` / `CoreState` / `ControllerManager` (+ `CleverTapAPI` late-init parity).

All ND state lives in separate prefs namespaces — no collision with in-app.

## Docs
- `docs/NativeDisplayFrequencyCaps.md` — Android SDK TAN for ND fcaps.
- `docs/InAppFrequencyCapsAndServing.md` — in-app fcaps/serving reference the TAN builds on.

## Verification
- `:clevertap-core:compileDebugSources` + `compileDebugUnitTestSources` — BUILD SUCCESSFUL.
- `ImpressionManagerTest`, `TriggerManagerTest` — pass (behavior-preserving refactor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Native Display frequency-cap support, including daily, session, lifetime, global, and per-target limits.
  * Native Display impressions and evaluation data are now tracked separately from in-app notifications.
  * Added support for updating limits, recording impressions, switching devices, and cleaning up stale display targets.

* **Documentation**
  * Added comprehensive documentation for in-app serving and frequency caps.
  * Added technical documentation for Native Display frequency-cap behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->