### PR TITLE
SDK-6059 [Android][ND] Phase 3: request-header counters (ndtlc/ndmp)

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/QueueHeaderBuilder.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/QueueHeaderBuilder.kt
@@ -53,6 +53,7 @@ internal class QueueHeaderBuilder(
             addReferrerInfo(header)
             addWzrkParams(header)
             addInAppFC(header)
+            addNdFC(header)
             return header
         } catch (e: JSONException) {
             logger.verbose(config.accountId, "CommsManager: Failed to attach header", e)
@@ -191,5 +192,19 @@ internal class QueueHeaderBuilder(
             header.put("imp", it.shownTodayCount)
             header.put("tlc", it.getInAppsCount(context))
         } ?: logger.verbose(config.accountId, "controllerManager.getInAppFCManager() is NULL, not Attaching InAppFC to Header")
+    }
+
+    /**
+     * Native Display (ND) frequency-cap counters (SDK-6055). Mirrors [addInAppFC] but in ND's own
+     * keyspace: `ndmp` = SDK's ND render count today, `ndtlc` = [[ti, today, lifetime], ...].
+     * The `adUnit_eval` / `adUnit_suppressed` meta are attached separately by the ND evaluator's
+     * NetworkHeadersListener (they are populated by local evaluation, not by the counter store).
+     */
+    private fun addNdFC(header: JSONObject) {
+        controllerManager.ndFCManager?.let {
+            Logger.v("Attaching NdFC to Header")
+            header.put(Constants.ND_MAX_PER_DAY_KEY, it.shownTodayCount)
+            header.put(Constants.ND_TARGET_SHOWN_LIST, it.getNdCounts(context))
+        } ?: logger.verbose(config.accountId, "controllerManager.getNdFCManager() is NULL, not Attaching NdFC to Header")
     }
 }


### PR DESCRIPTION
Part of epic **SDK-6055** · ticket **SDK-6059** · design **SDK-6056** (`docs/NativeDisplayFrequencyCaps.md` §3.2). **Stacked on #1058 (Phase 2).**

Attaches the ND frequency-cap **counters** to the `/a1` queue header via `QueueHeaderBuilder.addNdFC`, mirroring `addInAppFC` in ND's keyspace:
- **`ndmp`** = `NdFCManager.getShownTodayCount()` — the SDK's ND render count today.
- **`ndtlc`** = `NdFCManager.getNdCounts()` — `[[ti, today, lifetime], ...]`.

## Scope note
`adUnit_eval` / `adUnit_suppressed` header meta are **moved to Phase 4** (evaluator), where the in-memory eval/suppressed lists live and the attach → send → remove-exactly-sent lifecycle is owned — matching how in-app's `EvaluationManager.onAttachHeaders` does it. This keeps the counter header (this PR) cleanly separate from evaluation.

## Verification
- `:clevertap-core:compileDebugSources` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Native Display frequency-cap information is now included in network request headers.
  * Daily render counts and target display limits are recorded when frequency-cap tracking is available.
  * Added logging when Native Display frequency-cap tracking is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->