### PR TITLE
SDK-6060 [Android][ND] Phase 4: ND evaluator + adUnit_eval header

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
@@ -28,6 +28,7 @@ import com.clevertap.android.sdk.inapp.customtemplates.system.SystemTemplates
 import com.clevertap.android.sdk.inapp.delay.DelayedInAppStorageStrategy
 import com.clevertap.android.sdk.inapp.delay.InAppSchedulerFactory
 import com.clevertap.android.sdk.inapp.evaluation.EvaluationManager
+import com.clevertap.android.sdk.inapp.evaluation.NdEvaluationManager
 import com.clevertap.android.sdk.inapp.evaluation.LimitsMatcher
 import com.clevertap.android.sdk.inapp.evaluation.TriggersMatcher
 import com.clevertap.android.sdk.inapp.images.FileResourceProvider
@@ -254,6 +255,15 @@ internal object CleverTapFactory {
             templatesManager = templatesManager
         )
 
+        // Native Display (ND) evaluator (SDK-6055) — reuses matchers over ND's own stores.
+        val ndLimitsMatcher = LimitsMatcher(ndImpressionManager, ndTriggersManager)
+        val ndEvaluationManager = NdEvaluationManager(
+            triggersMatcher = triggersMatcher,
+            ndTriggersManager = ndTriggersManager,
+            ndLimitsMatcher = ndLimitsMatcher,
+            storeRegistry = storeRegistry
+        )
+
         val taskInitStores = executors.ioTask<Unit>()
         taskInitStores.execute("initStores") {
             if (deviceInfo.getDeviceID() != null) {
@@ -285,6 +295,7 @@ internal object CleverTapFactory {
                         accountId = config.accountId
                     )
                     storeRegistry.ndStore = ndStore
+                    ndEvaluationManager.loadEvaluatedAndSuppressedNdIds()
                     callbackManager.addChangeUserCallback(ndStore)
                 }
                 if (storeRegistry.ndImpressionStore == null) {
@@ -522,6 +533,7 @@ internal object CleverTapFactory {
         )
 
         networkManager.addNetworkHeadersListener(evaluationManager)
+        networkManager.addNetworkHeadersListener(ndEvaluationManager)
 
         val pipManager = PIPManager { FileResourceProvider.initInstance(context, config.logger, networkMonitor) }
 
@@ -537,6 +549,7 @@ internal object CleverTapFactory {
             deviceInfo,
             StoreRegistryInAppQueue(storeRegistry, config.accountId),
             evaluationManager,
+            ndEvaluationManager,
             templatesManager,
             inAppActionHandler,
             inAppNotificationInflater,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -47,6 +47,7 @@ import com.clevertap.android.sdk.inapp.delay.DelayedInAppResult
 import com.clevertap.android.sdk.inapp.delay.InActionResult
 import com.clevertap.android.sdk.inapp.delay.InAppScheduler
 import com.clevertap.android.sdk.inapp.evaluation.EvaluationManager
+import com.clevertap.android.sdk.inapp.evaluation.NdEvaluationManager
 import com.clevertap.android.sdk.inapp.fragment.CTInAppBaseFragment
 import com.clevertap.android.sdk.inapp.fragment.CTInAppHtmlFooterFragment
 import com.clevertap.android.sdk.inapp.fragment.CTInAppHtmlHeaderFragment
@@ -76,6 +77,7 @@ internal class InAppController(
     private val deviceInfo: DeviceInfo,
     private val inAppQueue: InAppQueue,
     private val evaluationManager: EvaluationManager,
+    private val ndEvaluationManager: NdEvaluationManager,
     private val templatesManager: TemplatesManager,
     private val inAppActionHandler: InAppActionHandler,
     private val inAppNotificationInflater: InAppNotificationInflater,
@@ -572,6 +574,9 @@ internal class InAppController(
         val appFieldsWithEventProperties = JsonUtil.mapFromJson<Any>(deviceInfo.appLaunchedFields)
         appFieldsWithEventProperties.putAll(eventProperties)
 
+        // Native Display (ND) local evaluation — votes eligible advanced campaigns into adUnit_eval.
+        ndEvaluationManager.evaluateOnEvent(eventName, appFieldsWithEventProperties, userLocation)
+
         // Returns (immediateCS, delayedCS, inActionSS)
         val evaluatedInApps = evaluationManager.evaluateOnEvent(
             eventName,
@@ -605,6 +610,9 @@ internal class InAppController(
             JsonUtil.mapFromJson<Any>(deviceInfo.appLaunchedFields)
         appFieldsWithChargedEventProperties.putAll(chargeDetails)
 
+        // Native Display (ND) local evaluation.
+        ndEvaluationManager.evaluateOnChargedEvent(appFieldsWithChargedEventProperties, items, userLocation)
+
         // Returns (immediateCS, delayedCS, inActionSS)
         val evaluatedInApps = evaluationManager.evaluateOnChargedEvent(
             appFieldsWithChargedEventProperties,
@@ -634,6 +642,9 @@ internal class InAppController(
         location: Location?
     ) {
         val appFields = JsonUtil.mapFromJson<Any>(deviceInfo.appLaunchedFields)
+
+        // Native Display (ND) local evaluation.
+        ndEvaluationManager.evaluateOnUserAttributeChange(userAttributeChangedProperties, location, appFields)
 
         // Returns (immediateCS, delayedCS, inActionSS)
         val evaluatedInApps = evaluationManager.evaluateOnUserAttributeChange(

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManager.kt
@@ -1,0 +1,203 @@
+package com.clevertap.android.sdk.inapp.evaluation
+
+import android.location.Location
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.WorkerThread
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.Logger
+import com.clevertap.android.sdk.inapp.TriggerManager
+import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry
+import com.clevertap.android.sdk.isNotNullAndEmpty
+import com.clevertap.android.sdk.network.EndpointId
+import com.clevertap.android.sdk.network.EndpointId.ENDPOINT_A1
+import com.clevertap.android.sdk.network.NetworkHeadersListener
+import com.clevertap.android.sdk.orEmptyArray
+import com.clevertap.android.sdk.toList
+import com.clevertap.android.sdk.variables.JsonUtil
+import org.json.JSONObject
+
+/**
+ * Local evaluation of Native Display (ND) advanced-rule campaigns (SDK-6055, Phase 4).
+ *
+ * ND is SS-only. On each event the SDK evaluates the cached advanced-rule metadata bundle
+ * (`adUnit_notifs_ss`) exactly like in-app SS: match `whenTriggers` → increment the ND trigger
+ * count → check `whenLimits` (frequency + occurrence) over ND's own impression/trigger stores. Every
+ * eligible campaign's `ti` is added to the `adUnit_eval` vote list, which is reported back in the
+ * `/a1` request header; the server delivers content only for voted campaigns.
+ *
+ * The class is the ND [NetworkHeadersListener]: it owns the in-memory `adUnit_eval` /
+ * `adUnit_suppressed` lists (persisted via [StoreRegistry.ndStore]) and the attach → send →
+ * remove-exactly-sent lifecycle. `adUnit_suppressed` (App-Launched CG acks) is populated in Phase 6.
+ *
+ * Reuses [TriggersMatcher] and [LimitsMatcher]; only the stores differ from in-app.
+ */
+internal class NdEvaluationManager(
+    private val triggersMatcher: TriggersMatcher,
+    private val ndTriggersManager: TriggerManager,
+    private val ndLimitsMatcher: LimitsMatcher,
+    private val storeRegistry: StoreRegistry
+) : NetworkHeadersListener {
+
+    companion object {
+        private val TAG = NdEvaluationManager::class.java.simpleName
+    }
+
+    @VisibleForTesting
+    internal var evaluatedNdCampaignIds: MutableList<Long> = ArrayList()
+
+    // App-Launched CG-suppression acks (bare {wzrk_id, wzrk_pivot, wzrk_cgId}); filled in Phase 6.
+    @VisibleForTesting
+    internal var suppressedNdCampaigns: MutableList<Map<String, Any?>> = ArrayList()
+
+    fun evaluateOnEvent(
+        eventName: String,
+        eventProperties: Map<String, Any>,
+        userLocation: Location?
+    ) {
+        evaluate(listOf(EventAdapter(eventName, eventProperties, userLocation = userLocation)))
+    }
+
+    fun evaluateOnChargedEvent(
+        details: Map<String, Any>,
+        items: List<Map<String, Any>>,
+        userLocation: Location?
+    ) {
+        evaluate(listOf(EventAdapter(Constants.CHARGED_EVENT, details, items, userLocation = userLocation)))
+    }
+
+    fun evaluateOnUserAttributeChange(
+        eventProperties: Map<String, Map<String, Any?>>,
+        userLocation: Location?,
+        appFields: Map<String, Any>
+    ) {
+        val events = eventProperties.map { entry ->
+            val merged = entry.value.toMutableMap().apply { putAll(appFields) }
+            EventAdapter(
+                eventName = entry.key + Constants.USER_ATTRIBUTE_CHANGE,
+                eventProperties = merged,
+                userLocation = userLocation,
+                profileAttrName = entry.key
+            )
+        }
+        evaluate(events)
+    }
+
+    /**
+     * Core loop: for each event, vote every advanced-rule ND campaign whose triggers match and whose
+     * whenLimits still pass. Mirrors [EvaluationManager.evaluate] minus display/priority/suppression
+     * (the server owns dispatch for ND; the SDK only votes eligibility).
+     */
+    @WorkerThread
+    @VisibleForTesting
+    internal fun evaluate(events: List<EventAdapter>) {
+        val ndStore = storeRegistry.ndStore ?: return
+        val metadata = ndStore.readServerSideNdMetaData()
+        if (metadata.isEmpty()) return
+
+        var updated = false
+        for (event in events) {
+            for (inApp in metadata) {
+                if (!triggersMatcher.matchEvent(getWhenTriggers(inApp), event)) {
+                    continue
+                }
+                val campaignId = inApp.optString(Constants.INAPP_ID_IN_PAYLOAD)
+                if (campaignId.isEmpty()) continue
+
+                ndTriggersManager.increment(campaignId)
+
+                if (ndLimitsMatcher.matchWhenLimits(getWhenLimits(inApp), campaignId)) {
+                    val ti = campaignId.toLongOrNull() ?: continue
+                    if (!evaluatedNdCampaignIds.contains(ti)) {
+                        evaluatedNdCampaignIds.add(ti)
+                        updated = true
+                        Logger.v(TAG, "ND campaign $ti eligible -> adUnit_eval")
+                    }
+                }
+            }
+        }
+        if (updated) {
+            saveEvaluatedNdIds()
+        }
+    }
+
+    @VisibleForTesting
+    internal fun getWhenTriggers(triggerJson: JSONObject): List<TriggerAdapter> {
+        val whenTriggers = triggerJson.optJSONArray(Constants.INAPP_WHEN_TRIGGERS).orEmptyArray()
+        return (0 until whenTriggers.length()).mapNotNull {
+            (whenTriggers[it] as? JSONObject)?.let { obj -> TriggerAdapter(obj) }
+        }
+    }
+
+    @VisibleForTesting
+    internal fun getWhenLimits(limitJSON: JSONObject): List<LimitAdapter> {
+        val frequencyLimits = limitJSON.optJSONArray(Constants.INAPP_FC_LIMITS).orEmptyArray()
+        val occurrenceLimits = limitJSON.optJSONArray(Constants.INAPP_OCCURRENCE_LIMITS).orEmptyArray()
+        return (frequencyLimits.toList<JSONObject>() + occurrenceLimits.toList()).mapNotNull {
+            if (it.isNotNullAndEmpty()) LimitAdapter(it) else null
+        }
+    }
+
+    override fun onAttachHeaders(endpointId: EndpointId): JSONObject? {
+        if (endpointId != ENDPOINT_A1) return null
+        val header = JSONObject()
+        if (evaluatedNdCampaignIds.isNotEmpty()) {
+            header.put(Constants.ND_SS_EVAL_META, JsonUtil.listToJsonArray(evaluatedNdCampaignIds))
+        }
+        if (suppressedNdCampaigns.isNotEmpty()) {
+            header.put(Constants.ND_SUPPRESSED_META, JsonUtil.listToJsonArray(suppressedNdCampaigns))
+        }
+        return if (header.isNotNullAndEmpty()) header else null
+    }
+
+    override fun onSentHeaders(allHeaders: JSONObject, endpointId: EndpointId) {
+        if (endpointId != ENDPOINT_A1) return
+        removeSentEvaluatedNdIds(allHeaders)
+        removeSentSuppressedNd(allHeaders)
+    }
+
+    private fun removeSentEvaluatedNdIds(header: JSONObject) {
+        var updated = false
+        header.optJSONArray(Constants.ND_SS_EVAL_META)?.let {
+            for (i in 0 until it.length()) {
+                val ti = it.optLong(i)
+                if (ti != 0L) {
+                    updated = evaluatedNdCampaignIds.remove(ti) || updated
+                }
+            }
+        }
+        if (updated) saveEvaluatedNdIds()
+    }
+
+    private fun removeSentSuppressedNd(header: JSONObject) {
+        var updated = false
+        val sent = header.optJSONArray(Constants.ND_SUPPRESSED_META) ?: return
+        val sentString = sent.toString()
+        val iterator = suppressedNdCampaigns.iterator()
+        while (iterator.hasNext()) {
+            val id = iterator.next()[Constants.NOTIFICATION_ID_TAG] as? String
+            if (id != null && sentString.contains(id)) {
+                iterator.remove()
+                updated = true
+            }
+        }
+        if (updated) saveSuppressedNdIds()
+    }
+
+    @WorkerThread
+    fun loadEvaluatedAndSuppressedNdIds() {
+        storeRegistry.ndStore?.let { store ->
+            evaluatedNdCampaignIds = store.readEvaluatedServerSideNdIds().toList<Long>().toMutableList()
+            suppressedNdCampaigns = JsonUtil.listFromJsonSafe(store.readSuppressedNdIds())
+        }
+    }
+
+    @VisibleForTesting
+    internal fun saveEvaluatedNdIds() {
+        storeRegistry.ndStore?.storeEvaluatedServerSideNdIds(JsonUtil.listToJsonArray(evaluatedNdCampaignIds))
+    }
+
+    @VisibleForTesting
+    internal fun saveSuppressedNdIds() {
+        storeRegistry.ndStore?.storeSuppressedNdIds(JsonUtil.listToJsonArray(suppressedNdCampaigns))
+    }
+}

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/InAppControllerTest.kt
@@ -1019,6 +1019,7 @@ class InAppControllerTest {
             deviceInfo = mockk(relaxed = true),
             inAppQueue = fakeInAppQueue,
             evaluationManager = mockEvaluationManager,
+            ndEvaluationManager = mockk(relaxed = true),
             templatesManager = mockTemplatesManager,
             inAppActionHandler = mockInAppActionHandler,
             inAppNotificationInflater = mockInAppInflater,


### PR DESCRIPTION
Part of epic **SDK-6055** · ticket **SDK-6060** · design **SDK-6056** (`docs/NativeDisplayFrequencyCaps.md` §6). **Stacked on #1060 (Phase 3).**

Adds **`NdEvaluationManager`** — local evaluation of advanced-rule ND campaigns on the event stream, mirroring in-app SS but over ND's own impression/trigger stores.

## What's in this PR
- `evaluateOnEvent` / `evaluateOnChargedEvent` / `evaluateOnUserAttributeChange`: read the cached `adUnit_notifs_ss` bundle, match `whenTriggers` (reusing `TriggersMatcher`), increment the ND trigger count, check `whenLimits` (reusing `LimitsMatcher` over `ndImpressionManager` + `ndTriggersManager`), and vote eligible `ti`s into `adUnit_eval`.
- Implements `NetworkHeadersListener`: attaches **`adUnit_eval`** (+ `adUnit_suppressed`, populated in Phase 6) for `ENDPOINT_A1`, and on send removes **exactly** the ids present in the sent header (guards concurrent evals). Lists persisted via `NdStore`.
- Wiring: constructed in `CleverTapFactory` (`ndLimitsMatcher` over ND managers), registered as a header listener, loaded on store init, injected into `InAppController` and invoked alongside in-app evaluation in the `onQueue*` hooks.

## Notes
- The SDK doesn't classify campaigns — only advanced-rule non-journey campaigns appear in `adUnit_notifs_ss` (server filter), so "evaluate the bundle, vote eligible" is correct by construction.
- Reuses `TriggersMatcher`/`LimitsMatcher` unchanged; only the backing stores differ from in-app.

## Verification
- `:clevertap-core:compileDebugSources` + `compileDebugUnitTestSources` — BUILD SUCCESSFUL (incl. `InAppControllerTest` constructor updated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)