### PR TITLE
SDK-6062 [Android][ND] Phase 6: CG-suppression acks (App-Launched)

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
@@ -439,7 +439,7 @@ internal object CleverTapFactory {
             ),
             FetchVariablesResponse(config, controllerManager, callbackManager),
             DisplayUnitResponse(config, callbackManager, controllerManager),
-            AdUnitResponse(config, storeRegistry, controllerManager, ndTriggersManager),
+            AdUnitResponse(config, storeRegistry, controllerManager, ndTriggersManager, ndEvaluationManager, callbackManager),
             FeatureFlagResponse(config, controllerManager),
             ProductConfigResponse(config, coreMetaData, controllerManager),
             GeofenceResponse(config, callbackManager),

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManager.kt
@@ -137,6 +137,27 @@ internal class NdEvaluationManager(
         }
     }
 
+    /**
+     * Records a CG-suppressed App-Launched ND stub as an `adUnit_suppressed` ack. The server ships
+     * stubs (`suppressed:true` + `wzrk_cgId`) inline in `adUnit_notifs_applaunched`; the SDK acks at
+     * its would-have-been-surfaced moment (App-Launched path only — regular events need no ack) so the
+     * CG event fires at render time rather than server-delivery time. Bare shape mirrors in-app's
+     * `inapps_suppressed`.
+     */
+    fun recordCgSuppressed(stub: JSONObject) {
+        val wzrkId = stub.optString(Constants.NOTIFICATION_ID_TAG)
+        if (wzrkId.isEmpty()) return
+        suppressedNdCampaigns.add(
+            mapOf(
+                Constants.NOTIFICATION_ID_TAG to wzrkId,
+                Constants.INAPP_WZRK_PIVOT to stub.optString(Constants.INAPP_WZRK_PIVOT, "wzrk_default"),
+                Constants.INAPP_WZRK_CGID to stub.optInt(Constants.INAPP_WZRK_CGID)
+            )
+        )
+        saveSuppressedNdIds()
+        Logger.v(TAG, "Recorded ND CG-suppression ack for $wzrkId")
+    }
+
     override fun onAttachHeaders(endpointId: EndpointId): JSONObject? {
         if (endpointId != ENDPOINT_A1) return null
         val header = JSONObject()

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/response/AdUnitResponse.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/response/AdUnitResponse.java
@@ -1,16 +1,21 @@
 package com.clevertap.android.sdk.response;
 
 import android.content.Context;
+import android.text.TextUtils;
 
 import androidx.annotation.WorkerThread;
 
+import com.clevertap.android.sdk.BaseCallbackManager;
 import com.clevertap.android.sdk.CleverTapInstanceConfig;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.ControllerManager;
 import com.clevertap.android.sdk.Logger;
 import com.clevertap.android.sdk.NdFCManager;
 import com.clevertap.android.sdk.Utils;
+import com.clevertap.android.sdk.displayunits.DisplayUnitCache;
+import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
 import com.clevertap.android.sdk.inapp.TriggerManager;
+import com.clevertap.android.sdk.inapp.evaluation.NdEvaluationManager;
 import com.clevertap.android.sdk.inapp.store.preference.ImpressionStore;
 import com.clevertap.android.sdk.inapp.store.preference.NdStore;
 import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry;
@@ -18,6 +23,7 @@ import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -45,18 +51,26 @@ public class AdUnitResponse extends CleverTapResponse {
 
     private final TriggerManager ndTriggerManager;
 
+    private final NdEvaluationManager ndEvaluationManager;
+
+    private final BaseCallbackManager callbackManager;
+
     private final Logger logger;
 
     public AdUnitResponse(
             CleverTapInstanceConfig config,
             StoreRegistry storeRegistry,
             ControllerManager controllerManager,
-            TriggerManager ndTriggerManager
+            TriggerManager ndTriggerManager,
+            NdEvaluationManager ndEvaluationManager,
+            BaseCallbackManager callbackManager
     ) {
         this.config = config;
         this.storeRegistry = storeRegistry;
         this.controllerManager = controllerManager;
         this.ndTriggerManager = ndTriggerManager;
+        this.ndEvaluationManager = ndEvaluationManager;
+        this.callbackManager = callbackManager;
         this.logger = config.getLogger();
     }
 
@@ -103,8 +117,52 @@ public class AdUnitResponse extends CleverTapResponse {
                             Constants.FEATURE_DISPLAY_UNIT + "Stored " + meta.size() + " ND SS metadata entries");
                 }
             }
+
+            // 4. App-Launched content-in-advance: deliver real content (fcap-gated) and ack any
+            //    CG-suppressed stubs via adUnit_suppressed.
+            processAppLaunched(response);
         } catch (Throwable t) {
             logger.verbose(config.getAccountId(), Constants.FEATURE_DISPLAY_UNIT + "Failed to process ND response", t);
+        }
+    }
+
+    /**
+     * Handles {@code adUnit_notifs_applaunched}: entries flagged {@code suppressed:true} are CG stubs
+     * — the SDK renders nothing and acks them via {@code adUnit_suppressed}; the remaining entries are
+     * real content delivered to the host through the display-unit cache/callback, filtered by the ND
+     * frequency-cap gate.
+     */
+    private void processAppLaunched(final JSONObject response) {
+        final JSONArray appLaunched = response.optJSONArray(Constants.DISPLAY_UNIT_NOTIFS_APP_LAUNCHED_KEY);
+        if (appLaunched == null || appLaunched.length() == 0) {
+            return;
+        }
+
+        final ArrayList<CleverTapDisplayUnit> content = new ArrayList<>();
+        for (int i = 0; i < appLaunched.length(); i++) {
+            final JSONObject entry = appLaunched.optJSONObject(i);
+            if (entry == null) {
+                continue;
+            }
+            if (entry.optBoolean(Constants.INAPP_SUPPRESSED, false)) {
+                ndEvaluationManager.recordCgSuppressed(entry); // CG stub -> ack, render nothing
+                continue;
+            }
+            final CleverTapDisplayUnit unit = CleverTapDisplayUnit.toDisplayUnit(entry);
+            if (TextUtils.isEmpty(unit.getError())) {
+                content.add(unit);
+            }
+        }
+
+        final ArrayList<CleverTapDisplayUnit> allowed =
+                NdFcapGate.filter(content, controllerManager.getNdFCManager(), logger, config.getAccountId());
+        if (allowed.isEmpty()) {
+            return;
+        }
+        final DisplayUnitCache cache = controllerManager.getOrCreateDisplayUnitCache();
+        if (cache != null) {
+            cache.updateDisplayUnits(allowed);
+            callbackManager.notifyDisplayUnitsLoaded(allowed);
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/response/DisplayUnitResponse.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/response/DisplayUnitResponse.java
@@ -8,7 +8,6 @@ import com.clevertap.android.sdk.CleverTapInstanceConfig;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.ControllerManager;
 import com.clevertap.android.sdk.Logger;
-import com.clevertap.android.sdk.NdFCManager;
 import com.clevertap.android.sdk.displayunits.DisplayUnitCache;
 import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
 import java.util.ArrayList;
@@ -97,62 +96,12 @@ public class DisplayUnitResponse extends CleverTapResponseDecorator {
             return;
         }
 
-        ArrayList<CleverTapDisplayUnit> displayUnits = applyNdFrequencyCaps(parseDisplayUnitsFromJson(messages));
+        ArrayList<CleverTapDisplayUnit> displayUnits = NdFcapGate.filter(
+                parseDisplayUnitsFromJson(messages), controllerManager.getNdFCManager(), logger, config.getAccountId());
         cache.updateDisplayUnits(displayUnits);
         if (!displayUnits.isEmpty()) {
             callbackManager.notifyDisplayUnitsLoaded(displayUnits);
         }
-    }
-
-    /**
-     * Native Display frequency caps (SDK-6055): drops units whose counter caps are maxed out before
-     * they are handed to the host (the ND analog of in-app's canShow gate). Only units that carry an
-     * fcap marker ({@code efc}/{@code tlc}/{@code tdc}/{@code mdc}/{@code excludeGlobalFCaps}) are
-     * gated; unmarked units pass through unchanged so existing (non-fcap) display units are never
-     * affected. Advanced {@code frequencyLimits}/{@code occurrenceLimits} were already applied during
-     * evaluation (the server only ships content for {@code adUnit_eval}-voted campaigns), so the
-     * delivery-time re-check here covers the counter caps only.
-     */
-    @NonNull
-    private ArrayList<CleverTapDisplayUnit> applyNdFrequencyCaps(@NonNull ArrayList<CleverTapDisplayUnit> units) {
-        final NdFCManager ndFCManager = controllerManager.getNdFCManager();
-        if (ndFCManager == null) {
-            return units;
-        }
-        final ArrayList<CleverTapDisplayUnit> allowed = new ArrayList<>(units.size());
-        for (CleverTapDisplayUnit unit : units) {
-            final JSONObject json = unit.getJsonObject();
-            if (json == null || !isFcapManaged(json)) {
-                allowed.add(unit); // not fcap-managed -> deliver as before
-                continue;
-            }
-            final boolean excludeFromCaps =
-                    json.optInt(Constants.KEY_EFC, -1) == 1
-                            || json.optInt(Constants.KEY_EXCLUDE_GLOBAL_CAPS, -1) == 1;
-            final boolean canShow = ndFCManager.canShow(
-                    unit.getUnitID(),
-                    excludeFromCaps,
-                    json.optInt(Constants.KEY_TLC, -1),  // -1 = uncapped
-                    json.optInt(Constants.KEY_TDC, -1),  // -1 = uncapped
-                    json.optInt(Constants.INAPP_MAX_DISPLAY_COUNT, -1),
-                    false /* advanced whenLimits already applied at evaluation time */);
-            if (canShow) {
-                allowed.add(unit);
-            } else {
-                logger.verbose(config.getAccountId(),
-                        Constants.FEATURE_DISPLAY_UNIT + "ND unit " + unit.getUnitID()
-                                + " suppressed by frequency caps");
-            }
-        }
-        return allowed;
-    }
-
-    private static boolean isFcapManaged(@NonNull JSONObject json) {
-        return json.has(Constants.KEY_EFC)
-                || json.has(Constants.KEY_TLC)
-                || json.has(Constants.KEY_TDC)
-                || json.has(Constants.INAPP_MAX_DISPLAY_COUNT)
-                || json.has(Constants.KEY_EXCLUDE_GLOBAL_CAPS);
     }
 
     /**

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/response/NdFcapGate.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/response/NdFcapGate.java
@@ -1,0 +1,76 @@
+package com.clevertap.android.sdk.response;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.clevertap.android.sdk.Constants;
+import com.clevertap.android.sdk.Logger;
+import com.clevertap.android.sdk.NdFCManager;
+import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
+
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+
+/**
+ * Native Display frequency-cap gate (SDK-6055). Filters display units through
+ * {@link NdFCManager#canShow} before they are handed to the host — the ND analog of in-app's
+ * pre-display cap gate.
+ *
+ * <p>Only units carrying an fcap marker ({@code efc}/{@code tlc}/{@code tdc}/{@code mdc}/
+ * {@code excludeGlobalFCaps}) are gated; unmarked units pass through unchanged so existing non-fcap
+ * display units are never affected. Advanced {@code frequencyLimits}/{@code occurrenceLimits} were
+ * already applied during evaluation (the server only ships content for {@code adUnit_eval}-voted
+ * campaigns), so the delivery-time re-check here covers the counter caps only.
+ */
+final class NdFcapGate {
+
+    private NdFcapGate() {
+    }
+
+    @NonNull
+    static ArrayList<CleverTapDisplayUnit> filter(
+            @NonNull ArrayList<CleverTapDisplayUnit> units,
+            @Nullable NdFCManager ndFCManager,
+            @NonNull Logger logger,
+            String accountId
+    ) {
+        if (ndFCManager == null) {
+            return units;
+        }
+        final ArrayList<CleverTapDisplayUnit> allowed = new ArrayList<>(units.size());
+        for (CleverTapDisplayUnit unit : units) {
+            final JSONObject json = unit.getJsonObject();
+            if (json == null || !isFcapManaged(json)) {
+                allowed.add(unit); // not fcap-managed -> deliver as before
+                continue;
+            }
+            final boolean excludeFromCaps =
+                    json.optInt(Constants.KEY_EFC, -1) == 1
+                            || json.optInt(Constants.KEY_EXCLUDE_GLOBAL_CAPS, -1) == 1;
+            final boolean canShow = ndFCManager.canShow(
+                    unit.getUnitID(),
+                    excludeFromCaps,
+                    json.optInt(Constants.KEY_TLC, -1),   // -1 = uncapped
+                    json.optInt(Constants.KEY_TDC, -1),   // -1 = uncapped
+                    json.optInt(Constants.INAPP_MAX_DISPLAY_COUNT, -1),
+                    false /* advanced whenLimits already applied at evaluation time */);
+            if (canShow) {
+                allowed.add(unit);
+            } else {
+                logger.verbose(accountId,
+                        Constants.FEATURE_DISPLAY_UNIT + "ND unit " + unit.getUnitID()
+                                + " suppressed by frequency caps");
+            }
+        }
+        return allowed;
+    }
+
+    private static boolean isFcapManaged(@NonNull JSONObject json) {
+        return json.has(Constants.KEY_EFC)
+                || json.has(Constants.KEY_TLC)
+                || json.has(Constants.KEY_TDC)
+                || json.has(Constants.INAPP_MAX_DISPLAY_COUNT)
+                || json.has(Constants.KEY_EXCLUDE_GLOBAL_CAPS);
+    }
+}


### PR DESCRIPTION
Part of epic **SDK-6055** · ticket **SDK-6062** · design **SDK-6056** (`docs/NativeDisplayFrequencyCaps.md` §6.3). **Stacked on #1062 (Phase 5).**

Adds control-group (CG) suppression acks for App-Launched ND content-in-advance.

## What's in this PR
- **`NdEvaluationManager.recordCgSuppressed`** builds an `adUnit_suppressed` ack `{wzrk_id, wzrk_pivot, wzrk_cgId}` from a server-shipped CG stub and persists it; the ND `NetworkHeadersListener` (Phase 4) attaches it to the `/a1` header.
- **`AdUnitResponse.processAppLaunched`** handles `adUnit_notifs_applaunched`: entries flagged `suppressed:true` are CG stubs (render nothing → ack); the rest are real content delivered to the host via the display-unit cache/callback, filtered by the ND cap gate.
- Extracted the ND cap gate into **`NdFcapGate`** (shared by `DisplayUnitResponse` and `AdUnitResponse`) to avoid duplication.

## Per contract
CG acks are **App-Launched-only**; regular-event CG is server-decided and needs no SDK ack. This also lands the deferred `adUnit_notifs_applaunched` content-delivery path (now that the gate exists).

## Verification
- `:clevertap-core:compileDebugSources` + `compileDebugUnitTestSources` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)