### PR TITLE
SDK-6063 [Android][ND] Phase 7: mid-session ND meta refresh + gating safety

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -3790,6 +3790,24 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
         coreState.getAnalyticsManager().sendFetchEvent(event);
     }
 
+    /**
+     * Requests a fresh Native Display (ND) advanced-rule metadata bundle mid-session (SDK-6055).
+     * Sends a {@code wzrk_fetch} event with {@code t = FETCH_TYPE_ND_META}; the server responds with
+     * {@code adUnit_notifs_ss} (see {@link com.clevertap.android.sdk.response.AdUnitResponse}). Old
+     * SDKs/servers ignore the unknown fetch type, so this is forward/backward compatible.
+     *
+     * Note: the placeholder fetch-type value must be locked with BE before release, and the exact
+     * refresh cadence (when the SDK fires this) is still to be finalised.
+     */
+    public void fetchNativeDisplayMeta() {
+        if (coreState.getConfig().isAnalyticsOnly()) {
+            return;
+        }
+        Logger.v(Constants.FEATURE_DISPLAY_UNIT + "Fetching Native Display metadata...");
+        JSONObject event = getFetchRequestAsJson(Constants.FETCH_TYPE_ND_META);
+        coreState.getAnalyticsManager().sendFetchEvent(event);
+    }
+
     @NonNull
     JSONObject getFetchRequestAsJson(int fetchType) {
         JSONObject event = new JSONObject();


### PR DESCRIPTION
Part of epic **SDK-6055** · ticket **SDK-6063** · design **SDK-6056** (`docs/NativeDisplayFrequencyCaps.md` §9). **Stacked on #1063 (Phase 6).**

Mid-session ND metadata refresh + gating-safety confirmation.

## What's in this PR
- **`CleverTapAPI.fetchNativeDisplayMeta()`** — sends `wzrk_fetch` with `t = FETCH_TYPE_ND_META` to request a fresh `adUnit_notifs_ss` bundle mid-session (mirrors `fetchInApps`). Consumed by `AdUnitResponse`.

## Gating safety (already satisfied by design)
- **Version gate is server-side** — LC returns V2 by SDK version; the SDK signals V2 capability via `ndtlc`/`ndmp`/`adUnit_eval` (Phases 3–4).
- **Ignore unknown response keys** — ND response processors only read known keys; old SDKs drop `adUnit_*`.
- **Additive limit types** — `LimitType.fromString` falls back gracefully (no crash on unknown types).

## To lock with BE
- The `FETCH_TYPE_ND_META` value (placeholder `100`) and the exact refresh cadence (when the SDK fires this).

## Verification
- `:clevertap-core:compileDebugSources` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)