### PR TITLE
SDK-6064 [Android][ND] Phase 8: unit tests + doc finalization

### DIFF
--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManagerTest.kt
@@ -1,0 +1,111 @@
+package com.clevertap.android.sdk.inapp.evaluation
+
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.inapp.TriggerManager
+import com.clevertap.android.sdk.inapp.store.preference.NdStore
+import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry
+import com.clevertap.android.sdk.network.EndpointId
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NdEvaluationManagerTest {
+
+    private lateinit var triggersMatcher: TriggersMatcher
+    private lateinit var ndTriggersManager: TriggerManager
+    private lateinit var ndLimitsMatcher: LimitsMatcher
+    private lateinit var storeRegistry: StoreRegistry
+    private lateinit var ndStore: NdStore
+    private lateinit var manager: NdEvaluationManager
+
+    @Before
+    fun setUp() {
+        triggersMatcher = mockk()
+        ndTriggersManager = mockk(relaxed = true)
+        ndLimitsMatcher = mockk()
+        ndStore = mockk(relaxed = true)
+        storeRegistry = mockk(relaxed = true)
+        every { storeRegistry.ndStore } returns ndStore
+        manager = NdEvaluationManager(triggersMatcher, ndTriggersManager, ndLimitsMatcher, storeRegistry)
+    }
+
+    @Test
+    fun `evaluate votes eligible campaign into adUnit_eval`() {
+        val inApp = JSONObject().put(Constants.INAPP_ID_IN_PAYLOAD, "70001")
+        every { ndStore.readServerSideNdMetaData() } returns listOf(inApp)
+        every { triggersMatcher.matchEvent(any(), any()) } returns true
+        every { ndLimitsMatcher.matchWhenLimits(any(), any()) } returns true
+
+        manager.evaluateOnEvent("Home Viewed", emptyMap(), null)
+
+        assertTrue(manager.evaluatedNdCampaignIds.contains(70001L))
+        verify { ndTriggersManager.increment("70001") }
+        verify { ndStore.storeEvaluatedServerSideNdIds(any()) }
+    }
+
+    @Test
+    fun `evaluate does not vote when whenLimits fail`() {
+        val inApp = JSONObject().put(Constants.INAPP_ID_IN_PAYLOAD, "70001")
+        every { ndStore.readServerSideNdMetaData() } returns listOf(inApp)
+        every { triggersMatcher.matchEvent(any(), any()) } returns true
+        every { ndLimitsMatcher.matchWhenLimits(any(), any()) } returns false
+
+        manager.evaluateOnEvent("e", emptyMap(), null)
+
+        assertTrue(manager.evaluatedNdCampaignIds.isEmpty())
+        verify { ndTriggersManager.increment("70001") } // trigger still counted
+    }
+
+    @Test
+    fun `evaluate does not vote when trigger does not match`() {
+        val inApp = JSONObject().put(Constants.INAPP_ID_IN_PAYLOAD, "70001")
+        every { ndStore.readServerSideNdMetaData() } returns listOf(inApp)
+        every { triggersMatcher.matchEvent(any(), any()) } returns false
+
+        manager.evaluateOnEvent("e", emptyMap(), null)
+
+        assertTrue(manager.evaluatedNdCampaignIds.isEmpty())
+    }
+
+    @Test
+    fun `onAttachHeaders attaches adUnit_eval only for A1`() {
+        manager.evaluatedNdCampaignIds.add(70001L)
+
+        val header = manager.onAttachHeaders(EndpointId.ENDPOINT_A1)
+        assertEquals(
+            JSONArray().put(70001L).toString(),
+            header!!.optJSONArray(Constants.ND_SS_EVAL_META).toString()
+        )
+        assertNull(manager.onAttachHeaders(EndpointId.ENDPOINT_SPIKY))
+    }
+
+    @Test
+    fun `onSentHeaders removes exactly the sent eval ids`() {
+        manager.evaluatedNdCampaignIds.addAll(listOf(70001L, 70002L))
+        val sent = JSONObject().put(Constants.ND_SS_EVAL_META, JSONArray().put(70001L))
+
+        manager.onSentHeaders(sent, EndpointId.ENDPOINT_A1)
+
+        assertEquals(listOf(70002L), manager.evaluatedNdCampaignIds)
+    }
+
+    @Test
+    fun `recordCgSuppressed adds a bare ack entry`() {
+        val stub = JSONObject()
+            .put(Constants.NOTIFICATION_ID_TAG, "70004_20260810")
+            .put(Constants.INAPP_WZRK_CGID, 0)
+
+        manager.recordCgSuppressed(stub)
+
+        assertEquals(1, manager.suppressedNdCampaigns.size)
+        assertEquals("70004_20260810", manager.suppressedNdCampaigns[0][Constants.NOTIFICATION_ID_TAG])
+        assertEquals("wzrk_default", manager.suppressedNdCampaigns[0][Constants.INAPP_WZRK_PIVOT])
+    }
+}

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/store/preference/NdStoreTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/store/preference/NdStoreTest.kt
@@ -1,0 +1,82 @@
+package com.clevertap.android.sdk.inapp.store.preference
+
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.store.preference.ICTPreference
+import com.clevertap.android.sdk.toList
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class NdStoreTest {
+
+    private lateinit var ctPreference: ICTPreference
+    private lateinit var ndStore: NdStore
+
+    @Before
+    fun setUp() {
+        ctPreference = mockk(relaxed = true)
+        ndStore = NdStore(ctPreference)
+    }
+
+    @Test
+    fun `storeServerSideNdMetaData writes JSONArray and read returns it from cache`() {
+        val meta = JSONArray("[{\"ti\":70001},{\"ti\":70002}]").toList<JSONObject>()
+        every { ctPreference.writeString(any(), any()) } just Runs
+
+        ndStore.storeServerSideNdMetaData(meta)
+
+        assertEquals(meta.toString(), ndStore.readServerSideNdMetaData().toString())
+        verify { ctPreference.writeString(Constants.PREFS_ND_KEY_SS, JSONArray(meta).toString()) }
+    }
+
+    @Test
+    fun `readServerSideNdMetaData reads from prefs when no cache`() {
+        every { ctPreference.readString(Constants.PREFS_ND_KEY_SS, any()) } returns "[{\"ti\":70003}]"
+
+        val result = ndStore.readServerSideNdMetaData()
+
+        assertEquals(1, result.size)
+        assertEquals(70003, result[0].optInt("ti"))
+    }
+
+    @Test
+    fun `readServerSideNdMetaData returns empty on blank`() {
+        every { ctPreference.readString(Constants.PREFS_ND_KEY_SS, any()) } returns ""
+        assertEquals(0, ndStore.readServerSideNdMetaData().size)
+    }
+
+    @Test
+    fun `evaluated nd ids round trip`() {
+        every { ctPreference.readString(Constants.PREFS_EVALUATED_ND_KEY_SS, any()) } returns
+                JSONArray().put(70001L).put(70002L).toString()
+
+        assertEquals(2, ndStore.readEvaluatedServerSideNdIds().length())
+    }
+
+    @Test
+    fun `suppressed nd ids round trip`() {
+        every { ctPreference.readString(Constants.PREFS_SUPPRESSED_ND_KEY, any()) } returns
+                JSONArray().put(JSONObject().put(Constants.NOTIFICATION_ID_TAG, "70004_20260810")).toString()
+
+        assertEquals(1, ndStore.readSuppressedNdIds().length())
+    }
+
+    @Test
+    fun `removeServerSideNdMetaData clears key`() {
+        ndStore.removeServerSideNdMetaData()
+        verify { ctPreference.remove(Constants.PREFS_ND_KEY_SS) }
+    }
+
+    @Test
+    fun `onChangeUser changes preference name`() {
+        ndStore.onChangeUser("device_id", "account_id")
+        verify { ctPreference.changePreferenceName(any()) }
+    }
+}

--- a/docs/NativeDisplayFrequencyCaps.md
+++ b/docs/NativeDisplayFrequencyCaps.md
@@ -340,21 +340,31 @@ Still to lock:
 
 ---
 
-## 11. Phased implementation plan (SDK)
+## 11. Phased implementation plan (SDK) — tickets & PRs
 
-1. **Foundations**: constants + `StoreProvider` ND types + `NdStore`, `NdFCManager`, and a second
-   `ImpressionManager`/`TriggerManager` instance on ND namespaces. Daily-reset + serializers.
-2. **Response ingest**: `AdUnitResponse` for `adUnit_notifs_ss` (cache), `adUnit_notifs_applaunched`,
-   `adUnit_notifs`, `adUnit_stale`, `ndmc`/`ndmp`. Wire into `CleverTapFactory` chain.
-3. **Header out**: `ndtlc`/`ndmp` in `QueueHeaderBuilder`; `adUnit_eval`/`adUnit_suppressed` via an ND
-   `NetworkHeadersListener` (attach/remove exactly-sent).
-4. **Evaluator**: extract channel-agnostic eval core; add `NdEvaluationManager`; hook into the event
-   stream next to `initInAppEvaluation`. (Blocked on Q1.)
-5. **Cap gate + impressions**: `canShow`-equivalent at delivery; `recordImpression` on the viewed
-   event; global daily/session enforcement.
-6. **CG acks**: consume App-Launched stubs → `adUnit_suppressed`.
-7. **Refresh + flags**: `wzrk_fetch t=ND_META` trigger; version/flag gating; ignore-unknown-keys checks.
-8. **Tests + docs**: unit tests mirroring the in-app fcap tests; finalize this doc → Confluence.
+Implemented as a stack of PRs (base `develop`), one per phase, each `SDK-<ticket>-nd-phaseN`.
+
+| Phase | Ticket | PR | Status | Scope |
+|---|---|---|---|---|
+| 1 Foundations | SDK-6057 | #1057 | ✅ done | constants + `StoreProvider` ND types + `NdStore` + `NdFCManager` + ND `ImpressionManager`/`TriggerManager` (daily-reset, serializers). |
+| 2 Response ingest | SDK-6058 | #1058 | ✅ done | `AdUnitResponse`: `adUnit_notifs_ss` → `NdStore`, `adUnit_stale` GC, `ndmc`/`ndmp` → `updateLimits`. |
+| 3 Header (counters) | SDK-6059 | #1060 | ✅ done | `QueueHeaderBuilder.addNdFC` → `ndtlc`/`ndmp`. |
+| 4 Evaluator | SDK-6060 | #1061 | ✅ done | `NdEvaluationManager` (evaluate → `adUnit_eval`); `NetworkHeadersListener` for `adUnit_eval`/`adUnit_suppressed` (moved here from Phase 3 — the evaluator owns the lists). |
+| 5 Cap gate + impressions | SDK-6061 | #1062 | ✅ done | `NdFcapGate` at delivery (fcap-marked units only); `didShow` on the viewed event. |
+| 6 CG acks | SDK-6062 | #1063 | ✅ done | `recordCgSuppressed`; `AdUnitResponse.processAppLaunched` (stubs → ack, content → gated delivery). |
+| 7 Refresh + gating | SDK-6063 | #1064 | ✅ done | `fetchNativeDisplayMeta()` (`wzrk_fetch t=ND_META`); gating-safety confirmed. |
+| 8 Tests + docs | SDK-6064 | #1065 | ✅ done | `NdStoreTest`, `NdEvaluationManagerTest`; this status table. |
+
+Notes on adjustments made during implementation:
+- `adUnit_eval`/`adUnit_suppressed` header attach landed in **Phase 4** (not 3) because the evaluator
+  owns the in-memory lists + attach/remove-exactly-sent lifecycle (mirrors in-app `EvaluationManager`).
+- The delivery gate (Phase 5) is applied **only to fcap-marked units** to avoid regressing existing
+  ungated display units; full global-cap activation depends on the feature/version gate.
+- The `adUnit_notifs_applaunched` content path landed with **Phase 6** (alongside CG acks), once the
+  cap gate existed, so ND content is never delivered ungated.
+
+Still to lock with BE before release: the `FETCH_TYPE_ND_META` value (placeholder `100`), the
+mid-session refresh cadence, ND impression-map size, and viewed-event re-view/dedupe semantics.
 
 ---
 


### PR DESCRIPTION
Part of epic **SDK-6055** · ticket **SDK-6064** · design **SDK-6056**. **Stacked on #1064 (Phase 7).** Top of the ND fcaps stack.

## What's in this PR
- **`NdStoreTest`** — metadata store/read (+ cache), evaluated/suppressed round-trips, remove, `onChangeUser`.
- **`NdEvaluationManagerTest`** — votes an eligible campaign into `adUnit_eval`; no vote when whenLimits/triggers fail (trigger still counted); `onAttachHeaders` A1-only; `onSentHeaders` removes exactly the sent ids; `recordCgSuppressed` ack shape.
- **`docs/NativeDisplayFrequencyCaps.md`** — §11 finalized with the ticket/PR mapping, status table, and the implementation adjustments made across the stack.

## Verification
- `:clevertap-core:testDebugUnitTest` for `NdStoreTest` + `NdEvaluationManagerTest` — passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)