### PR TITLE
SDK-6065 [Android][ND] Phase 9: address Vision review feedback

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
@@ -353,9 +353,10 @@ public class AnalyticsManager extends BaseAnalyticsManager {
                 if (displayUnit != null) {
                     // Native Display frequency caps (SDK-6055): the viewed event is the ND impression
                     // hook (the host renders the unit; the SDK is not in the render path). Record it so
-                    // ndtlc/ndmp/session counters stay accurate.
+                    // ndtlc/ndmp/session counters stay accurate — but ONLY for fcap-managed units, so an
+                    // unmarked/legacy unit's view can't consume the ND global budget and starve gated ones.
                     NdFCManager ndFCManager = controllerManager.getNdFCManager();
-                    if (ndFCManager != null) {
+                    if (ndFCManager != null && NdFCManager.isFcapManaged(displayUnit.getJsonObject())) {
                         ndFCManager.didShow(context, unitID);
                     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -50,6 +50,7 @@ import com.clevertap.android.sdk.inapp.images.repo.FileResourcesRepoFactory;
 import com.clevertap.android.sdk.inapp.images.repo.FileResourcesRepoImpl;
 import com.clevertap.android.sdk.inapp.store.preference.ImpressionStore;
 import com.clevertap.android.sdk.inapp.store.preference.InAppStore;
+import com.clevertap.android.sdk.inapp.store.preference.NdStore;
 import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry;
 import com.clevertap.android.sdk.inbox.CTInboxActivity;
 import com.clevertap.android.sdk.inbox.CTInboxMessage;
@@ -3220,6 +3221,20 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
                 // can cause ANR if called from main thread
                 coreState.getCallbackManager().addChangeUserCallback(impStore);
             }
+            // Native Display (ND) frequency caps (SDK-6055): mirror the ND stores here too, else on
+            // the async device-id path they stay null for the process and ND capping silently no-ops.
+            if (storeRegistry.getNdStore() == null) {
+                NdStore ndStore = storeProvider.provideNdStore(context, deviceId, accountId);
+                storeRegistry.setNdStore(ndStore);
+                coreState.getNdEvaluationManager().loadEvaluatedAndSuppressedNdIds();
+                coreState.getCallbackManager().addChangeUserCallback(ndStore);
+            }
+            if (storeRegistry.getNdImpressionStore() == null) {
+                ImpressionStore ndImpStore = storeProvider.provideNdImpressionStore(context, deviceId,
+                        accountId);
+                storeRegistry.setNdImpressionStore(ndImpStore);
+                coreState.getCallbackManager().addChangeUserCallback(ndImpStore);
+            }
             return null;
         });
 
@@ -3797,8 +3812,10 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
      * SDKs/servers ignore the unknown fetch type, so this is forward/backward compatible.
      *
      * Note: the placeholder fetch-type value must be locked with BE before release, and the exact
-     * refresh cadence (when the SDK fires this) is still to be finalised.
+     * refresh cadence (when the SDK fires this) is still to be finalised. Kept SDK-internal
+     * ({@code LIBRARY_GROUP}) until both are locked, so it isn't a customer-facing contract yet.
      */
+    @RestrictTo(Scope.LIBRARY_GROUP)
     public void fetchNativeDisplayMeta() {
         if (coreState.getConfig().isAnalyticsOnly()) {
             return;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
@@ -438,8 +438,10 @@ internal object CleverTapFactory {
                 controllerManager
             ),
             FetchVariablesResponse(config, controllerManager, callbackManager),
+            // ND meta/acks must run before DisplayUnitResponse so ceilings + stale-purge land before
+            // the delivery cap gate; DisplayUnitResponse then delivers all ND content in one write.
+            AdUnitResponse(config, storeRegistry, controllerManager, ndTriggersManager, ndEvaluationManager),
             DisplayUnitResponse(config, callbackManager, controllerManager),
-            AdUnitResponse(config, storeRegistry, controllerManager, ndTriggersManager, ndEvaluationManager, callbackManager),
             FeatureFlagResponse(config, controllerManager),
             ProductConfigResponse(config, coreMetaData, controllerManager),
             GeofenceResponse(config, callbackManager),
@@ -666,6 +668,7 @@ internal object CleverTapFactory {
             evaluationManager = evaluationManager,
             ndImpressionManager = ndImpressionManager,
             ndTriggerManager = ndTriggersManager,
+            ndEvaluationManager = ndEvaluationManager,
             impressionManager = impressionManager,
             loginController = loginController,
             sessionManager = sessionManager,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CoreState.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CoreState.kt
@@ -10,6 +10,7 @@ import com.clevertap.android.sdk.inapp.InAppController
 import com.clevertap.android.sdk.inapp.TriggerManager
 import com.clevertap.android.sdk.inapp.customtemplates.TemplatesManager
 import com.clevertap.android.sdk.inapp.evaluation.EvaluationManager
+import com.clevertap.android.sdk.inapp.evaluation.NdEvaluationManager
 import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry
 import com.clevertap.android.sdk.inbox.InboxV2Bridge
 import com.clevertap.android.sdk.login.LoginController
@@ -46,6 +47,7 @@ internal open class CoreState(
     // Native Display (ND) frequency caps (SDK-6055) — separate per-channel instances.
     val ndImpressionManager: ImpressionManager,
     val ndTriggerManager: TriggerManager,
+    val ndEvaluationManager: NdEvaluationManager,
     val loginController: LoginController,
     val sessionManager: SessionManager,
     val validationResultStack: ValidationResultStack,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/NdFCManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/NdFCManager.java
@@ -14,6 +14,7 @@ import com.clevertap.android.sdk.task.Task;
 import com.clevertap.android.sdk.utils.Clock;
 
 import org.json.JSONArray;
+import org.json.JSONObject;
 
 import java.text.SimpleDateFormat;
 import java.util.Locale;
@@ -45,6 +46,20 @@ public class NdFCManager {
     static final int UNCAPPED = -1;
 
     private static final String ND_DATE_KEY = "nd_ict_date";
+
+    /**
+     * Whether an ND unit/target carries any frequency-cap configuration. Only such units are gated at
+     * delivery and counted at impression time; unmarked (legacy) units bypass ND capping entirely so
+     * existing display units are never affected and never consume the ND global budget.
+     */
+    public static boolean isFcapManaged(JSONObject json) {
+        return json != null
+                && (json.has(Constants.KEY_EFC)
+                || json.has(Constants.KEY_TLC)
+                || json.has(Constants.KEY_TDC)
+                || json.has(Constants.INAPP_MAX_DISPLAY_COUNT)
+                || json.has(Constants.KEY_EXCLUDE_GLOBAL_CAPS));
+    }
 
     private final SimpleDateFormat ddMMyyyy = new SimpleDateFormat("ddMMyyyy", Locale.US);
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/InAppController.kt
@@ -574,15 +574,20 @@ internal class InAppController(
         val appFieldsWithEventProperties = JsonUtil.mapFromJson<Any>(deviceInfo.appLaunchedFields)
         appFieldsWithEventProperties.putAll(eventProperties)
 
-        // Native Display (ND) local evaluation — votes eligible advanced campaigns into adUnit_eval.
-        ndEvaluationManager.evaluateOnEvent(eventName, appFieldsWithEventProperties, userLocation)
-
         // Returns (immediateCS, delayedCS, inActionSS)
         val evaluatedInApps = evaluationManager.evaluateOnEvent(
             eventName,
             appFieldsWithEventProperties,
             userLocation
         )
+
+        // Native Display (ND) local evaluation — runs AFTER in-app and guarded so a fault in ND (a new,
+        // independently authored server payload) can't abort in-app delivery or queue-flush scheduling.
+        try {
+            ndEvaluationManager.evaluateOnEvent(eventName, appFieldsWithEventProperties, userLocation)
+        } catch (t: Throwable) {
+            logger.debug(defaultLogTag, "ND evaluation failed", t)
+        }
 
         // Handle immediate CS in-apps
         if (evaluatedInApps.immediateClientSideInApps.isNotEmpty()) {
@@ -610,15 +615,19 @@ internal class InAppController(
             JsonUtil.mapFromJson<Any>(deviceInfo.appLaunchedFields)
         appFieldsWithChargedEventProperties.putAll(chargeDetails)
 
-        // Native Display (ND) local evaluation.
-        ndEvaluationManager.evaluateOnChargedEvent(appFieldsWithChargedEventProperties, items, userLocation)
-
         // Returns (immediateCS, delayedCS, inActionSS)
         val evaluatedInApps = evaluationManager.evaluateOnChargedEvent(
             appFieldsWithChargedEventProperties,
             items,
             userLocation
         )
+
+        // Native Display (ND) local evaluation — after in-app, guarded (see onQueueEvent).
+        try {
+            ndEvaluationManager.evaluateOnChargedEvent(appFieldsWithChargedEventProperties, items, userLocation)
+        } catch (t: Throwable) {
+            logger.debug(defaultLogTag, "ND evaluation failed", t)
+        }
 
         // Handle immediate CS in-apps
         if (evaluatedInApps.immediateClientSideInApps.isNotEmpty()) {
@@ -643,15 +652,19 @@ internal class InAppController(
     ) {
         val appFields = JsonUtil.mapFromJson<Any>(deviceInfo.appLaunchedFields)
 
-        // Native Display (ND) local evaluation.
-        ndEvaluationManager.evaluateOnUserAttributeChange(userAttributeChangedProperties, location, appFields)
-
         // Returns (immediateCS, delayedCS, inActionSS)
         val evaluatedInApps = evaluationManager.evaluateOnUserAttributeChange(
             userAttributeChangedProperties,
             location,
             appFields
         )
+
+        // Native Display (ND) local evaluation — after in-app, guarded (see onQueueEvent).
+        try {
+            ndEvaluationManager.evaluateOnUserAttributeChange(userAttributeChangedProperties, location, appFields)
+        } catch (t: Throwable) {
+            logger.debug(defaultLogTag, "ND evaluation failed", t)
+        }
 
         // Handle immediate CS in-apps
         if (evaluatedInApps.immediateClientSideInApps.isNotEmpty()) {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManager.kt
@@ -674,7 +674,11 @@ internal class EvaluationManager(
     @WorkerThread
     fun loadSuppressedCSAndEvaluatedSSInAppsIds() {
         storeRegistry.inAppStore?.let { store ->
-            evaluatedServerSideCampaignIds = store.readEvaluatedServerSideInAppIds().toList<Long>()
+            // Read via optLong, NOT toList<Long>(): org.json parses int-range numbers as Integer and
+            // `element is Long` filters them all out, so campaign ids would be silently dropped.
+            val stored = store.readEvaluatedServerSideInAppIds()
+            evaluatedServerSideCampaignIds =
+                (0 until stored.length()).map { stored.optLong(it) }.filter { it != 0L }.toMutableList()
             suppressedClientSideInApps = JsonUtil.listFromJsonSafe(store.readSuppressedClientSideInAppIds())
         }
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManager.kt
@@ -27,7 +27,8 @@ import org.json.JSONObject
  *
  * The class is the ND [NetworkHeadersListener]: it owns the in-memory `adUnit_eval` /
  * `adUnit_suppressed` lists (persisted via [StoreRegistry.ndStore]) and the attach → send →
- * remove-exactly-sent lifecycle. `adUnit_suppressed` (App-Launched CG acks) is populated in Phase 6.
+ * remove-exactly-sent lifecycle. `adUnit_suppressed` carries App-Launched CG-suppression acks
+ * (see [recordCgSuppressed]).
  *
  * Reuses [TriggersMatcher] and [LimitsMatcher]; only the stores differ from in-app.
  */
@@ -45,7 +46,7 @@ internal class NdEvaluationManager(
     @VisibleForTesting
     internal var evaluatedNdCampaignIds: MutableList<Long> = ArrayList()
 
-    // App-Launched CG-suppression acks (bare {wzrk_id, wzrk_pivot, wzrk_cgId}); filled in Phase 6.
+    // App-Launched CG-suppression acks (bare {wzrk_id, wzrk_pivot, wzrk_cgId}), via recordCgSuppressed.
     @VisibleForTesting
     internal var suppressedNdCampaigns: MutableList<Map<String, Any?>> = ArrayList()
 
@@ -107,11 +108,11 @@ internal class NdEvaluationManager(
 
                 if (ndLimitsMatcher.matchWhenLimits(getWhenLimits(inApp), campaignId)) {
                     val ti = campaignId.toLongOrNull() ?: continue
-                    if (!evaluatedNdCampaignIds.contains(ti)) {
-                        evaluatedNdCampaignIds.add(ti)
-                        updated = true
-                        Logger.v(TAG, "ND campaign $ti eligible -> adUnit_eval")
-                    }
+                    // Append without a contains() guard: a re-vote while a prior send is in flight must
+                    // not be dropped (onSentHeaders removes only what was sent). Server dedups (§6.2).
+                    evaluatedNdCampaignIds.add(ti)
+                    updated = true
+                    Logger.v(TAG, "ND campaign $ti eligible -> adUnit_eval")
                 }
             }
         }
@@ -146,7 +147,12 @@ internal class NdEvaluationManager(
      */
     fun recordCgSuppressed(stub: JSONObject) {
         val wzrkId = stub.optString(Constants.NOTIFICATION_ID_TAG)
-        if (wzrkId.isEmpty()) return
+        if (wzrkId.isEmpty()) {
+            // Per contract §5.4 the CG stub always ships wzrk_id (unlike in-app payloads which carry
+            // only ti). Log if one ever doesn't, rather than dropping the ack silently.
+            Logger.v(TAG, "Dropping ND CG ack: stub missing wzrk_id (ti=${stub.optString(Constants.INAPP_ID_IN_PAYLOAD)})")
+            return
+        }
         suppressedNdCampaigns.add(
             mapOf(
                 Constants.NOTIFICATION_ID_TAG to wzrkId,
@@ -207,7 +213,11 @@ internal class NdEvaluationManager(
     @WorkerThread
     fun loadEvaluatedAndSuppressedNdIds() {
         storeRegistry.ndStore?.let { store ->
-            evaluatedNdCampaignIds = store.readEvaluatedServerSideNdIds().toList<Long>().toMutableList()
+            // Read via optLong, NOT toList<Long>(): org.json parses int-range numbers as Integer and
+            // `element is Long` filters them all out, so `ti`s (epoch-second ids) would be dropped.
+            val stored = store.readEvaluatedServerSideNdIds()
+            evaluatedNdCampaignIds =
+                (0 until stored.length()).map { stored.optLong(it) }.filter { it != 0L }.toMutableList()
             suppressedNdCampaigns = JsonUtil.listFromJsonSafe(store.readSuppressedNdIds())
         }
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/NdStore.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/NdStore.kt
@@ -106,6 +106,9 @@ internal class NdStore(
     }
 
     override fun onChangeUser(deviceId: String, accountId: String) {
+        // Invalidate the in-memory cache before repointing, else the next read returns the previous
+        // user's metadata bundle until a fresh adUnit_notifs_ss arrives.
+        metaCache = null
         val newPrefName =
             StoreProvider.getInstance().constructStorePreferenceName(STORE_TYPE_ND, deviceId, accountId)
         ctPreference.changePreferenceName(newPrefName)

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/login/LoginController.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/login/LoginController.java
@@ -171,6 +171,11 @@ public class LoginController {
                     notifyChangeUserCallback();
 
                     controllerManager.getInAppFCManager().changeUser(deviceInfo.getDeviceID());
+                    // Native Display (ND) frequency caps (SDK-6055): repoint ND counters to the new
+                    // user too. Null-guarded — ndFCManager can still be null on the async device-id path.
+                    if (controllerManager.getNdFCManager() != null) {
+                        controllerManager.getNdFCManager().changeUser(deviceInfo.getDeviceID());
+                    }
                 } catch (Throwable t) {
                     config.getLogger().verbose(config.getAccountId(), "Reset Profile error", t);
                 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/response/AdUnitResponse.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/response/AdUnitResponse.java
@@ -1,19 +1,15 @@
 package com.clevertap.android.sdk.response;
 
 import android.content.Context;
-import android.text.TextUtils;
 
 import androidx.annotation.WorkerThread;
 
-import com.clevertap.android.sdk.BaseCallbackManager;
 import com.clevertap.android.sdk.CleverTapInstanceConfig;
 import com.clevertap.android.sdk.Constants;
 import com.clevertap.android.sdk.ControllerManager;
 import com.clevertap.android.sdk.Logger;
 import com.clevertap.android.sdk.NdFCManager;
 import com.clevertap.android.sdk.Utils;
-import com.clevertap.android.sdk.displayunits.DisplayUnitCache;
-import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
 import com.clevertap.android.sdk.inapp.TriggerManager;
 import com.clevertap.android.sdk.inapp.evaluation.NdEvaluationManager;
 import com.clevertap.android.sdk.inapp.store.preference.ImpressionStore;
@@ -23,23 +19,23 @@ import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Ingests the Native Display (ND) frequency-cap response keys (SDK-6055, Phase 2).
- *
- * <p>ND content itself still flows through {@link DisplayUnitResponse} ({@code adUnit_notifs}); this
- * processor handles only the new SS/fcap surface, none of which is user-visible on its own:
+ * Ingests the Native Display (ND) frequency-cap <b>meta</b> from the response (SDK-6055), none of
+ * which is user-visible on its own:
  * <ul>
- *   <li>{@code adUnit_notifs_ss} — advanced-rule metadata bundle → {@link NdStore} (for local eval),</li>
+ *   <li>{@code ndmc}/{@code ndmp} — session/daily ceilings → {@link NdFCManager#updateLimits},</li>
  *   <li>{@code adUnit_stale} — dead-target GC → clear ND impressions/triggers/counters,</li>
- *   <li>{@code ndmc}/{@code ndmp} — session/daily ceilings → {@link NdFCManager#updateLimits}.</li>
+ *   <li>{@code adUnit_notifs_ss} — advanced-rule metadata bundle → {@link NdStore} (for local eval),</li>
+ *   <li>CG-suppressed stubs inside {@code adUnit_notifs_applaunched} → {@code adUnit_suppressed} ack.</li>
  * </ul>
  *
- * <p>Content delivery for {@code adUnit_notifs_applaunched} + the cap gate are added in a later phase
- * (they must ship together with enforcement, not ungated). No-ops for old (V1) responses that carry
- * none of these keys.
+ * <p>This processor is registered <b>before</b> {@link DisplayUnitResponse} so ceilings and the
+ * stale-purge land before the delivery cap gate runs. It deliberately does <b>not</b> write display
+ * content: both {@code adUnit_notifs} and the non-stub {@code adUnit_notifs_applaunched} entries are
+ * delivered by {@link DisplayUnitResponse} in a single merged, gated cache write, so one response
+ * carrying both keys can't wipe the other. No-ops for old (V1) responses that carry none of these keys.
  */
 public class AdUnitResponse extends CleverTapResponse {
 
@@ -53,8 +49,6 @@ public class AdUnitResponse extends CleverTapResponse {
 
     private final NdEvaluationManager ndEvaluationManager;
 
-    private final BaseCallbackManager callbackManager;
-
     private final Logger logger;
 
     public AdUnitResponse(
@@ -62,15 +56,13 @@ public class AdUnitResponse extends CleverTapResponse {
             StoreRegistry storeRegistry,
             ControllerManager controllerManager,
             TriggerManager ndTriggerManager,
-            NdEvaluationManager ndEvaluationManager,
-            BaseCallbackManager callbackManager
+            NdEvaluationManager ndEvaluationManager
     ) {
         this.config = config;
         this.storeRegistry = storeRegistry;
         this.controllerManager = controllerManager;
         this.ndTriggerManager = ndTriggerManager;
         this.ndEvaluationManager = ndEvaluationManager;
-        this.callbackManager = callbackManager;
         this.logger = config.getLogger();
     }
 
@@ -87,8 +79,9 @@ public class AdUnitResponse extends CleverTapResponse {
         try {
             final NdFCManager ndFCManager = controllerManager.getNdFCManager();
 
-            // 1. Account-level ceilings. ndmc is emitted on every V2 response; ndmp only when the
-            //    account has a daily cap (absent => uncapped daily).
+            // 1. Account-level ceilings. Per contract §5.1 `ndmc` is emitted on every V2 response;
+            //    `ndmp` only when the account has a daily cap (absent => uncapped daily, hence
+            //    Integer.MAX_VALUE rather than a numeric default that would wrongly cap it).
             if (response.has(Constants.ND_MAX_PER_SESSION_KEY) && ndFCManager != null) {
                 final int perSession = response.optInt(Constants.ND_MAX_PER_SESSION_KEY, 1);
                 final int perDay = response.has(Constants.ND_MAX_PER_DAY_KEY)
@@ -106,7 +99,9 @@ public class AdUnitResponse extends CleverTapResponse {
                 }
             }
 
-            // 3. Advanced-rule metadata bundle (rules only) for local evaluation.
+            // 3. Advanced-rule metadata bundle (rules only) for local evaluation. Full replace,
+            //    including an empty array: the bundle is emitted only on App-Launched / ND-meta-fetch
+            //    and is always the complete current set (contract §5.2), so [] legitimately means "clear".
             if (response.has(Constants.DISPLAY_UNIT_NOTIFS_SS_KEY)) {
                 final NdStore ndStore = storeRegistry.getNdStore();
                 final JSONArray ssArray = response.optJSONArray(Constants.DISPLAY_UNIT_NOTIFS_SS_KEY);
@@ -118,51 +113,29 @@ public class AdUnitResponse extends CleverTapResponse {
                 }
             }
 
-            // 4. App-Launched content-in-advance: deliver real content (fcap-gated) and ack any
-            //    CG-suppressed stubs via adUnit_suppressed.
-            processAppLaunched(response);
+            // 4. Ack CG-suppressed App-Launched stubs (the real content is delivered by
+            //    DisplayUnitResponse). App-Launched path only — regular-event CG is server-decided.
+            ackCgSuppressedStubs(response);
         } catch (Throwable t) {
             logger.verbose(config.getAccountId(), Constants.FEATURE_DISPLAY_UNIT + "Failed to process ND response", t);
         }
     }
 
     /**
-     * Handles {@code adUnit_notifs_applaunched}: entries flagged {@code suppressed:true} are CG stubs
-     * — the SDK renders nothing and acks them via {@code adUnit_suppressed}; the remaining entries are
-     * real content delivered to the host through the display-unit cache/callback, filtered by the ND
-     * frequency-cap gate.
+     * Records an {@code adUnit_suppressed} ack for every CG stub ({@code suppressed:true}) inside
+     * {@code adUnit_notifs_applaunched}. Non-stub entries are ignored here — they are delivered as
+     * content by {@link DisplayUnitResponse}.
      */
-    private void processAppLaunched(final JSONObject response) {
+    private void ackCgSuppressedStubs(final JSONObject response) {
         final JSONArray appLaunched = response.optJSONArray(Constants.DISPLAY_UNIT_NOTIFS_APP_LAUNCHED_KEY);
-        if (appLaunched == null || appLaunched.length() == 0) {
+        if (appLaunched == null) {
             return;
         }
-
-        final ArrayList<CleverTapDisplayUnit> content = new ArrayList<>();
         for (int i = 0; i < appLaunched.length(); i++) {
             final JSONObject entry = appLaunched.optJSONObject(i);
-            if (entry == null) {
-                continue;
+            if (entry != null && entry.optBoolean(Constants.INAPP_SUPPRESSED, false)) {
+                ndEvaluationManager.recordCgSuppressed(entry);
             }
-            if (entry.optBoolean(Constants.INAPP_SUPPRESSED, false)) {
-                ndEvaluationManager.recordCgSuppressed(entry); // CG stub -> ack, render nothing
-                continue;
-            }
-            final CleverTapDisplayUnit unit = CleverTapDisplayUnit.toDisplayUnit(entry);
-            if (TextUtils.isEmpty(unit.getError())) {
-                content.add(unit);
-            }
-        }
-
-        final ArrayList<CleverTapDisplayUnit> allowed =
-                NdFcapGate.filter(content, controllerManager.getNdFCManager(), logger, config.getAccountId());
-        if (allowed.isEmpty()) {
-            return;
-        }
-        final DisplayUnitCache cache = controllerManager.getOrCreateDisplayUnitCache();
-        if (cache != null) {
-            cache.updateDisplayUnits(allowed);
-            callbackManager.notifyDisplayUnitsLoaded(allowed);
         }
     }
 

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/response/DisplayUnitResponse.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/response/DisplayUnitResponse.java
@@ -57,35 +57,46 @@ public class DisplayUnitResponse extends CleverTapResponseDecorator {
             return;
         }
 
-        if (!response.has(Constants.DISPLAY_UNIT_JSON_RESPONSE_KEY)) {
+        final JSONArray notifs = response.optJSONArray(Constants.DISPLAY_UNIT_JSON_RESPONSE_KEY);
+        final JSONArray appLaunched = response.optJSONArray(Constants.DISPLAY_UNIT_NOTIFS_APP_LAUNCHED_KEY);
+        final boolean hasNotifs = notifs != null && notifs.length() > 0;
+        final boolean hasAppLaunched = appLaunched != null && appLaunched.length() > 0;
+        if (!hasNotifs && !hasAppLaunched) {
             logger.verbose(config.getAccountId(),
                     Constants.FEATURE_DISPLAY_UNIT + "JSON object doesn't contain the Display Units key");
             return;
         }
         try {
-            logger
-                    .verbose(config.getAccountId(),
-                            Constants.FEATURE_DISPLAY_UNIT + "Processing Display Unit response");
-            parseDisplayUnits(response.getJSONArray(Constants.DISPLAY_UNIT_JSON_RESPONSE_KEY));
+            logger.verbose(config.getAccountId(),
+                    Constants.FEATURE_DISPLAY_UNIT + "Processing Display Unit response");
+            parseDisplayUnits(notifs, appLaunched);
         } catch (Throwable t) {
             logger.verbose(config.getAccountId(), Constants.FEATURE_DISPLAY_UNIT + "Failed to parse response", t);
         }
     }
 
     /**
-     * Parses the Display Units from the JSON response, populates the cache and
-     * notifies the callback only when at least one valid unit was received.
+     * Parses Display Units from both {@code adUnit_notifs} and (non-CG-suppressed)
+     * {@code adUnit_notifs_applaunched}, merges them, applies the ND frequency-cap gate, and writes
+     * the cache once. Both keys are handled in a single pass because
+     * {@link com.clevertap.android.sdk.displayunits.CTDisplayUnitController#updateDisplayUnits}
+     * replaces (not merges) the cache — two separate writes for one response would wipe each other.
+     * CG stubs ({@code suppressed:true}) are skipped here; they are acked by {@link AdUnitResponse}.
      *
-     * A null or empty array is a no-op: the cache is not touched and the callback
-     * is not fired. This preserves the legacy pre-8.x contract and matches iOS
-     * parity — iOS guards on displayUnitJSON.count > 0 before doing anything.
-     *
-     * @param messages - Json array of Display Unit items
+     * A response with no valid units is a no-op (cache untouched, callback not fired), preserving the
+     * legacy pre-8.x contract / iOS parity.
      */
-    private void parseDisplayUnits(JSONArray messages) {
-        if (messages == null || messages.length() == 0) {
+    private void parseDisplayUnits(JSONArray notifs, JSONArray appLaunched) {
+        final ArrayList<CleverTapDisplayUnit> parsed = new ArrayList<>();
+        if (notifs != null) {
+            parsed.addAll(parseDisplayUnitsFromJson(notifs, false));
+        }
+        if (appLaunched != null) {
+            parsed.addAll(parseDisplayUnitsFromJson(appLaunched, true));
+        }
+        if (parsed.isEmpty()) {
             logger.verbose(config.getAccountId(),
-                    Constants.FEATURE_DISPLAY_UNIT + "Can't parse Display Units, jsonArray is null or empty");
+                    Constants.FEATURE_DISPLAY_UNIT + "No valid Display Units to process");
             return;
         }
 
@@ -97,7 +108,7 @@ public class DisplayUnitResponse extends CleverTapResponseDecorator {
         }
 
         ArrayList<CleverTapDisplayUnit> displayUnits = NdFcapGate.filter(
-                parseDisplayUnitsFromJson(messages), controllerManager.getNdFCManager(), logger, config.getAccountId());
+                parsed, controllerManager.getNdFCManager(), logger, config.getAccountId());
         cache.updateDisplayUnits(displayUnits);
         if (!displayUnits.isEmpty()) {
             callbackManager.notifyDisplayUnitsLoaded(displayUnits);
@@ -105,15 +116,20 @@ public class DisplayUnitResponse extends CleverTapResponseDecorator {
     }
 
     /**
-     * Converts a JSON array of display units into model objects, filtering out
-     * malformed entries.
+     * Converts a JSON array of display units into model objects, filtering out malformed entries.
+     * When {@code skipSuppressed} is true, CG-suppressed stubs ({@code suppressed:true}, no content)
+     * are skipped — those are acked by {@link AdUnitResponse}, not rendered.
      */
     @NonNull
-    private ArrayList<CleverTapDisplayUnit> parseDisplayUnitsFromJson(@NonNull JSONArray messages) {
+    private ArrayList<CleverTapDisplayUnit> parseDisplayUnitsFromJson(@NonNull JSONArray messages, boolean skipSuppressed) {
         final ArrayList<CleverTapDisplayUnit> list = new ArrayList<>();
         for (int i = 0; i < messages.length(); i++) {
             try {
-                CleverTapDisplayUnit unit = CleverTapDisplayUnit.toDisplayUnit(messages.getJSONObject(i));
+                JSONObject json = messages.getJSONObject(i);
+                if (skipSuppressed && json.optBoolean(Constants.INAPP_SUPPRESSED, false)) {
+                    continue;
+                }
+                CleverTapDisplayUnit unit = CleverTapDisplayUnit.toDisplayUnit(json);
                 if (TextUtils.isEmpty(unit.getError())) {
                     list.add(unit);
                 } else {

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/response/NdFcapGate.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/response/NdFcapGate.java
@@ -41,7 +41,7 @@ final class NdFcapGate {
         final ArrayList<CleverTapDisplayUnit> allowed = new ArrayList<>(units.size());
         for (CleverTapDisplayUnit unit : units) {
             final JSONObject json = unit.getJsonObject();
-            if (json == null || !isFcapManaged(json)) {
+            if (json == null || !NdFCManager.isFcapManaged(json)) {
                 allowed.add(unit); // not fcap-managed -> deliver as before
                 continue;
             }
@@ -64,13 +64,5 @@ final class NdFcapGate {
             }
         }
         return allowed;
-    }
-
-    private static boolean isFcapManaged(@NonNull JSONObject json) {
-        return json.has(Constants.KEY_EFC)
-                || json.has(Constants.KEY_TLC)
-                || json.has(Constants.KEY_TDC)
-                || json.has(Constants.INAPP_MAX_DISPLAY_COUNT)
-                || json.has(Constants.KEY_EXCLUDE_GLOBAL_CAPS);
     }
 }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/MockCoreState.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/MockCoreState.kt
@@ -24,6 +24,7 @@ internal class MockCoreStateKotlin(cleverTapInstanceConfig: CleverTapInstanceCon
     mockk(relaxed = true), // impressionManager
     mockk(relaxed = true), // ndImpressionManager
     mockk(relaxed = true), // ndTriggerManager
+    mockk(relaxed = true), // ndEvaluationManager
     mockk(relaxed = true), // loginController
     mockk(relaxed = true), // sessionManager
     ValidationResultStack(),

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/NdFCManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/NdFCManagerTest.kt
@@ -1,0 +1,88 @@
+package com.clevertap.android.sdk
+
+import com.clevertap.android.sdk.inapp.ImpressionManager
+import com.clevertap.android.sdk.task.MockCTExecutors
+import com.clevertap.android.sdk.utils.FakeClock
+import com.clevertap.android.shared.test.BaseTestCase
+import io.mockk.mockk
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NdFCManagerTest : BaseTestCase() {
+
+    private lateinit var impressionManager: ImpressionManager
+    private lateinit var clock: FakeClock
+
+    override fun setUp() {
+        super.setUp()
+        impressionManager = mockk(relaxed = true) // perSession / perSessionTotal -> 0
+        clock = FakeClock()
+    }
+
+    @Test
+    fun `canShow returns true for empty id`() {
+        val fc = create()
+        assertTrue(fc.canShow("", false, -1, -1, -1, false))
+    }
+
+    @Test
+    fun `canShow returns false when frequency limits are maxed`() {
+        val fc = create()
+        assertFalse(fc.canShow("70001", false, -1, -1, -1, true))
+    }
+
+    @Test
+    fun `canShow allows an uncapped target`() {
+        val fc = create()
+        fc.updateLimits(appCtx, 10, 10) // don't let global defaults (1) interfere
+        assertTrue(fc.canShow("70001", false, -1, -1, -1, false))
+    }
+
+    @Test
+    fun `excludeFromCaps bypasses counter caps`() {
+        val fc = create()
+        fc.updateLimits(appCtx, 10, 10)
+        fc.didShow(appCtx, "70001") // today/lifetime = 1
+        // per-target daily cap of 1 would deny, but excludeFromCaps short-circuits
+        assertFalse(fc.canShow("70001", false, -1, 1, -1, false))
+        assertTrue(fc.canShow("70001", true, -1, 1, -1, false))
+    }
+
+    @Test
+    fun `per-target daily cap denies once reached`() {
+        val fc = create()
+        fc.updateLimits(appCtx, 10, 10)
+        fc.didShow(appCtx, "70001") // today = 1
+        assertFalse(fc.canShow("70001", false, -1, 1, -1, false)) // 1 >= 1
+        assertTrue(fc.canShow("70001", false, -1, 2, -1, false))  // 1 < 2
+    }
+
+    @Test
+    fun `didShow increments ndtlc counters and shown-today`() {
+        val fc = create()
+        fc.updateLimits(appCtx, 10, 10)
+        fc.didShow(appCtx, "70001")
+        fc.didShow(appCtx, "70001")
+
+        assertEquals(2, fc.shownTodayCount)
+        val counts = fc.getNdCounts(appCtx)!!
+        assertEquals(1, counts.length())
+        val entry = counts.getJSONArray(0)
+        assertEquals("70001", entry.getString(0))
+        assertEquals(2, entry.getInt(1)) // today
+        assertEquals(2, entry.getInt(2)) // lifetime
+    }
+
+    private fun create(deviceId: String = "deviceId"): NdFCManager {
+        return NdFCManager(
+            appCtx,
+            cleverTapInstanceConfig,
+            deviceId,
+            impressionManager,
+            MockCTExecutors(),
+            clock
+        )
+    }
+}

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManagerTest.kt
@@ -64,6 +64,32 @@ class NdEvaluationManagerTest {
     }
 
     @Test
+    fun `evaluate appends a concurrent re-vote without dedup`() {
+        val inApp = JSONObject().put(Constants.INAPP_ID_IN_PAYLOAD, "70001")
+        every { ndStore.readServerSideNdMetaData() } returns listOf(inApp)
+        every { triggersMatcher.matchEvent(any(), any()) } returns true
+        every { ndLimitsMatcher.matchWhenLimits(any(), any()) } returns true
+
+        // Same campaign eligible on two events (e.g. a re-vote while a prior send is in flight).
+        manager.evaluateOnEvent("e1", emptyMap(), null)
+        manager.evaluateOnEvent("e2", emptyMap(), null)
+
+        // Must NOT be de-duped — onSentHeaders removes only what was sent (see §6.2).
+        assertEquals(listOf(70001L, 70001L), manager.evaluatedNdCampaignIds)
+    }
+
+    @Test
+    fun `loadEvaluatedAndSuppressedNdIds restores persisted int-range ids`() {
+        // ti's are epoch-second ids that org.json parses as Integer; the load must not drop them.
+        every { ndStore.readEvaluatedServerSideNdIds() } returns JSONArray("[70001,70002]")
+        every { ndStore.readSuppressedNdIds() } returns JSONArray()
+
+        manager.loadEvaluatedAndSuppressedNdIds()
+
+        assertEquals(listOf(70001L, 70002L), manager.evaluatedNdCampaignIds)
+    }
+
+    @Test
     fun `evaluate does not vote when trigger does not match`() {
         val inApp = JSONObject().put(Constants.INAPP_ID_IN_PAYLOAD, "70001")
         every { ndStore.readServerSideNdMetaData() } returns listOf(inApp)

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/store/preference/NdStoreTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/store/preference/NdStoreTest.kt
@@ -53,18 +53,24 @@ class NdStoreTest {
     }
 
     @Test
-    fun `evaluated nd ids round trip`() {
-        every { ctPreference.readString(Constants.PREFS_EVALUATED_ND_KEY_SS, any()) } returns
-                JSONArray().put(70001L).put(70002L).toString()
+    fun `evaluated nd ids write then read`() {
+        every { ctPreference.writeString(any(), any()) } just Runs
+        val ids = JSONArray().put(70001L).put(70002L)
+        ndStore.storeEvaluatedServerSideNdIds(ids)
+        verify { ctPreference.writeString(Constants.PREFS_EVALUATED_ND_KEY_SS, ids.toString()) }
 
+        every { ctPreference.readString(Constants.PREFS_EVALUATED_ND_KEY_SS, any()) } returns ids.toString()
         assertEquals(2, ndStore.readEvaluatedServerSideNdIds().length())
     }
 
     @Test
-    fun `suppressed nd ids round trip`() {
-        every { ctPreference.readString(Constants.PREFS_SUPPRESSED_ND_KEY, any()) } returns
-                JSONArray().put(JSONObject().put(Constants.NOTIFICATION_ID_TAG, "70004_20260810")).toString()
+    fun `suppressed nd ids write then read`() {
+        every { ctPreference.writeString(any(), any()) } just Runs
+        val entries = JSONArray().put(JSONObject().put(Constants.NOTIFICATION_ID_TAG, "70004_20260810"))
+        ndStore.storeSuppressedNdIds(entries)
+        verify { ctPreference.writeString(Constants.PREFS_SUPPRESSED_ND_KEY, entries.toString()) }
 
+        every { ctPreference.readString(Constants.PREFS_SUPPRESSED_ND_KEY, any()) } returns entries.toString()
         assertEquals(1, ndStore.readSuppressedNdIds().length())
     }
 
@@ -75,8 +81,8 @@ class NdStoreTest {
     }
 
     @Test
-    fun `onChangeUser changes preference name`() {
+    fun `onChangeUser repoints to the ND namespace for the new user`() {
         ndStore.onChangeUser("device_id", "account_id")
-        verify { ctPreference.changePreferenceName(any()) }
+        verify { ctPreference.changePreferenceName("${Constants.ND_KEY}:device_id:account_id") }
     }
 }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/network/QueueHeaderBuilderTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/network/QueueHeaderBuilderTest.kt
@@ -147,11 +147,18 @@ class QueueHeaderBuilderTest {
                 put("lifetimeCount", 22)
             })
         }
+        val ndCountsJson = JSONArray().apply {
+            put(JSONArray().apply { put("70001"); put(1); put(4) })
+        }
         // Mock controllerManager
         every { controllerManager.pushProviders } returns null
         every { controllerManager.inAppFCManager } returns mockk {
             every { shownTodayCount } returns 5
             every { getInAppsCount(any()) } returns inappsJson
+        }
+        every { controllerManager.ndFCManager } returns mockk {
+            every { shownTodayCount } returns 2
+            every { getNdCounts(any()) } returns ndCountsJson
         }
 
         // Mock context
@@ -198,5 +205,8 @@ class QueueHeaderBuilderTest {
         assertEquals("wzrk_value", wzrk.optString("wzrk_key"))
         assertEquals(5, header.optInt("imp"))
         assertEquals(inappsJson.toString(), header.optJSONArray("tlc")?.toString())
+        // Native Display counters (SDK-6055): ndmp = ND render count today, ndtlc = per-target counts.
+        assertEquals(2, header.optInt("ndmp"))
+        assertEquals(ndCountsJson.toString(), header.optJSONArray("ndtlc")?.toString())
     }
 }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/response/AdUnitResponseTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/response/AdUnitResponseTest.kt
@@ -1,0 +1,116 @@
+package com.clevertap.android.sdk.response
+
+import android.content.Context
+import com.clevertap.android.sdk.CleverTapInstanceConfig
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.ControllerManager
+import com.clevertap.android.sdk.Logger
+import com.clevertap.android.sdk.NdFCManager
+import com.clevertap.android.sdk.inapp.TriggerManager
+import com.clevertap.android.sdk.inapp.evaluation.NdEvaluationManager
+import com.clevertap.android.sdk.inapp.store.preference.ImpressionStore
+import com.clevertap.android.sdk.inapp.store.preference.NdStore
+import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class AdUnitResponseTest {
+
+    private lateinit var config: CleverTapInstanceConfig
+    private lateinit var storeRegistry: StoreRegistry
+    private lateinit var controllerManager: ControllerManager
+    private lateinit var ndTriggerManager: TriggerManager
+    private lateinit var ndEvaluationManager: NdEvaluationManager
+    private lateinit var ndStore: NdStore
+    private lateinit var ndImpressionStore: ImpressionStore
+    private lateinit var ndFCManager: NdFCManager
+    private lateinit var context: Context
+    private lateinit var response: AdUnitResponse
+
+    @Before
+    fun setUp() {
+        config = mockk(relaxed = true)
+        every { config.isAnalyticsOnly } returns false
+        every { config.logger } returns mockk<Logger>(relaxed = true)
+        every { config.accountId } returns "acc"
+
+        ndStore = mockk(relaxed = true)
+        ndImpressionStore = mockk(relaxed = true)
+        ndFCManager = mockk(relaxed = true)
+        ndTriggerManager = mockk(relaxed = true)
+        ndEvaluationManager = mockk(relaxed = true)
+        context = mockk(relaxed = true)
+
+        storeRegistry = mockk(relaxed = true)
+        every { storeRegistry.ndStore } returns ndStore
+        every { storeRegistry.ndImpressionStore } returns ndImpressionStore
+
+        controllerManager = mockk(relaxed = true)
+        every { controllerManager.ndFCManager } returns ndFCManager
+
+        response = AdUnitResponse(config, storeRegistry, controllerManager, ndTriggerManager, ndEvaluationManager)
+    }
+
+    @Test
+    fun `stores adUnit_notifs_ss metadata bundle`() {
+        val json = JSONObject("""{"adUnit_notifs_ss":[{"ti":70001},{"ti":70002}]}""")
+
+        response.processResponse(json, "", context)
+
+        val slot = slot<List<JSONObject>>()
+        verify { ndStore.storeServerSideNdMetaData(capture(slot)) }
+        assertEquals(2, slot.captured.size)
+    }
+
+    @Test
+    fun `applies ndmc and ndmp ceilings`() {
+        val json = JSONObject("""{"ndmc":1,"ndmp":10}""")
+
+        response.processResponse(json, "", context)
+
+        verify { ndFCManager.updateLimits(context, 10, 1) }
+    }
+
+    @Test
+    fun `purges stale nd targets from all cap stores`() {
+        val json = JSONObject("""{"adUnit_stale":["70001","70002"]}""")
+
+        response.processResponse(json, "", context)
+
+        verify { ndImpressionStore.clear("70001") }
+        verify { ndImpressionStore.clear("70002") }
+        verify { ndTriggerManager.removeTriggers("70001") }
+        verify { ndFCManager.processResponse(context, any()) }
+    }
+
+    @Test
+    fun `acks CG-suppressed app-launched stubs and ignores real content`() {
+        val json = JSONObject(
+            """{"adUnit_notifs_applaunched":[
+                {"ti":70003,"wzrk_id":"70003_20260810","suppressed":true,"wzrk_cgId":0},
+                {"ti":70004,"wzrk_id":"70004_20260810","type":"simple"}
+            ]}"""
+        )
+
+        response.processResponse(json, "", context)
+
+        val slot = slot<JSONObject>()
+        verify(exactly = 1) { ndEvaluationManager.recordCgSuppressed(capture(slot)) }
+        assertEquals("70003_20260810", slot.captured.optString("wzrk_id"))
+    }
+
+    @Test
+    fun `no-op for analytics-only`() {
+        every { config.isAnalyticsOnly } returns true
+
+        response.processResponse(JSONObject("""{"ndmc":1,"ndmp":10}"""), "", context)
+
+        verify(exactly = 0) { ndFCManager.updateLimits(any(), any(), any()) }
+    }
+}

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/response/NdFcapGateTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/response/NdFcapGateTest.kt
@@ -1,0 +1,60 @@
+package com.clevertap.android.sdk.response
+
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.Logger
+import com.clevertap.android.sdk.NdFCManager
+import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.json.JSONObject
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class NdFcapGateTest {
+
+    private val logger = mockk<Logger>(relaxed = true)
+
+    private fun unit(json: JSONObject, id: String = "u1"): CleverTapDisplayUnit {
+        val u = mockk<CleverTapDisplayUnit>(relaxed = true)
+        every { u.jsonObject } returns json
+        every { u.unitID } returns id
+        return u
+    }
+
+    @Test
+    fun `unmarked units pass through and are never cap-checked`() {
+        val ndfc = mockk<NdFCManager>()
+        val units = arrayListOf(unit(JSONObject().put(Constants.NOTIFICATION_ID_TAG, "u1")))
+
+        val out = NdFcapGate.filter(units, ndfc, logger, "acc")
+
+        assertEquals(1, out.size)
+        verify(exactly = 0) { ndfc.canShow(any(), any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `fcap-marked unit is delivered when canShow allows`() {
+        val ndfc = mockk<NdFCManager>()
+        every { ndfc.canShow(any(), any(), any(), any(), any(), any()) } returns true
+        val units = arrayListOf(unit(JSONObject().put(Constants.KEY_TLC, 5)))
+
+        assertEquals(1, NdFcapGate.filter(units, ndfc, logger, "acc").size)
+    }
+
+    @Test
+    fun `fcap-marked unit is dropped when canShow denies`() {
+        val ndfc = mockk<NdFCManager>()
+        every { ndfc.canShow(any(), any(), any(), any(), any(), any()) } returns false
+        val units = arrayListOf(unit(JSONObject().put(Constants.KEY_TDC, 1)))
+
+        assertEquals(0, NdFcapGate.filter(units, ndfc, logger, "acc").size)
+    }
+
+    @Test
+    fun `null fcManager passes everything through`() {
+        val units = arrayListOf(unit(JSONObject().put(Constants.KEY_TLC, 5)))
+
+        assertEquals(1, NdFcapGate.filter(units, null, logger, "acc").size)
+    }
+}

--- a/docs/InAppFrequencyCapsAndServing.md
+++ b/docs/InAppFrequencyCapsAndServing.md
@@ -107,6 +107,10 @@ There are **two distinct one-at-a-time chokepoints**; both are deliberate.
    Consequence: **DB persistence and in-app evaluation for a given event are atomic and ordered** —
    evaluation always sees the event already committed, and no two events interleave. The network
    flush (`flushDBQueue`) runs on this same executor, so queueing, evaluation, and flushing never race.
+   Nuance: this ordering is per task on the executor; it does **not** mean nothing runs during a flush's
+   network round-trip. `onAttachHeaders` builds the header and `onSentHeaders` runs after the response,
+   and a *separate* event task can be evaluated in between — which is exactly why the eval-header
+   lifecycle (§3.2) removes only the ids that were actually sent rather than clearing the whole list.
 
 2. **The in-app display queue (one in-app on screen at a time).** Selected in-apps go through a
    single FIFO (`StoreRegistryInAppQueue`, persisted), and `currentlyDisplayingInApp` +

--- a/docs/NativeDisplayFrequencyCaps.md
+++ b/docs/NativeDisplayFrequencyCaps.md
@@ -169,6 +169,11 @@ From the design TAN §7, the SDK's responsibilities (what the SDK must enforce l
 Precedence (same as in-app): `isNdFcapEnabled==false` overrides all; then `efc==1` short-circuits;
 `excludeGlobalFCaps==true` bypasses only the ND global-daily cap.
 
+*Where each is enforced:* `frequencyLimits`/`occurrenceLimits` are enforced at **eval time** (the
+`adUnit_eval` vote) and are **not** re-checked at delivery; the counter caps (`efc`/`tlc`/`tdc`/`mdc`
++ global) are re-checked at delivery in `canShow`. See §7.2 for why ND skips the delivery-time
+whenLimits re-check that in-app does.
+
 The elegant simplification: **the SDK does not need to classify campaigns.** Only advanced-rule,
 non-journey campaigns ever appear in `adUnit_notifs_ss` (the server's eligibility filter, design §6.7).
 So "evaluate everything in the metadata bundle and vote the eligible ones into `adUnit_eval`" is
@@ -252,22 +257,52 @@ flowchart TD
 
 ### 7.2 The ND cap gate (mirrors in-app canShow, minus CS)
 
+At delivery the gate (`NdFcapGate` → `NdFCManager.canShow`) enforces the **counter caps only**. The
+advanced `whenLimits` (`frequencyLimits`/`occurrenceLimits`) were already applied at eval time (the
+`adUnit_eval` vote), so `canShow` is called with `frequencyLimitsMaxedOut = false` — see the note below.
+
 ```mermaid
 flowchart TD
-    A[unit about to be surfaced / viewed] --> M{isNdFcapEnabled?}
+    EV[event: whenTriggers + whenLimits applied at eval time -> adUnit_eval vote] -.server delivers content.-> A
+    A[unit about to be surfaced] --> M{isNdFcapEnabled / fcap-managed?}
     M -- no --> ALLOW[allow - deliver as today]
-    M -- yes --> B{advanced whenLimits maxed?}
-    B -- yes --> DENY[suppress]
-    B -- no --> C{efc == 1?}
+    M -- yes --> C{efc == 1?}
     C -- yes --> ALLOW
     C -- no --> D{session cap<br/>mdc + global ndmc}
-    D -- maxed --> DENY
+    D -- maxed --> DENY[suppress]
     D -- ok --> E{lifetime cap tlc}
     E -- maxed --> DENY
     E -- ok --> F{daily cap<br/>tdc + global ndmp/ndstc}
     F -- maxed --> DENY
     F -- ok --> ALLOW
 ```
+
+**Divergence from in-app: no delivery-time whenLimits re-check (intentional).**
+In-app evaluates `whenLimits` **twice** — once at eval, then again right before render via
+`InAppFCManager.canShow`'s `matchWhenLimitsBeforeDisplay` step. That second check exists because in-app
+*eval and render are decoupled by an on-device queue*: a selected in-app can sit in
+`inAppQueue`/`pendingNotifications` for a long, unpredictable time (app backgrounded, another in-app
+showing, blacklisted/suspended activity, media still downloading), during which impressions can accrue
+— so it re-verifies the frequency limits at the last moment.
+
+ND deliberately does **not** re-run `whenLimits` at delivery (`NdFcapGate` passes
+`frequencyLimitsMaxedOut = false`). The counter caps (`efc`/`tlc`/`tdc`/`mdc` + global) *are* still
+re-checked. This is the right shape for ND, not a gap, because:
+
+1. **No on-device deferred display queue.** ND content is handed to the host as the response is
+   processed — there's no `pendingNotifications`-style deferral, so the long eval→render gap that
+   in-app's re-check guards essentially doesn't exist.
+2. **The SDK can't gate the actual show anyway.** The host renders ND (and reports `viewed`) whenever
+   it chooses; the SDK's gate runs at *delivery*, not at render, so a delivery-time re-check would not
+   cover the host's render timing regardless.
+3. **The server is the authority for ND advanced caps.** LC gates content on the `adUnit_eval` vote and
+   trusts it (contract §6.4/§6.9); the vote *is* the enforcement point for `whenLimits`, and the
+   delivery counter-cap check is the belt-and-suspenders layer on top.
+
+The only window this leaves is a single flush round-trip between the vote and the content arriving; the
+counter caps (`tdc`/session/global-daily) cover the common same-day/same-session over-delivery within
+it. If strict in-app parity is ever required, the gate can look up the campaign's rules from `NdStore`
+by `ti` and call `ndLimitsMatcher.matchWhenLimits` before `canShow`.
 
 ### 7.3 App-Launched vs regular-event dispatch (server-side, for SDK context)
 - **App-Launched:** union of app-launched + no-trigger ND targets, sorted priority DESC then ti ASC.

--- a/docs/NativeDisplayFrequencyCaps.md
+++ b/docs/NativeDisplayFrequencyCaps.md
@@ -122,18 +122,28 @@ Follow the exact in-app pattern (`StoreProvider.constructStorePreferenceName(typ
 accountId)` → `StorageHelper` file `WizRocket_<namespace>`), with **new namespaces** so ND never
 collides with in-app:
 
-| State | Proposed prefs file | Key | Value | Mirror of |
+Two different prefs-file mechanisms are in play (same split as in-app), so the counters and the
+impressions do **not** share a file:
+- `InAppFCManager`/`NdFCManager` use `StorageHelper.getPreferences`, which **prepends** the
+  `WizRocket_` tag → file `WizRocket_<namespace>`.
+- `ImpressionStore`/`TriggerManager`/`NdStore` go through `CTPreference`, which calls
+  `getSharedPreferences(name)` with **no** prefix → file `<namespace>` (no `WizRocket_`).
+
+| State | Prefs file (Android xml name) | Key | Value | Mirror of |
 |---|---|---|---|---|
-| Per-target counters (today+lifetime) | `WizRocket_nd_counts_per_target:<deviceId>:<accountId>` | `<ti>` | `"today,lifetime"` | `counts_per_inapp` (`InAppFCManager`) |
-| Impression timestamps (whenLimits windows) | **same** `nd_counts_per_target:…` file | `__impressions_<ti>` | unix-seconds CSV | `ImpressionStore` |
-| Trigger counts (onEvery/onExactly) | `WizRocket_nd_triggers_per_target:<deviceId>:<accountId>` | `__triggers_<ti>` | int | `TriggerManager` |
-| Global ND counters + ceilings | base `WizRocket` | `ndstc:<…>` (shown-today), `ndmp:<…>` (day ceiling), `ndmc:<…>` (session ceiling), `nd_ict_date:<…>` | ints / date | `istc_inapp`/`istmcd_inapp`/`imc`/`ict_date` |
-| Advanced metadata bundle | `WizRocket_adUnit:<deviceId>:<accountId>` | `adUnit_notifs_ss` | JSON array (plaintext — SS only, no CS encryption) | `inapp_notifs_ss` in `InAppStore` |
-| Eval / suppressed pending report | `WizRocket_adUnit:…` | `adUnit_eval`, `adUnit_suppressed` | JSON arrays | `evaluated_ss` / `suppressed_ss` |
+| Per-target counters (today+lifetime) | `WizRocket_nd_counts_per_target:<deviceId>:<accountId>` (StorageHelper) | `<ti>` | `"today,lifetime"` | `counts_per_inapp` (`InAppFCManager`) |
+| Impression timestamps (whenLimits windows) | `nd_counts_per_target:<deviceId>:<accountId>` (**CTPreference — no `WizRocket_` prefix; a *different* file from the counters**) | `__impressions_<ti>` | unix-seconds CSV | `ImpressionStore` |
+| Trigger counts (onEvery/onExactly) | `nd_triggers_per_target:<deviceId>:<accountId>` (CTPreference) | `__triggers_<ti>` | int | `TriggerManager` |
+| Global ND counters + ceilings | base `WizRocket` | `ndstc:<…>` (shown-today), `ndstmcd:<…>` (day ceiling, `KEY_ND_MAX_PER_DAY`), `ndmc:<…>` (session ceiling), `nd_ict_date:<…>` | ints / date | `istc_inapp`/`istmcd_inapp`/`imc`/`ict_date` |
+| Advanced metadata bundle | `adUnit:<deviceId>:<accountId>` (CTPreference) | `adUnit_notifs_ss` | JSON array (plaintext — SS only, no CS encryption) | `inapp_notifs_ss` in `InAppStore` |
+| Eval / suppressed pending report | `adUnit:…` (CTPreference) | `evaluated_nd_ss`, `suppressed_nd` | JSON arrays | `evaluated_ss` / `suppressed_ss` |
 
 Notes:
 - **No encrypted CS store** and **no delivery-mode/purge machinery** — ND has no CS mode.
-- Impressions share the counters file (via the `__impressions_` prefix) exactly like in-app.
+- The `__impressions_`-prefix skip in `NdFCManager.getNdCounts`/`init` is a harmless defensive guard;
+  because impressions live in a *different* file (see above), those keys never actually appear in the
+  counters file. (The earlier "impressions share the counters file" claim — and the same claim in the
+  in-app doc — was incorrect.)
 - New `STORE_TYPE_ND_*` constants in `StoreProvider` (mirrors `STORE_TYPE_IMPRESSION`, etc.).
 - New constants: `KEY_ND_COUNTS_PER_TARGET`, `KEY_ND_TRIGGERS_PER_TARGET`, `ND_MAX_PER_SESSION`
   (`ndsm`/`ndmc`), `ND_MAX_PER_DAY` (`ndmp`), `ND_COUNTS_SHOWN_TODAY` (`ndstc`), plus the wire keys.
@@ -354,6 +364,7 @@ Implemented as a stack of PRs (base `develop`), one per phase, each `SDK-<ticket
 | 6 CG acks | SDK-6062 | #1063 | ✅ done | `recordCgSuppressed`; `AdUnitResponse.processAppLaunched` (stubs → ack, content → gated delivery). |
 | 7 Refresh + gating | SDK-6063 | #1064 | ✅ done | `fetchNativeDisplayMeta()` (`wzrk_fetch t=ND_META`); gating-safety confirmed. |
 | 8 Tests + docs | SDK-6064 | #1065 | ✅ done | `NdStoreTest`, `NdEvaluationManagerTest`; this status table. |
+| 9 Review feedback | SDK-6065 | #1066 | ✅ done | Vision-review FIX set: async-path ND store init, `changeUser`, `optLong` reload (ND + in-app), no-dedup vote, guarded ND eval after in-app, single merged ND content write + AdUnitResponse-before-DisplayUnitResponse, fcap-managed-only impression recording, `@RestrictTo` on `fetchNativeDisplayMeta`, doc/store-file corrections, tests (`NdFCManagerTest`, `NdFcapGateTest`, `AdUnitResponseTest`, reload/no-dedup, `addNdFC`). |
 
 Notes on adjustments made during implementation:
 - `adUnit_eval`/`adUnit_suppressed` header attach landed in **Phase 4** (not 3) because the evaluator


### PR DESCRIPTION
Part of epic **SDK-6055** · ticket **SDK-6065**. **Top of the ND stack, stacked on #1065.** Addresses the Vision bot review feedback across #1057–#1065.

## Fixes applied
| # | Sev | Fix |
|---|---|---|
| F1 | HIGH | Create `ndStore`/`ndImpressionStore` (+ load persisted ids) on the async device-id path (`CleverTapAPI.deviceIDCreated`) — ND was a no-op on first launch. (Added `CoreState.ndEvaluationManager`.) |
| F2 | HIGH | `ndFCManager.changeUser()` on user switch (`LoginController.resetProfile`). |
| F3 | HIGH | Reload eval ids via `optLong` loop, not `toList<Long>()` — org.json parses int-range ids as `Integer`, which the reified filter silently dropped. Fixed for **ND and in-app**. |
| F4 | HIGH | Drop the `contains()` dedup in `NdEvaluationManager.evaluate` so a concurrent re-vote isn't lost (server dedups). |
| F5 | HIGH | Run ND eval **after** in-app eval, wrapped in `try/catch`, so an ND fault can't abort in-app delivery / queue-flush. |
| F6 | BLOCKER | `AdUnitResponse` now does ND **meta + CG-acks only** and runs **before** `DisplayUnitResponse`; `DisplayUnitResponse` delivers `adUnit_notifs` + non-stub `adUnit_notifs_applaunched` in **one merged, gated cache write**. No more same-response cache wipe; ceilings/stale land before the gate. |
| F7 | HIGH | Record `didShow` only for fcap-managed units (`NdFCManager.isFcapManaged`) so legacy units don't drain the ND global budget. |
| F8 | MED | `@RestrictTo(LIBRARY_GROUP)` on `fetchNativeDisplayMeta` (placeholder wire value, no caller yet). |
| F9/F10 | LOW | Stale javadoc + store-file/key-name doc corrections (ND impressions live in a CTPreference file — no `WizRocket_` prefix — distinct from the counters file). |
| F11 | MED | Tests: `NdFCManagerTest`, `NdFcapGateTest`, `AdUnitResponseTest`, ND-eval reload + no-dedup, `addNdFC` header asserts, `NdStore` write/`onChangeUser` asserts. |

## Intentionally not changed (answered on the review threads)
- **Uncapped-when-`ndmp`-absent** (`Integer.MAX_VALUE`, not `10`): absent `ndmp` = uncapped per contract §5.1; a numeric default would wrongly cap uncapped accounts.
- **Empty `adUnit_notifs_ss` full-replace**: the bundle is the complete set, emitted only on App-Launched / ND-fetch, so `[]` legitimately means "clear".
- **`ndmp`/`ndtlc` on non-`/a1` endpoints**: mirrors in-app `imp`/`tlc`; the `/a1`-scoped meta is the eval/suppressed listener.
- **`recordCgSuppressed` reads `wzrk_id`**: correct for ND (contract §5.4 ships it on the stub); added a log if it's ever absent instead of a silent drop.

## Verification
- `:clevertap-core:compileDebugSources` + `compileDebugUnitTestSources` — BUILD SUCCESSFUL.
- New/changed tests pass: `NdFCManagerTest`, `NdFcapGateTest`, `AdUnitResponseTest`, `NdStoreTest`, `NdEvaluationManagerTest`, `QueueHeaderBuilderTest`, `InAppControllerTest`, `EvaluationManagerTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)