### PR TITLE
SDK-6070 [Android][ND] Share eval-rules + header vote-list across in-app and ND

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvalRules.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvalRules.kt
@@ -1,0 +1,31 @@
+package com.clevertap.android.sdk.inapp.evaluation
+
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.isNotNullAndEmpty
+import com.clevertap.android.sdk.orEmptyArray
+import com.clevertap.android.sdk.toList
+import org.json.JSONObject
+
+/**
+ * Channel-agnostic parsing of a campaign's `whenTriggers` / `whenLimits` blocks.
+ *
+ * The trigger/limit schema is identical across channels (in-app + Native Display), so both
+ * evaluators share this instead of keeping verbatim copies (prototype A — SDK-6055 design review).
+ */
+internal object EvalRules {
+
+    fun whenTriggers(triggerJson: JSONObject): List<TriggerAdapter> {
+        val whenTriggers = triggerJson.optJSONArray(Constants.INAPP_WHEN_TRIGGERS).orEmptyArray()
+        return (0 until whenTriggers.length()).mapNotNull {
+            (whenTriggers[it] as? JSONObject)?.let { obj -> TriggerAdapter(obj) }
+        }
+    }
+
+    fun whenLimits(limitJSON: JSONObject): List<LimitAdapter> {
+        val frequencyLimits = limitJSON.optJSONArray(Constants.INAPP_FC_LIMITS).orEmptyArray()
+        val occurrenceLimits = limitJSON.optJSONArray(Constants.INAPP_OCCURRENCE_LIMITS).orEmptyArray()
+        return (frequencyLimits.toList<JSONObject>() + occurrenceLimits.toList()).mapNotNull {
+            if (it.isNotNullAndEmpty()) LimitAdapter(it) else null
+        }
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/EvaluationManager.kt
@@ -13,11 +13,9 @@ import com.clevertap.android.sdk.inapp.data.EvaluatedInAppsResult
 import com.clevertap.android.sdk.inapp.data.InAppDelayConstants.INAPP_DELAY_AFTER_TRIGGER
 import com.clevertap.android.sdk.inapp.store.preference.InAppStore
 import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry
-import com.clevertap.android.sdk.isNotNullAndEmpty
 import com.clevertap.android.sdk.network.EndpointId
 import com.clevertap.android.sdk.network.EndpointId.ENDPOINT_A1
 import com.clevertap.android.sdk.network.NetworkHeadersListener
-import com.clevertap.android.sdk.orEmptyArray
 import com.clevertap.android.sdk.toList
 import com.clevertap.android.sdk.utils.Clock
 import com.clevertap.android.sdk.variables.JsonUtil
@@ -496,24 +494,11 @@ internal class EvaluationManager(
     }
 
     @VisibleForTesting
-    internal fun getWhenTriggers(triggerJson: JSONObject): List<TriggerAdapter> {
-        val whenTriggers = triggerJson.optJSONArray(Constants.INAPP_WHEN_TRIGGERS).orEmptyArray()
-        return (0 until whenTriggers.length()).mapNotNull {
-            val jsonObject = whenTriggers[it] as? JSONObject
-            jsonObject?.let { nonNullJsonObject -> TriggerAdapter(nonNullJsonObject) }
-        }
-    }
+    internal fun getWhenTriggers(triggerJson: JSONObject): List<TriggerAdapter> =
+        EvalRules.whenTriggers(triggerJson)
 
-    internal fun getWhenLimits(limitJSON: JSONObject): List<LimitAdapter> {
-        val frequencyLimits = limitJSON.optJSONArray(Constants.INAPP_FC_LIMITS).orEmptyArray()
-        val occurrenceLimits = limitJSON.optJSONArray(Constants.INAPP_OCCURRENCE_LIMITS).orEmptyArray()
-
-        return (frequencyLimits.toList<JSONObject>() + occurrenceLimits.toList()).mapNotNull {
-            if (it.isNotNullAndEmpty()) {
-                LimitAdapter(it)
-            } else null
-        }
-    }
+    internal fun getWhenLimits(limitJSON: JSONObject): List<LimitAdapter> =
+        EvalRules.whenLimits(limitJSON)
 
     /**
      * Sorts list of InApp objects with priority(100 highest - 1 lowest) and if equal priority
@@ -583,39 +568,13 @@ internal class EvaluationManager(
     }
 
     private fun removeSentEvaluatedServerSideCampaignIds(header: JSONObject) {
-        var updated = false
-        val inAppsEval = header.optJSONArray(Constants.INAPP_SS_EVAL_META)
-        inAppsEval?.let {
-            for (i in 0 until it.length()) {
-                val campaignId = it.optLong(i)
-
-                if (campaignId != 0L) {
-                    updated = true
-                    evaluatedServerSideCampaignIds.remove(campaignId)
-                }
-            }
-        }
-        if (updated) {
+        if (HeaderVoteLists.removeSentEvalIds(header, Constants.INAPP_SS_EVAL_META, evaluatedServerSideCampaignIds)) {
             saveEvaluatedServerSideInAppIds()
         }
     }
 
     private fun removeSentSuppressedClientSideInApps(header: JSONObject) {
-        var updated = false
-        val inAppsEval = header.optJSONArray(Constants.INAPP_SUPPRESSED_META)
-        inAppsEval?.let {
-            val iterator = suppressedClientSideInApps.iterator()
-            while (iterator.hasNext()) {
-                val suppressedInApp = iterator.next()
-                val inAppId = suppressedInApp[Constants.NOTIFICATION_ID_TAG] as? String
-                if (inAppId != null && inAppsEval.toString().contains(inAppId)) {
-                    updated = true
-                    iterator.remove()
-                }
-            }
-        }
-
-        if (updated) {
+        if (HeaderVoteLists.removeSentSuppressed(header, Constants.INAPP_SUPPRESSED_META, suppressedClientSideInApps)) {
             saveSuppressedClientSideInAppIds()
         }
     }
@@ -631,24 +590,13 @@ internal class EvaluationManager(
      * @return A JSONObject containing additional headers, or null if no headers need to be attached.
      */
     override fun onAttachHeaders(endpointId: EndpointId): JSONObject? {
-        // Initialize a JSONObject to hold additional headers.
-        val header = JSONObject()
-        // Check if the network request is targeting a specific endpoint (e.g., ENDPOINT_A1).
-        if (endpointId == ENDPOINT_A1) {
-            // Attach evaluated server-side in-app campaign IDs if available.
-            if (evaluatedServerSideCampaignIds.isNotEmpty()) {
-                header.put(Constants.INAPP_SS_EVAL_META, JsonUtil.listToJsonArray(evaluatedServerSideCampaignIds))
-            }
-            // Attach suppressed client-side in-app notifications if available.
-            if (suppressedClientSideInApps.isNotEmpty()) {
-                header.put(Constants.INAPP_SUPPRESSED_META, JsonUtil.listToJsonArray(suppressedClientSideInApps))
-            }
-        }
-        // Return the header JSONObject if it is not empty; otherwise, return null.
-        if (header.isNotNullAndEmpty())
-            return header
-
-        return null
+        if (endpointId != ENDPOINT_A1) return null
+        return HeaderVoteLists.attach(
+            Constants.INAPP_SS_EVAL_META,
+            Constants.INAPP_SUPPRESSED_META,
+            evaluatedServerSideCampaignIds,
+            suppressedClientSideInApps
+        )
     }
 
     /**
@@ -674,11 +622,7 @@ internal class EvaluationManager(
     @WorkerThread
     fun loadSuppressedCSAndEvaluatedSSInAppsIds() {
         storeRegistry.inAppStore?.let { store ->
-            // Read via optLong, NOT toList<Long>(): org.json parses int-range numbers as Integer and
-            // `element is Long` filters them all out, so campaign ids would be silently dropped.
-            val stored = store.readEvaluatedServerSideInAppIds()
-            evaluatedServerSideCampaignIds =
-                (0 until stored.length()).map { stored.optLong(it) }.filter { it != 0L }.toMutableList()
+            evaluatedServerSideCampaignIds = HeaderVoteLists.readEvalIds(store.readEvaluatedServerSideInAppIds())
             suppressedClientSideInApps = JsonUtil.listFromJsonSafe(store.readSuppressedClientSideInAppIds())
         }
     }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/HeaderVoteLists.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/HeaderVoteLists.kt
@@ -1,0 +1,88 @@
+package com.clevertap.android.sdk.inapp.evaluation
+
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.isNotNullAndEmpty
+import com.clevertap.android.sdk.variables.JsonUtil
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Channel-agnostic logic for the `/a1` header "vote" lists — the evaluated-campaign ids and the
+ * CG/suppressed acks that each evaluator attaches and then removes-exactly-what-was-sent.
+ *
+ * Only the wire keys and the persistence sinks differ per channel (in-app `inapps_eval` /
+ * `inapps_suppressed` vs ND `adUnit_eval` / `adUnit_suppressed`); the attach, remove-exactly-sent,
+ * and int-safe id parsing are identical. Keeping them here removes the copy-paste that already caused
+ * drift — the `optLong` reload fix (F3) previously had to be applied in two places
+ * (prototype B — SDK-6055 design review).
+ *
+ * State (the actual lists) stays owned by each evaluator; this object only holds the shared algorithms.
+ */
+internal object HeaderVoteLists {
+
+    /**
+     * Parses persisted eval ids without dropping int-range values. `org.json` deserializes numeric
+     * literals within `Int` range as `Integer`, so a reified `toList<Long>()` filter would silently
+     * discard every id (campaign ids are epoch-second, always int-range).
+     */
+    fun readEvalIds(stored: JSONArray): MutableList<Long> =
+        (0 until stored.length()).map { stored.optLong(it) }.filter { it != 0L }.toMutableList()
+
+    /** Builds the header contribution, or null if both lists are empty. */
+    fun attach(
+        evalMetaKey: String,
+        suppressedMetaKey: String,
+        evalIds: List<Long>,
+        suppressed: List<Map<String, Any?>>
+    ): JSONObject? {
+        val header = JSONObject()
+        if (evalIds.isNotEmpty()) {
+            header.put(evalMetaKey, JsonUtil.listToJsonArray(evalIds))
+        }
+        if (suppressed.isNotEmpty()) {
+            header.put(suppressedMetaKey, JsonUtil.listToJsonArray(suppressed))
+        }
+        return if (header.isNotNullAndEmpty()) header else null
+    }
+
+    /**
+     * Removes exactly the eval ids present in the sent header (a concurrent vote added after attach
+     * but not in the sent header survives). Returns true if the caller should persist.
+     */
+    fun removeSentEvalIds(sentHeader: JSONObject, evalMetaKey: String, evalIds: MutableList<Long>): Boolean {
+        var updated = false
+        sentHeader.optJSONArray(evalMetaKey)?.let {
+            for (i in 0 until it.length()) {
+                val id = it.optLong(i)
+                if (id != 0L) {
+                    updated = true
+                    evalIds.remove(id)
+                }
+            }
+        }
+        return updated
+    }
+
+    /**
+     * Removes suppressed acks whose id appears in the sent header. Returns true if the caller should
+     * persist.
+     */
+    fun removeSentSuppressed(
+        sentHeader: JSONObject,
+        suppressedMetaKey: String,
+        suppressed: MutableList<Map<String, Any?>>
+    ): Boolean {
+        val sent = sentHeader.optJSONArray(suppressedMetaKey) ?: return false
+        val sentString = sent.toString()
+        var updated = false
+        val iterator = suppressed.iterator()
+        while (iterator.hasNext()) {
+            val id = iterator.next()[Constants.NOTIFICATION_ID_TAG] as? String
+            if (id != null && sentString.contains(id)) {
+                iterator.remove()
+                updated = true
+            }
+        }
+        return updated
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/evaluation/NdEvaluationManager.kt
@@ -7,12 +7,9 @@ import com.clevertap.android.sdk.Constants
 import com.clevertap.android.sdk.Logger
 import com.clevertap.android.sdk.inapp.TriggerManager
 import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry
-import com.clevertap.android.sdk.isNotNullAndEmpty
 import com.clevertap.android.sdk.network.EndpointId
 import com.clevertap.android.sdk.network.EndpointId.ENDPOINT_A1
 import com.clevertap.android.sdk.network.NetworkHeadersListener
-import com.clevertap.android.sdk.orEmptyArray
-import com.clevertap.android.sdk.toList
 import com.clevertap.android.sdk.variables.JsonUtil
 import org.json.JSONObject
 
@@ -98,7 +95,7 @@ internal class NdEvaluationManager(
         var updated = false
         for (event in events) {
             for (inApp in metadata) {
-                if (!triggersMatcher.matchEvent(getWhenTriggers(inApp), event)) {
+                if (!triggersMatcher.matchEvent(EvalRules.whenTriggers(inApp), event)) {
                     continue
                 }
                 val campaignId = inApp.optString(Constants.INAPP_ID_IN_PAYLOAD)
@@ -106,7 +103,7 @@ internal class NdEvaluationManager(
 
                 ndTriggersManager.increment(campaignId)
 
-                if (ndLimitsMatcher.matchWhenLimits(getWhenLimits(inApp), campaignId)) {
+                if (ndLimitsMatcher.matchWhenLimits(EvalRules.whenLimits(inApp), campaignId)) {
                     val ti = campaignId.toLongOrNull() ?: continue
                     // Append without a contains() guard: a re-vote while a prior send is in flight must
                     // not be dropped (onSentHeaders removes only what was sent). Server dedups (§6.2).
@@ -118,23 +115,6 @@ internal class NdEvaluationManager(
         }
         if (updated) {
             saveEvaluatedNdIds()
-        }
-    }
-
-    @VisibleForTesting
-    internal fun getWhenTriggers(triggerJson: JSONObject): List<TriggerAdapter> {
-        val whenTriggers = triggerJson.optJSONArray(Constants.INAPP_WHEN_TRIGGERS).orEmptyArray()
-        return (0 until whenTriggers.length()).mapNotNull {
-            (whenTriggers[it] as? JSONObject)?.let { obj -> TriggerAdapter(obj) }
-        }
-    }
-
-    @VisibleForTesting
-    internal fun getWhenLimits(limitJSON: JSONObject): List<LimitAdapter> {
-        val frequencyLimits = limitJSON.optJSONArray(Constants.INAPP_FC_LIMITS).orEmptyArray()
-        val occurrenceLimits = limitJSON.optJSONArray(Constants.INAPP_OCCURRENCE_LIMITS).orEmptyArray()
-        return (frequencyLimits.toList<JSONObject>() + occurrenceLimits.toList()).mapNotNull {
-            if (it.isNotNullAndEmpty()) LimitAdapter(it) else null
         }
     }
 
@@ -166,58 +146,28 @@ internal class NdEvaluationManager(
 
     override fun onAttachHeaders(endpointId: EndpointId): JSONObject? {
         if (endpointId != ENDPOINT_A1) return null
-        val header = JSONObject()
-        if (evaluatedNdCampaignIds.isNotEmpty()) {
-            header.put(Constants.ND_SS_EVAL_META, JsonUtil.listToJsonArray(evaluatedNdCampaignIds))
-        }
-        if (suppressedNdCampaigns.isNotEmpty()) {
-            header.put(Constants.ND_SUPPRESSED_META, JsonUtil.listToJsonArray(suppressedNdCampaigns))
-        }
-        return if (header.isNotNullAndEmpty()) header else null
+        return HeaderVoteLists.attach(
+            Constants.ND_SS_EVAL_META,
+            Constants.ND_SUPPRESSED_META,
+            evaluatedNdCampaignIds,
+            suppressedNdCampaigns
+        )
     }
 
     override fun onSentHeaders(allHeaders: JSONObject, endpointId: EndpointId) {
         if (endpointId != ENDPOINT_A1) return
-        removeSentEvaluatedNdIds(allHeaders)
-        removeSentSuppressedNd(allHeaders)
-    }
-
-    private fun removeSentEvaluatedNdIds(header: JSONObject) {
-        var updated = false
-        header.optJSONArray(Constants.ND_SS_EVAL_META)?.let {
-            for (i in 0 until it.length()) {
-                val ti = it.optLong(i)
-                if (ti != 0L) {
-                    updated = evaluatedNdCampaignIds.remove(ti) || updated
-                }
-            }
+        if (HeaderVoteLists.removeSentEvalIds(allHeaders, Constants.ND_SS_EVAL_META, evaluatedNdCampaignIds)) {
+            saveEvaluatedNdIds()
         }
-        if (updated) saveEvaluatedNdIds()
-    }
-
-    private fun removeSentSuppressedNd(header: JSONObject) {
-        var updated = false
-        val sent = header.optJSONArray(Constants.ND_SUPPRESSED_META) ?: return
-        val sentString = sent.toString()
-        val iterator = suppressedNdCampaigns.iterator()
-        while (iterator.hasNext()) {
-            val id = iterator.next()[Constants.NOTIFICATION_ID_TAG] as? String
-            if (id != null && sentString.contains(id)) {
-                iterator.remove()
-                updated = true
-            }
+        if (HeaderVoteLists.removeSentSuppressed(allHeaders, Constants.ND_SUPPRESSED_META, suppressedNdCampaigns)) {
+            saveSuppressedNdIds()
         }
-        if (updated) saveSuppressedNdIds()
     }
 
     @WorkerThread
     fun loadEvaluatedAndSuppressedNdIds() {
         storeRegistry.ndStore?.let { store ->
-            // Read via optLong, NOT toList<Long>(): org.json parses int-range numbers as Integer and
-            // `element is Long` filters them all out, so `ti`s (epoch-second ids) would be dropped.
-            val stored = store.readEvaluatedServerSideNdIds()
-            evaluatedNdCampaignIds =
-                (0 until stored.length()).map { stored.optLong(it) }.filter { it != 0L }.toMutableList()
+            evaluatedNdCampaignIds = HeaderVoteLists.readEvalIds(store.readEvaluatedServerSideNdIds())
             suppressedNdCampaigns = JsonUtil.listFromJsonSafe(store.readSuppressedNdIds())
         }
     }


### PR DESCRIPTION
Part of epic **SDK-6055** · ticket **SDK-6070**. Stacked on #1066.

De-duplicates the in-app and Native Display evaluators **without merging them** — the channels genuinely differ (ND has no CS mode, no on-device priority/strategy/suppression, host renders), so unified classes would be conditional-heavy. State stays per-channel; only the shared *logic* is extracted.

## `EvalRules` — shared whenTriggers/whenLimits parsing
- `EvaluationManager.getWhenTriggers`/`getWhenLimits` delegate to it (kept as methods so the in-app tests that call them stay green).
- `NdEvaluationManager` calls `EvalRules` directly; its verbatim copies are gone.

## `HeaderVoteLists` — shared /a1 vote-list logic
- `attach(...)`, `removeSentEvalIds(...)`, `removeSentSuppressed(...)`, and the int-safe `readEvalIds(...)`.
- `readEvalIds` is the `optLong` parse that previously had to be duplicated in both evaluators (the drift this extraction prevents).
- Both evaluators delegate `onAttachHeaders`/`onSentHeaders`/load; **the eval-id + suppressed lists stay owned by each manager**, so existing tests referencing those fields are unaffected.

## Verification
- `:clevertap-core:compileDebugSources` — BUILD SUCCESSFUL.
- `EvaluationManagerTest`, `NdEvaluationManagerTest`, `EvalRulesTest`, `HeaderVoteListsTest`, `AdUnitResponseTest`/`DisplayUnitResponseTest`, `QueueHeaderBuilderTest` pass. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)