### PR TITLE
SDK-6076 [Android][ND] Extract NdCountsStore DAO; tidy json.has + Context threading

### DIFF
--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/AnalyticsManager.java
@@ -357,7 +357,7 @@ public class AnalyticsManager extends BaseAnalyticsManager {
                     // unmarked/legacy unit's view can't consume the ND global budget and starve gated ones.
                     NdFCManager ndFCManager = controllerManager.getNdFCManager();
                     if (ndFCManager != null && NdFCManager.isFcapManaged(displayUnit.getJsonObject())) {
-                        ndFCManager.didShow(context, unitID);
+                        ndFCManager.didShow(unitID);
                     }
 
                     JSONObject eventExtras = displayUnit.getWZRKFields();

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapAPI.java
@@ -50,6 +50,7 @@ import com.clevertap.android.sdk.inapp.images.repo.FileResourcesRepoFactory;
 import com.clevertap.android.sdk.inapp.images.repo.FileResourcesRepoImpl;
 import com.clevertap.android.sdk.inapp.store.preference.ImpressionStore;
 import com.clevertap.android.sdk.inapp.store.preference.InAppStore;
+import com.clevertap.android.sdk.inapp.store.preference.NdCountsStore;
 import com.clevertap.android.sdk.inapp.store.preference.NdStore;
 import com.clevertap.android.sdk.inapp.store.preference.StoreRegistry;
 import com.clevertap.android.sdk.inbox.CTInboxActivity;
@@ -3259,8 +3260,10 @@ public class CleverTapAPI implements CTInboxActivity.InboxActivityListener {
         if (coreState.getControllerManager().getNdFCManager() == null) {
             getConfigLogger().verbose(accountId + ":async_deviceID",
                     "Initializing NdFC after Device ID Created = " + deviceId);
+            NdCountsStore ndCountsStore = StoreProvider.getInstance()
+                    .provideNdCountsStore(context, deviceId, accountId);
             coreState.getControllerManager()
-                    .setNdFCManager(new NdFCManager(context, coreState.getConfig(), deviceId,
+                    .setNdFCManager(new NdFCManager(coreState.getConfig(), ndCountsStore,
                             coreState.getNdImpressionManager(),
                             coreState.getExecutors(), clevertapClock));
         }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/CleverTapFactory.kt
@@ -340,9 +340,8 @@ internal object CleverTapFactory {
             // Native Display (ND) frequency caps (SDK-6055)
             if (deviceId != null && controllerManager.ndFCManager == null) {
                 controllerManager.ndFCManager = NdFCManager(
-                    context = context,
                     config = config,
-                    deviceId = deviceId,
+                    countsStore = storeProvider.provideNdCountsStore(context, deviceId, config.accountId),
                     impressionManager = ndImpressionManager,
                     executors = executors,
                     clock = SYSTEM,

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/Constants.java
@@ -180,7 +180,9 @@ public interface Constants {
     // ---- Native Display (ND) frequency-cap storage keys (SDK-6055), mirror the in-app keys above ----
     String KEY_ND_MAX_PER_DAY = "ndstmcd";                 // stored ND daily ceiling (mirror of istmcd_inapp)
     String KEY_ND_COUNTS_SHOWN_TODAY = "ndstc";            // stored ND global shown-today (mirror of istc_inapp)
-    String KEY_ND_COUNTS_PER_TARGET = "nd_counts_per_target";   // per-target today/lifetime + impressions file
+    String KEY_ND_LAST_RESET_DATE = "nd_ict_date";         // ddMMyyyy of the last daily reset (mirror of ict_date)
+    String KEY_ND_COUNTS_PER_TARGET = "nd_counts_per_target";   // NdCountsStore namespace (per-target counts + globals)
+    String KEY_ND_IMPRESSIONS_PER_TARGET = "nd_impressions";    // ND ImpressionStore namespace (whenLimits timestamps)
     String KEY_ND_TRIGGERS_PER_TARGET = "nd_triggers_per_target"; // onEvery/onExactly trigger counts
     String INAPP_ID_IN_PAYLOAD = "ti";
     int LOCATION_PING_INTERVAL_IN_SECONDS = 10;

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/NdFCManager.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/NdFCManager.kt
@@ -1,10 +1,8 @@
 package com.clevertap.android.sdk
 
-import android.content.Context
 import androidx.annotation.RestrictTo
-import com.clevertap.android.sdk.StorageHelper.getPreferences
 import com.clevertap.android.sdk.inapp.ImpressionManager
-import com.clevertap.android.sdk.inapp.store.preference.ImpressionStore
+import com.clevertap.android.sdk.inapp.store.preference.NdCountsStore
 import com.clevertap.android.sdk.task.CTExecutors
 import com.clevertap.android.sdk.utils.Clock
 import org.json.JSONArray
@@ -13,17 +11,16 @@ import java.text.SimpleDateFormat
 import java.util.Locale
 
 /**
- * Frequency-cap counter gate for the Native Display (ND / Display Units) channel.
+ * Frequency-cap policy for the Native Display (ND / Display Units) channel.
  *
  * This is the ND sibling of [InAppFCManager] and enforces the counter-based caps at the point a unit
  * would be surfaced to the host app:
  * - per-target lifetime (`tlc`) and daily (`tdc`) counts,
  * - per-target and global session caps (`mdc` / `ndmc`),
- * - global daily cap (`ndstc` shown-today vs `ndstmcd` ceiling).
+ * - global daily cap (shown-today vs the account ceiling).
  *
- * ND is SS + legacy only, so unlike [InAppFCManager] there is no legacy pref-key migration here.
- * Counter state lives in its own namespaces (see [Constants.KEY_ND_COUNTS_PER_TARGET]) and never
- * collides with in-app. The advanced `frequencyLimits`/`occurrenceLimits` (whenLimits) are evaluated
+ * It holds only the cap *policy* and the daily-rollover trigger; all persistence lives in
+ * [NdCountsStore]. The advanced `frequencyLimits`/`occurrenceLimits` (whenLimits) are evaluated
  * separately by the ND `LimitsMatcher`; their result is passed in as `frequencyLimitsMaxedOut`.
  *
  * The API is model-light (primitives) so it stays decoupled from the ND content/target model, which is
@@ -31,9 +28,8 @@ import java.util.Locale
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 class NdFCManager internal constructor(
-    private val context: Context,
     private val config: CleverTapInstanceConfig,
-    private var deviceId: String,
+    private val countsStore: NdCountsStore,
     private val impressionManager: ImpressionManager,
     private val executors: CTExecutors,
     private val clock: Clock,
@@ -42,8 +38,6 @@ class NdFCManager internal constructor(
     companion object {
 
         private const val UNCAPPED = -1
-
-        private const val ND_DATE_KEY = "nd_ict_date"
 
         private const val SESSION_CAP_DEFAULT = 1000
 
@@ -67,7 +61,7 @@ class NdFCManager internal constructor(
 
     init {
         executors.postAsyncSafelyTask<Unit>().execute("initNdFCManager") {
-            initDailyState(deviceId)
+            resetDailyStateIfNewDay()
         }
     }
 
@@ -107,58 +101,41 @@ class NdFCManager internal constructor(
 
     fun changeUser(deviceId: String) {
         impressionManager.clearSessionData()
-        this.deviceId = deviceId
-        initDailyState(deviceId)
+        countsStore.onChangeUser(deviceId, config.accountId)
+        resetDailyStateIfNewDay()
     }
 
     /**
      * Records a surfaced ND impression: bumps the per-target today/lifetime counts, the global
      * shown-today counter, and the in-memory session impression state.
      */
-    fun didShow(context: Context, id: String?) {
+    fun didShow(id: String?) {
         if (id.isNullOrEmpty()) {
             return
         }
         executors.ioTask<Unit>().execute("recordNdImpressionsAndCounts") {
             impressionManager.recordImpression(id)
-            incrementNdCountsInPersistentStore(id)
-
-            val shownToday = getIntFromPrefs(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_SHOWN_TODAY, deviceId), 0)
-            StorageHelper.putInt(
-                context,
-                storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_SHOWN_TODAY, deviceId)),
-                shownToday + 1,
-            )
+            countsStore.increment(id)
+            countsStore.shownToday += 1
         }
     }
 
     /** The SDK's total ND render count today (`ndmp` request value). */
     val shownTodayCount: Int
-        get() = getIntFromPrefs(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_SHOWN_TODAY, deviceId), 0)
+        get() = countsStore.shownToday
 
     /** The `ndtlc` array: `[[targetId, todayCount, lifetimeCount], ...]`, or null on failure. */
-    fun getNdCounts(context: Context): JSONArray? {
+    fun getNdCounts(): JSONArray? {
         return try {
             val arr = JSONArray()
-            val prefs = getPreferences(
-                context,
-                storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_PER_TARGET, deviceId)),
-            )
-            for ((key, value) in prefs.all) {
-                // impressions share this file under the "__impressions_" prefix — skip them.
-                if (key.startsWith(ImpressionStore.PREF_PREFIX) || value !is String) {
-                    continue
-                }
-                val parts = value.split(",")
-                if (parts.size == 2) {
-                    arr.put(
-                        JSONArray().apply {
-                            put(0, key)
-                            put(1, parts[0].toInt())
-                            put(2, parts[1].toInt())
-                        },
-                    )
-                }
+            countsStore.allTargetCounts().forEach { (targetId, counts) ->
+                arr.put(
+                    JSONArray().apply {
+                        put(0, targetId)
+                        put(1, counts.today)
+                        put(2, counts.lifetime)
+                    },
+                )
             }
             arr
         } catch (t: Throwable) {
@@ -168,175 +145,58 @@ class NdFCManager internal constructor(
     }
 
     /** Purges dead-target (`adUnit_stale`) counter state from the ND counts store. */
-    fun processResponse(context: Context, staleIds: JSONArray?) {
+    fun processResponse(staleIds: JSONArray?) {
         if (staleIds == null) {
             return
         }
-        try {
-            val prefs = getPreferences(
-                context,
-                storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_PER_TARGET, deviceId)),
-            )
-            val editor = prefs.edit()
-            for (i in 0 until staleIds.length()) {
-                when (val o = staleIds.get(i)) {
-                    is Int -> editor.remove(o.toString()).also { Logger.d("Purged stale ND target - $o") }
-                    is String -> editor.remove(o).also { Logger.d("Purged stale ND target - $o") }
-                }
+        for (i in 0 until staleIds.length()) {
+            val targetId = staleIds.optString(i)
+            if (targetId.isNotEmpty()) {
+                countsStore.remove(targetId)
+                Logger.d("Purged stale ND target - $targetId")
             }
-            StorageHelper.persist(editor)
-        } catch (t: Throwable) {
-            Logger.v("Failed to purge stale ND targets", t)
         }
     }
 
     /** Stores the account-level ND ceilings pushed on every response (`ndmp`/`ndmc`). */
-    @Synchronized
-    fun updateLimits(context: Context, perDay: Int, perSession: Int) {
-        StorageHelper.putInt(
-            context,
-            storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_MAX_PER_DAY, deviceId)),
-            perDay,
-        )
-        StorageHelper.putInt(
-            context,
-            storageKeyWithSuffix(getKeyWithDeviceId(Constants.ND_MAX_PER_SESSION_KEY, deviceId)),
-            perSession,
-        )
+    fun updateLimits(perDay: Int, perSession: Int) {
+        countsStore.maxPerDay = perDay
+        countsStore.maxPerSession = perSession
     }
 
     private fun hasDailyCapacityMaxedOut(id: String, totalDailyCount: Int): Boolean {
         // 1. Global daily cap.
-        val shownTodayCount = getIntFromPrefs(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_SHOWN_TODAY, deviceId), 0)
-        val maxPerDayCount = getIntFromPrefs(getKeyWithDeviceId(Constants.KEY_ND_MAX_PER_DAY, deviceId), 1)
-        if (shownTodayCount >= maxPerDayCount) {
+        if (countsStore.shownToday >= countsStore.maxPerDay) {
             return true
         }
-
         // 2. Per-target daily cap.
-        return try {
-            if (totalDailyCount == UNCAPPED) false else getNdCountsFromPersistentStore(id)[0] >= totalDailyCount
-        } catch (t: Throwable) {
-            true
-        }
+        return totalDailyCount != UNCAPPED && countsStore.counts(id).today >= totalDailyCount
     }
 
-    private fun hasLifetimeCapacityMaxedOut(id: String, totalLifetimeCount: Int): Boolean {
-        if (totalLifetimeCount == UNCAPPED) {
-            return false
-        }
-        return try {
-            getNdCountsFromPersistentStore(id)[1] >= totalLifetimeCount
-        } catch (t: Throwable) {
-            true
-        }
-    }
+    private fun hasLifetimeCapacityMaxedOut(id: String, totalLifetimeCount: Int): Boolean =
+        totalLifetimeCount != UNCAPPED && countsStore.counts(id).lifetime >= totalLifetimeCount
 
     private fun hasSessionCapacityMaxedOut(id: String, maxPerSession: Int): Boolean {
-        // 1. Per-target session cap.
-        try {
-            val perSession = if (maxPerSession >= 0) maxPerSession else SESSION_CAP_DEFAULT
-            if (impressionManager.perSession(id) >= perSession) {
-                return true
-            }
-        } catch (t: Throwable) {
+        // 1. Per-target session cap (in-memory).
+        val perSession = if (maxPerSession >= 0) maxPerSession else SESSION_CAP_DEFAULT
+        if (impressionManager.perSession(id) >= perSession) {
             return true
         }
-
-        // 2. Global per-session cap (ndmc, default 1).
-        val globalCap = getIntFromPrefs(getKeyWithDeviceId(Constants.ND_MAX_PER_SESSION_KEY, deviceId), 1)
-        return impressionManager.perSessionTotal() >= globalCap
-    }
-
-    /** @return `[todayCount, lifetimeCount]`, defaulting to `[0, 0]` when absent/malformed. */
-    private fun getNdCountsFromPersistentStore(id: String): IntArray {
-        val prefs = getPreferences(
-            context,
-            storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_PER_TARGET, deviceId)),
-        )
-        val str = prefs.getString(id, null) ?: return intArrayOf(0, 0)
-        return try {
-            val parts = str.split(",")
-            if (parts.size != 2) intArrayOf(0, 0) else intArrayOf(parts[0].toInt(), parts[1].toInt())
-        } catch (t: Throwable) {
-            intArrayOf(0, 0)
-        }
-    }
-
-    private fun incrementNdCountsInPersistentStore(id: String) {
-        val current = getNdCountsFromPersistentStore(id)
-        val prefs = getPreferences(
-            context,
-            storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_PER_TARGET, deviceId)),
-        )
-        // protocol: todayCount,lifeTimeCount
-        prefs.edit().putString(id, "${current[0] + 1},${current[1] + 1}").also { StorageHelper.persist(it) }
+        // 2. Global per-session cap (ndmc).
+        return impressionManager.perSessionTotal() >= countsStore.maxPerSession
     }
 
     /** Resets the daily counters when the stored date differs from today (keeps lifetime counts). */
-    private fun initDailyState(deviceId: String) {
-        configLogger.verbose("${config.accountId}:async_deviceID", "NdFCManager init() called")
+    private fun resetDailyStateIfNewDay() {
         try {
             val today = ddMMyyyy.format(clock.newDate())
-            val lastUpdated = getStringFromPrefs(getKeyWithDeviceId(ND_DATE_KEY, deviceId), "20140428")
-            if (today == lastUpdated) {
+            if (countsStore.lastResetDate == today) {
                 return
             }
-            StorageHelper.putString(context, storageKeyWithSuffix(getKeyWithDeviceId(ND_DATE_KEY, deviceId)), today)
-
-            // Reset global shown-today count.
-            StorageHelper.putInt(
-                context,
-                storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_SHOWN_TODAY, deviceId)),
-                0,
-            )
-
-            // Reset per-target today counts (keep lifetime). Impression keys share this file under the
-            // "__impressions_" prefix — leave them untouched.
-            val prefs = getPreferences(
-                context,
-                storageKeyWithSuffix(getKeyWithDeviceId(Constants.KEY_ND_COUNTS_PER_TARGET, deviceId)),
-            )
-            val editor = prefs.edit()
-            for ((target, value) in prefs.all) {
-                if (target.startsWith(ImpressionStore.PREF_PREFIX) || value !is String) {
-                    continue
-                }
-                val oldValues = value.split(",")
-                if (oldValues.size != 2) {
-                    continue
-                }
-                // protocol: todayCount,lifeTimeCount
-                runCatching { editor.putString(target, "0,${oldValues[1]}") }
-                    .onFailure { configLogger.verbose(config.accountId, "Failed to reset todayCount for ND target $target", it) }
-            }
-            StorageHelper.persist(editor)
+            countsStore.lastResetDate = today
+            countsStore.resetDailyKeepingLifetime()
         } catch (e: Exception) {
-            configLogger.verbose(config.accountId, "Failed to init ND FC manager ${e.localizedMessage}")
+            config.logger.verbose(config.accountId, "Failed to reset ND daily state: ${e.localizedMessage}")
         }
     }
-
-    private val configLogger: Logger
-        get() = config.logger
-
-    private fun getIntFromPrefs(rawKey: String, defaultValue: Int): Int {
-        if (!config.isDefaultInstance) {
-            return StorageHelper.getInt(context, storageKeyWithSuffix(rawKey), defaultValue)
-        }
-        val dummy = -1000
-        val scoped = StorageHelper.getInt(context, storageKeyWithSuffix(rawKey), dummy)
-        return if (scoped != dummy) scoped else StorageHelper.getInt(context, rawKey, defaultValue)
-    }
-
-    private fun getStringFromPrefs(rawKey: String, defaultValue: String): String {
-        if (!config.isDefaultInstance) {
-            return StorageHelper.getString(context, storageKeyWithSuffix(rawKey), defaultValue) ?: defaultValue
-        }
-        val scoped = StorageHelper.getString(context, storageKeyWithSuffix(rawKey), defaultValue)
-        return scoped ?: StorageHelper.getString(context, rawKey, defaultValue) ?: defaultValue
-    }
-
-    private fun getKeyWithDeviceId(key: String, deviceId: String): String = "$key:$deviceId"
-
-    private fun storageKeyWithSuffix(key: String): String = "$key:${config.accountId}"
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/StoreProvider.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/StoreProvider.kt
@@ -9,6 +9,7 @@ import com.clevertap.android.sdk.inapp.store.preference.ImpressionStore
 import com.clevertap.android.sdk.inapp.store.preference.InAppAssetsStore
 import com.clevertap.android.sdk.inapp.store.preference.InAppStore
 import com.clevertap.android.sdk.inapp.store.preference.LegacyInAppStore
+import com.clevertap.android.sdk.inapp.store.preference.NdCountsStore
 import com.clevertap.android.sdk.inapp.store.preference.NdStore
 import com.clevertap.android.sdk.store.preference.CTPreference
 
@@ -21,6 +22,7 @@ const val STORE_TYPE_FILES = 5
 // Native Display (ND) frequency caps (SDK-6055)
 const val STORE_TYPE_ND = 6
 const val STORE_TYPE_ND_IMPRESSION = 7
+const val STORE_TYPE_ND_COUNTS = 8
 
 /**
  * The `StoreProvider` class is responsible for providing different types of stores
@@ -143,6 +145,19 @@ internal class StoreProvider {
     }
 
     /**
+     * Provides the [NdCountsStore] DAO — per-target today/lifetime counts plus the ND global
+     * shown-today counter, ceilings and daily-reset date, in its own namespace.
+     */
+    fun provideNdCountsStore(
+        context: Context,
+        deviceId: String,
+        accountId: String
+    ): NdCountsStore {
+        val prefName = constructStorePreferenceName(STORE_TYPE_ND_COUNTS, deviceId, accountId)
+        return NdCountsStore(getCTPreference(context, prefName))
+    }
+
+    /**
      * Provides an instance of [LegacyInAppStore] using the given parameters.
      *
      * @param context The Android application context.
@@ -179,7 +194,8 @@ internal class StoreProvider {
             STORE_TYPE_INAPP -> "${Constants.INAPP_KEY}:$deviceId:$accountId"
             STORE_TYPE_IMPRESSION -> "${Constants.KEY_COUNTS_PER_INAPP}:$deviceId:$accountId"
             STORE_TYPE_ND -> "${Constants.ND_KEY}:$deviceId:$accountId"
-            STORE_TYPE_ND_IMPRESSION -> "${Constants.KEY_ND_COUNTS_PER_TARGET}:$deviceId:$accountId"
+            STORE_TYPE_ND_IMPRESSION -> "${Constants.KEY_ND_IMPRESSIONS_PER_TARGET}:$deviceId:$accountId"
+            STORE_TYPE_ND_COUNTS -> "${Constants.KEY_ND_COUNTS_PER_TARGET}:$deviceId:$accountId"
             STORE_TYPE_LEGACY_INAPP -> Constants.CLEVERTAP_STORAGE_TAG
             else -> Constants.CLEVERTAP_STORAGE_TAG
         }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/NdCountsStore.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/inapp/store/preference/NdCountsStore.kt
@@ -1,0 +1,107 @@
+package com.clevertap.android.sdk.inapp.store.preference
+
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.STORE_TYPE_ND_COUNTS
+import com.clevertap.android.sdk.StoreProvider
+import com.clevertap.android.sdk.store.preference.ICTPreference
+
+/**
+ * DAO for the Native Display (ND) frequency-cap **counter** state (SDK-6055).
+ *
+ * Owns everything counter-related in a single prefs namespace (`nd_counts_per_target:<deviceId>:<accountId>`):
+ * - per-target counts, keyed by target id (`ti`), value `"today,lifetime"`,
+ * - the global shown-today counter, the daily/session ceilings, and the daily-reset date.
+ *
+ * This is the persistence half of the ND cap gate; [com.clevertap.android.sdk.NdFCManager] holds the
+ * policy and delegates all reads/writes here. It mirrors the DAO split already used by
+ * [ImpressionStore]/[InAppStore], so the manager no longer hand-rolls prefs access, key building or
+ * CSV (de)serialization. ND impression timestamps live in a *separate* namespace, so no key here needs
+ * an `__impressions_` guard.
+ */
+internal class NdCountsStore(
+    private val ctPreference: ICTPreference,
+) {
+
+    /** Per-target today + lifetime render counts. */
+    data class Counts(val today: Int, val lifetime: Int)
+
+    companion object {
+        // Global (non-per-target) keys in this store, excluded when enumerating per-target counts.
+        private val GLOBAL_KEYS = setOf(
+            Constants.KEY_ND_COUNTS_SHOWN_TODAY,
+            Constants.KEY_ND_MAX_PER_DAY,
+            Constants.ND_MAX_PER_SESSION_KEY,
+            Constants.KEY_ND_LAST_RESET_DATE,
+        )
+        private const val DEFAULT_DATE = "20140428"
+    }
+
+    // ---- per-target counts ----
+
+    /** Returns `[today, lifetime]` for a target, or `Counts(0, 0)` when absent/malformed. */
+    fun counts(targetId: String): Counts = parseOrNull(ctPreference.readString(targetId, "")) ?: Counts(0, 0)
+
+    /** Bumps both today and lifetime by one for a target. */
+    fun increment(targetId: String) {
+        val current = counts(targetId)
+        ctPreference.writeString(targetId, "${current.today + 1},${current.lifetime + 1}")
+    }
+
+    /** Removes a target's counts (dead-target GC). */
+    fun remove(targetId: String) = ctPreference.remove(targetId)
+
+    /** All valid per-target counts, keyed by target id (global keys excluded). */
+    fun allTargetCounts(): Map<String, Counts> {
+        val all = ctPreference.readAll() ?: return emptyMap()
+        return all.entries
+            .filter { it.key !in GLOBAL_KEYS }
+            .mapNotNull { entry -> parseOrNull(entry.value as? String)?.let { entry.key to it } }
+            .toMap()
+    }
+
+    /** Resets every target's today count to 0 (keeps lifetime) and clears the global shown-today. */
+    fun resetDailyKeepingLifetime() {
+        allTargetCounts().forEach { (targetId, counts) ->
+            ctPreference.writeString(targetId, "0,${counts.lifetime}")
+        }
+        shownToday = 0
+    }
+
+    // ---- global counters / ceilings / date ----
+
+    /** ND render count today (drives the `ndmp` request value and the global daily check). */
+    var shownToday: Int
+        get() = ctPreference.readInt(Constants.KEY_ND_COUNTS_SHOWN_TODAY, 0)
+        set(value) = ctPreference.writeInt(Constants.KEY_ND_COUNTS_SHOWN_TODAY, value)
+
+    /** Account global daily ceiling (`ndstmcd`), default 1 until the server pushes it. */
+    var maxPerDay: Int
+        get() = ctPreference.readInt(Constants.KEY_ND_MAX_PER_DAY, 1)
+        set(value) = ctPreference.writeInt(Constants.KEY_ND_MAX_PER_DAY, value)
+
+    /** Account global session ceiling (`ndmc`), default 1 until the server pushes it. */
+    var maxPerSession: Int
+        get() = ctPreference.readInt(Constants.ND_MAX_PER_SESSION_KEY, 1)
+        set(value) = ctPreference.writeInt(Constants.ND_MAX_PER_SESSION_KEY, value)
+
+    /** `ddMMyyyy` of the last daily reset. */
+    var lastResetDate: String
+        get() = ctPreference.readString(Constants.KEY_ND_LAST_RESET_DATE, DEFAULT_DATE) ?: DEFAULT_DATE
+        set(value) = ctPreference.writeString(Constants.KEY_ND_LAST_RESET_DATE, value)
+
+    fun onChangeUser(deviceId: String, accountId: String) {
+        ctPreference.changePreferenceName(
+            StoreProvider.getInstance().constructStorePreferenceName(STORE_TYPE_ND_COUNTS, deviceId, accountId),
+        )
+    }
+
+    /** Parses a `"today,lifetime"` value, or null if absent/malformed. */
+    private fun parseOrNull(raw: String?): Counts? {
+        if (raw.isNullOrEmpty()) return null
+        val parts = raw.split(",")
+        if (parts.size != 2) return null
+        val today = parts[0].toIntOrNull() ?: return null
+        val lifetime = parts[1].toIntOrNull() ?: return null
+        return Counts(today, lifetime)
+    }
+}

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/network/QueueHeaderBuilder.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/network/QueueHeaderBuilder.kt
@@ -204,7 +204,7 @@ internal class QueueHeaderBuilder(
         controllerManager.ndFCManager?.let {
             Logger.v("Attaching NdFC to Header")
             header.put(Constants.ND_MAX_PER_DAY_KEY, it.shownTodayCount)
-            header.put(Constants.ND_TARGET_SHOWN_LIST, it.getNdCounts(context))
+            header.put(Constants.ND_TARGET_SHOWN_LIST, it.getNdCounts())
         } ?: logger.verbose(config.accountId, "controllerManager.getNdFCManager() is NULL, not Attaching NdFC to Header")
     }
 }

--- a/clevertap-core/src/main/java/com/clevertap/android/sdk/response/DisplayUnitResponse.kt
+++ b/clevertap-core/src/main/java/com/clevertap/android/sdk/response/DisplayUnitResponse.kt
@@ -92,22 +92,20 @@ internal class DisplayUnitResponse(
         try {
             val ndFCManager = controllerManager.ndFCManager
 
-            // Account-level ceilings. Per contract §5.1 `ndmc` is emitted on every V2 response; `ndmp`
-            // only when the account has a daily cap (absent => uncapped daily, hence Int.MAX_VALUE).
+            // Account-level ceilings. `has(ndmc)` is load-bearing: `ndmc` is emitted on every V2
+            // response (contract §5.1), so its presence is what tells us this is a cap-aware response
+            // worth writing ceilings for. `ndmp` absent => uncapped daily, which optInt's Int.MAX_VALUE
+            // default already expresses (no separate has() needed).
             if (response.has(Constants.ND_MAX_PER_SESSION_KEY) && ndFCManager != null) {
                 val perSession = response.optInt(Constants.ND_MAX_PER_SESSION_KEY, 1)
-                val perDay = if (response.has(Constants.ND_MAX_PER_DAY_KEY)) {
-                    response.optInt(Constants.ND_MAX_PER_DAY_KEY, Int.MAX_VALUE)
-                } else {
-                    Int.MAX_VALUE
-                }
-                ndFCManager.updateLimits(context, perDay, perSession)
+                val perDay = response.optInt(Constants.ND_MAX_PER_DAY_KEY, Int.MAX_VALUE)
+                ndFCManager.updateLimits(perDay, perSession)
             }
 
             // Dead-target GC.
             response.optJSONArray(Constants.DISPLAY_UNIT_NOTIFS_STALE_KEY)?.let { staleIds ->
                 clearStaleNdCache(stores, staleIds)
-                ndFCManager?.processResponse(context, staleIds)
+                ndFCManager?.processResponse(staleIds)
             }
 
             // Advanced-rule metadata bundle (rules only) for local evaluation. Full replace, including

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/NdFCManagerTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/NdFCManagerTest.kt
@@ -36,15 +36,15 @@ class NdFCManagerTest : BaseTestCase() {
     @Test
     fun `canShow allows an uncapped target`() {
         val fc = create()
-        fc.updateLimits(appCtx, 10, 10) // don't let global defaults (1) interfere
+        fc.updateLimits(10, 10) // don't let global defaults (1) interfere
         assertTrue(fc.canShow("70001", false, -1, -1, -1, false))
     }
 
     @Test
     fun `excludeFromCaps bypasses counter caps`() {
         val fc = create()
-        fc.updateLimits(appCtx, 10, 10)
-        fc.didShow(appCtx, "70001") // today/lifetime = 1
+        fc.updateLimits(10, 10)
+        fc.didShow("70001") // today/lifetime = 1
         // per-target daily cap of 1 would deny, but excludeFromCaps short-circuits
         assertFalse(fc.canShow("70001", false, -1, 1, -1, false))
         assertTrue(fc.canShow("70001", true, -1, 1, -1, false))
@@ -53,8 +53,8 @@ class NdFCManagerTest : BaseTestCase() {
     @Test
     fun `per-target daily cap denies once reached`() {
         val fc = create()
-        fc.updateLimits(appCtx, 10, 10)
-        fc.didShow(appCtx, "70001") // today = 1
+        fc.updateLimits(10, 10)
+        fc.didShow("70001") // today = 1
         assertFalse(fc.canShow("70001", false, -1, 1, -1, false)) // 1 >= 1
         assertTrue(fc.canShow("70001", false, -1, 2, -1, false))  // 1 < 2
     }
@@ -62,12 +62,12 @@ class NdFCManagerTest : BaseTestCase() {
     @Test
     fun `didShow increments ndtlc counters and shown-today`() {
         val fc = create()
-        fc.updateLimits(appCtx, 10, 10)
-        fc.didShow(appCtx, "70001")
-        fc.didShow(appCtx, "70001")
+        fc.updateLimits(10, 10)
+        fc.didShow("70001")
+        fc.didShow("70001")
 
         assertEquals(2, fc.shownTodayCount)
-        val counts = fc.getNdCounts(appCtx)!!
+        val counts = fc.getNdCounts()!!
         assertEquals(1, counts.length())
         val entry = counts.getJSONArray(0)
         assertEquals("70001", entry.getString(0))
@@ -76,13 +76,14 @@ class NdFCManagerTest : BaseTestCase() {
     }
 
     private fun create(deviceId: String = "deviceId"): NdFCManager {
+        val countsStore = StoreProvider.getInstance()
+            .provideNdCountsStore(appCtx, deviceId, cleverTapInstanceConfig.accountId)
         return NdFCManager(
-            appCtx,
-            cleverTapInstanceConfig,
-            deviceId,
-            impressionManager,
-            MockCTExecutors(),
-            clock
+            config = cleverTapInstanceConfig,
+            countsStore = countsStore,
+            impressionManager = impressionManager,
+            executors = MockCTExecutors(),
+            clock = clock,
         )
     }
 }

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/store/preference/NdCountsStoreTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/inapp/store/preference/NdCountsStoreTest.kt
@@ -1,0 +1,108 @@
+package com.clevertap.android.sdk.inapp.store.preference
+
+import com.clevertap.android.sdk.Constants
+import com.clevertap.android.sdk.store.preference.ICTPreference
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class NdCountsStoreTest {
+
+    private lateinit var ctPreference: ICTPreference
+    private lateinit var store: NdCountsStore
+
+    @Before
+    fun setUp() {
+        ctPreference = mockk(relaxed = true)
+        store = NdCountsStore(ctPreference)
+    }
+
+    @Test
+    fun `counts parses today,lifetime CSV`() {
+        every { ctPreference.readString("70001", "") } returns "3,12"
+        assertEquals(NdCountsStore.Counts(3, 12), store.counts("70001"))
+    }
+
+    @Test
+    fun `counts defaults to zero when absent or malformed`() {
+        every { ctPreference.readString("absent", "") } returns ""
+        every { ctPreference.readString("bad", "") } returns "x,y"
+        every { ctPreference.readString("single", "") } returns "5"
+        assertEquals(NdCountsStore.Counts(0, 0), store.counts("absent"))
+        assertEquals(NdCountsStore.Counts(0, 0), store.counts("bad"))
+        assertEquals(NdCountsStore.Counts(0, 0), store.counts("single"))
+    }
+
+    @Test
+    fun `increment bumps both today and lifetime`() {
+        every { ctPreference.readString("70001", "") } returns "2,9"
+        every { ctPreference.writeString(any(), any()) } just Runs
+        store.increment("70001")
+        verify { ctPreference.writeString("70001", "3,10") }
+    }
+
+    @Test
+    fun `allTargetCounts excludes global keys and malformed entries`() {
+        every { ctPreference.readAll() } returns mapOf(
+            "70001" to "1,4",
+            "70002" to "0,2",
+            Constants.KEY_ND_COUNTS_SHOWN_TODAY to 5,        // global int -> excluded
+            Constants.KEY_ND_MAX_PER_DAY to 10,              // global int -> excluded
+            Constants.KEY_ND_LAST_RESET_DATE to "25082026",  // global string, not a pair -> excluded
+            "malformed" to "oops",
+        )
+
+        val result = store.allTargetCounts()
+
+        assertEquals(2, result.size)
+        assertEquals(NdCountsStore.Counts(1, 4), result["70001"])
+        assertEquals(NdCountsStore.Counts(0, 2), result["70002"])
+    }
+
+    @Test
+    fun `resetDailyKeepingLifetime zeroes today, keeps lifetime, clears shownToday`() {
+        every { ctPreference.readAll() } returns mapOf("70001" to "3,12", "70002" to "1,1")
+        every { ctPreference.writeString(any(), any()) } just Runs
+        every { ctPreference.writeInt(any(), any()) } just Runs
+
+        store.resetDailyKeepingLifetime()
+
+        verify { ctPreference.writeString("70001", "0,12") }
+        verify { ctPreference.writeString("70002", "0,1") }
+        verify { ctPreference.writeInt(Constants.KEY_ND_COUNTS_SHOWN_TODAY, 0) }
+    }
+
+    @Test
+    fun `global ceilings default to 1 until set`() {
+        every { ctPreference.readInt(Constants.KEY_ND_MAX_PER_DAY, 1) } returns 1
+        every { ctPreference.readInt(Constants.ND_MAX_PER_SESSION_KEY, 1) } returns 1
+        assertEquals(1, store.maxPerDay)
+        assertEquals(1, store.maxPerSession)
+    }
+
+    @Test
+    fun `setting ceilings writes them`() {
+        every { ctPreference.writeInt(any(), any()) } just Runs
+        store.maxPerDay = 10
+        store.maxPerSession = 3
+        verify { ctPreference.writeInt(Constants.KEY_ND_MAX_PER_DAY, 10) }
+        verify { ctPreference.writeInt(Constants.ND_MAX_PER_SESSION_KEY, 3) }
+    }
+
+    @Test
+    fun `remove deletes a target`() {
+        store.remove("70001")
+        verify { ctPreference.remove("70001") }
+    }
+
+    @Test
+    fun `onChangeUser repoints to the counts namespace for the new user`() {
+        store.onChangeUser("device_id", "account_id")
+        verify { ctPreference.changePreferenceName("${Constants.KEY_ND_COUNTS_PER_TARGET}:device_id:account_id") }
+    }
+}

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/network/QueueHeaderBuilderTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/network/QueueHeaderBuilderTest.kt
@@ -158,7 +158,7 @@ class QueueHeaderBuilderTest {
         }
         every { controllerManager.ndFCManager } returns mockk {
             every { shownTodayCount } returns 2
-            every { getNdCounts(any()) } returns ndCountsJson
+            every { getNdCounts() } returns ndCountsJson
         }
 
         // Mock context

--- a/clevertap-core/src/test/java/com/clevertap/android/sdk/response/DisplayUnitResponseTest.kt
+++ b/clevertap-core/src/test/java/com/clevertap/android/sdk/response/DisplayUnitResponseTest.kt
@@ -86,7 +86,7 @@ class DisplayUnitResponseTest : BaseTestCase() {
     @Test
     fun `applies ndmc and ndmp ceilings`() {
         response.processResponse(JSONObject("""{"ndmc":1,"ndmp":10}"""), "", context)
-        verify { ndFCManager.updateLimits(context, 10, 1) }
+        verify { ndFCManager.updateLimits(10, 1) }
     }
 
     @Test
@@ -95,7 +95,7 @@ class DisplayUnitResponseTest : BaseTestCase() {
         verify { ndImpressionStore.clear("70001") }
         verify { ndImpressionStore.clear("70002") }
         verify { ndTriggerManager.removeTriggers("70001") }
-        verify { ndFCManager.processResponse(context, any()) }
+        verify { ndFCManager.processResponse(any()) }
     }
 
     @Test
@@ -117,7 +117,7 @@ class DisplayUnitResponseTest : BaseTestCase() {
     fun `no-op for analytics-only`() {
         every { config.isAnalyticsOnly } returns true
         response.processResponse(JSONObject("""{"ndmc":1,"ndmp":10}"""), "", context)
-        verify(exactly = 0) { ndFCManager.updateLimits(any(), any(), any()) }
+        verify(exactly = 0) { ndFCManager.updateLimits(any(), any()) }
     }
 
     // ---- content delivery + user switch ----
@@ -139,7 +139,7 @@ class DisplayUnitResponseTest : BaseTestCase() {
 
         response.processResponse(json, "", context, true)
 
-        verify { ndFCManager.updateLimits(context, 10, 1) }               // meta ingested
+        verify { ndFCManager.updateLimits(10, 1) }               // meta ingested
         verify(exactly = 0) { callbackManager.notifyDisplayUnitsLoaded(any()) } // content skipped
     }
 }


### PR DESCRIPTION
Part of epic **SDK-6055** · ticket **SDK-6076**. Stacked on #1069. Addresses review points 1–3 (storage readability); point 4 (deferred-init nullability) is assessed separately below and **not** in this PR.

## 1. Storage: DAO(store) + use-case(manager) split
- New **`NdCountsStore`** (CTPreference-backed, like `InAppStore`/`ImpressionStore`) owns per-target counts, global shown-today, ceilings, and the daily-reset date in one namespace.
- **`NdFCManager`** is now a thin **use-case** — only cap policy (`canShow`/`didShow`/daily-reset), delegating all persistence to the store. Removed: inline key-building, CSV (de)serialization, raw `StorageHelper` access, the `isDefaultInstance` fallback, the dead `__impressions_` prefix guards, and **Context threading** (`didShow`/`getNdCounts`/`updateLimits`/`processResponse` no longer take a `Context`).
- ND impression file renamed to `nd_impressions` so counts and impressions no longer share a namespace (the source of the old prefix-guard confusion). ND is unreleased → no migration.

## 2. Redundant `json.has()` + `json.opt*()`
- Dropped the redundant `has(ndmp)` before `optInt(ndmp, MAX_VALUE)` (the default already expresses "absent ⇒ uncapped").
- **Kept** `has(ndmc)` and `has(adUnit_notifs_ss)` — those are load-bearing (they distinguish *absent* from *present-but-empty*, e.g. an empty SS bundle legitimately clears the cache) — now with a comment saying so.

## 3. Conversions / memory
- `prefs.all` access moved into the store (single place).
- The `JSONArray`↔`List<JSONObject>` conversions were surveyed and left as-is: bounded by campaign count, shallow ref-lists, not a memory concern.

## Verification
- `:clevertap-core:compileDebugSources` + `compileDebugUnitTestSources` — BUILD SUCCESSFUL.
- New `NdCountsStoreTest`; updated `NdFCManagerTest` (new ctor/signatures) still passes (behavior-preserving); `DisplayUnitResponseTest`, `QueueHeaderBuilderTest`, `NativeDisplayControllerTest`, `NdEvaluationManagerTest`, `EvaluationManagerTest`, `EventQueueManagerTest`, `InAppControllerTest` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)